### PR TITLE
i18n(sr): Update translations

### DIFF
--- a/i18n/sr-Cyrl/cosmic_files.ftl
+++ b/i18n/sr-Cyrl/cosmic_files.ftl
@@ -1,5 +1,6 @@
 empty-folder = Празна фасцикла
 empty-folder-hidden = Празна фасцикла (има скривене ставке)
+filesystem = Систем датотека
 trash = Отпад
 
 # Context Pages

--- a/i18n/sr-Cyrl/cosmic_files.ftl
+++ b/i18n/sr-Cyrl/cosmic_files.ftl
@@ -1,5 +1,6 @@
 empty-folder = Празна фасцикла
 empty-folder-hidden = Празна фасцикла (има скривене ставке)
+trash = Отпад
 
 # Context Pages
 
@@ -19,6 +20,27 @@ light = Светла
 # Context menu
 new-file = Нова датотека
 new-folder = Нова фасцикла
+move-to-trash = Премести у отпад
+restore-from-trash = Врати из отпада
+
+# Menu
+
+## File
+file = Датотека
+new-tab = Нова картица
+new-window = Нови прозор
+close-tab = Затвори картицу
+quit = Изађи
+
+## Edit
+edit = Уреди
+cut = Исеци
 copy = Копирај
 paste = Налепи
 select-all = Изабери све
+
+## View
+view = Приказ
+grid-view = Прикажи мрежу
+list-view = Прикажи списак
+menu-settings = Подешавања...

--- a/i18n/sr-Latn/cosmic_files.ftl
+++ b/i18n/sr-Latn/cosmic_files.ftl
@@ -1,5 +1,6 @@
 empty-folder = Prazna fascikla
 empty-folder-hidden = Prazna fascikla (ima skrivene stavke)
+filesystem = Sistem datoteka
 trash = Otpad
 
 # Context Pages

--- a/i18n/sr-Latn/cosmic_files.ftl
+++ b/i18n/sr-Latn/cosmic_files.ftl
@@ -1,5 +1,6 @@
 empty-folder = Prazna fascikla
 empty-folder-hidden = Prazna fascikla (ima skrivene stavke)
+trash = Otpad
 
 # Context Pages
 
@@ -19,6 +20,27 @@ light = Svetla
 # Context menu
 new-file = Nova datoteka
 new-folder = Nova fascikla
+move-to-trash = Premesti u otpad
+restore-from-trash = Vrati iz otpada
+
+# Menu
+
+## File
+file = Datoteka
+new-tab = Nova kartica
+new-window = Novi prozor
+close-tab = Zatvori karticu
+quit = Izađi
+
+## Edit
+edit = Uredi
+cut = Iseci
 copy = Kopiraj
 paste = Nalepi
 select-all = Izaberi sve
+
+## View
+view = Prikaz
+grid-view = Prikaži mrežu
+list-view = Prikaži spisak
+menu-settings = Podešavanja...


### PR DESCRIPTION
Unrelated to the pull request but didn't want to create a separate issue over something that isn't that important:

Perhaps the nav bar selection graphic should either be a bit longer or slightly thinner, since it's currently a kind of elongated squircle that doesn't match the pill shape present in cosmic-settings or cosmic-edit (though it had a pill shape before the `reduce width` commit, so might be better to just make it thinner). 

And perhaps the name of the Home directory in the nav bar should be just Home instead of the user name, to match other file managers.

If this was already planned or is intended, sorry for making you read all of this. Cosmic Files is starting to look pretty nice!

Edit: Just saw that the old Figma design draft has all of this, so maybe all this text was unnecessary.