### PR TITLE
Test helpers and unit tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1092,6 +1092,7 @@ dependencies = [
  "chrono",
  "dirs",
  "env_logger",
+ "fastrand 2.0.1",
  "fork",
  "i18n-embed",
  "i18n-embed-fl",
@@ -1104,6 +1105,8 @@ dependencies = [
  "rust-embed",
  "serde",
  "systemicons",
+ "tempfile",
+ "test-log",
  "tokio",
  "trash",
 ]
@@ -5012,6 +5015,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "test-log"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6159ab4116165c99fc88cce31f99fa2c9dbe08d3691cb38da02fc3b45f357d2b"
+dependencies = [
+ "env_logger",
+ "test-log-macros",
+]
+
+[[package]]
+name = "test-log-macros"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ba277e77219e9eea169e8508942db1bf5d8a41ff2db9b20aab5a5aadc9fa25d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.48",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,3 +47,10 @@ debug = true
 
 [target.'cfg(unix)'.dependencies]
 fork = "0.1"
+
+[dev-dependencies]
+# cap-std = "3"
+# cap-tempfile = "3"
+fastrand = "2"
+tempfile = "3"
+test-log = "0.2"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1151,7 +1151,7 @@ mod test_utils {
         path::Path,
     };
 
-    use log::debug;
+    use log::{debug, trace};
     use tempfile::{tempdir, TempDir};
 
     use crate::tab::Item;
@@ -1166,7 +1166,7 @@ mod test_utils {
 
     /// Add `n` temporary files in `dir`
     ///
-    /// Each file is assigned a numeric name from 0..n.
+    /// Each file is assigned a numeric name from [0, n).
     pub fn file_flat_hier<D: AsRef<Path>>(dir: D, n: usize) -> io::Result<Vec<File>> {
         let dir = dir.as_ref();
         (0..n)
@@ -1217,7 +1217,7 @@ mod test_utils {
             for entry in path.read_dir()? {
                 let entry = entry?;
                 if entry.file_type()?.is_file() {
-                    debug!("Created file: {}", entry.path().display());
+                    trace!("Created file: {}", entry.path().display());
                 }
             }
         }
@@ -1235,7 +1235,7 @@ mod test_utils {
     /// Directories are placed before files.
     /// Files are lexically sorted.
     /// This is more or less copied right from the [Tab] code
-    pub fn sort_files(a: &PathBuf, b: &PathBuf) -> Ordering {
+    pub fn sort_files(a: &Path, b: &Path) -> Ordering {
         match (a.is_dir(), b.is_dir()) {
             (true, false) => Ordering::Less,
             (false, true) => Ordering::Greater,

--- a/src/tab.rs
+++ b/src/tab.rs
@@ -1013,3 +1013,73 @@ impl Tab {
         .into()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::io;
+
+    use log::debug;
+    use test_log::test;
+
+    use super::scan_path;
+    use crate::test_utils::{
+        empty_fs, eq_path_item, simple_fs, sort_files, NAME_LEN, NUM_DIRS, NUM_FILES, NUM_NESTED,
+    };
+
+    #[test]
+    fn scan_path_succeeds_on_valid_path() -> io::Result<()> {
+        let fs = simple_fs(NUM_FILES, NUM_DIRS, NUM_NESTED, NAME_LEN)?;
+        let path = fs.path();
+
+        let mut entries: Vec<_> = path
+            .read_dir()?
+            .map(|maybe_entry| maybe_entry.map(|entry| entry.path()))
+            .collect::<io::Result<_>>()?;
+        entries.sort_by(sort_files);
+
+        debug!("Calling scan_path(\"{}\")", path.display());
+        let actual = scan_path(&path.to_owned());
+
+        // scan_path shouldn't skip any entries
+        assert_eq!(entries.len(), actual.len());
+
+        // Correct files should be scanned
+        assert!(entries
+            .into_iter()
+            .zip(actual.into_iter())
+            .all(|(path, item)| eq_path_item(&path, &item)));
+
+        Ok(())
+    }
+
+    #[test]
+    fn scan_path_returns_empty_vec_for_invalid_path() -> io::Result<()> {
+        let fs = simple_fs(NUM_FILES, NUM_DIRS, NUM_NESTED, NAME_LEN)?;
+        let path = fs.path();
+
+        // A nonexisting path within the temp dir
+        let invalid_path = path.join("ferris");
+        assert!(!invalid_path.exists());
+
+        debug!("Calling scan_path(\"{}\")", invalid_path.display());
+        let actual = scan_path(&invalid_path);
+
+        assert!(actual.is_empty());
+
+        Ok(())
+    }
+
+    #[test]
+    fn scan_path_empty_dir_returns_empty_vec() -> io::Result<()> {
+        let fs = empty_fs()?;
+        let path = fs.path();
+
+        debug!("Calling scan_path(\"{}\")", path.display());
+        let actual = scan_path(&path.to_owned());
+
+        assert_eq!(0, path.read_dir()?.count());
+        assert_eq!(0, actual.len());
+
+        Ok(())
+    }
+}

--- a/src/tab.rs
+++ b/src/tab.rs
@@ -1035,7 +1035,7 @@ mod tests {
             .read_dir()?
             .map(|maybe_entry| maybe_entry.map(|entry| entry.path()))
             .collect::<io::Result<_>>()?;
-        entries.sort_by(sort_files);
+        entries.sort_by(|a, b| sort_files(a, b));
 
         debug!("Calling scan_path(\"{}\")", path.display());
         let actual = scan_path(&path.to_owned());


### PR DESCRIPTION
I implemented a few helper functions for tests as well as three tests for `tab::scan_path`.

The helper functions create a small, temporary file hierarchy using [tempdir](https://docs.rs/tempdir/latest/tempdir/) to test file operations. I also wrote a few helpers for tasks that will likely be repeated throughout tests e.g. comparing `Item` and `Path`s.

I'll work on writing more unit tests if these are okay so far.