### PR TITLE
Add keyboard shortcuts for closing and cycling tabs

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -765,6 +765,16 @@ impl Application for App {
                     }
                 }
                 Event::Keyboard(KeyEvent::KeyPressed {
+                    key_code: KeyCode::W,
+                    modifiers,
+                }) => {
+                    if modifiers == Modifiers::CTRL {
+                        Some(Message::TabClose(None))
+                    } else {
+                        None
+                    }
+                }
+                Event::Keyboard(KeyEvent::KeyPressed {
                     key_code: KeyCode::V,
                     modifiers,
                 }) => {


### PR DESCRIPTION
This patch adds three new hot keys based on [common shortcuts](https://en.wikipedia.org/wiki/Table_of_keyboard_shortcuts).

| Key combo | Description |
| --- | --- |
| `ctrl` + `w` | Close current tab. Closes cosmic-files if only one tab is open. | 
| `ctrl` + `PgUp` | Activates the next tab. Move to the first tab if the last tab is active. |
| `ctrl` + `PgDown` | Activate the prev tab. Cycles through tabs like the above key combo. |

I'll implement more key combos if this PR is deemed useful and desirable. Personally, I have a keyboard centered workflow so I always navigate with shortcuts, even on Windows. I'm sure other future users would want more shortcuts as well.