### PR TITLE
Support going back/forward with mouse buttons

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -44,6 +44,9 @@ pub struct Flags {
 pub enum Action {
     Copy,
     Cut,
+    HistoryNext,
+    HistoryPrevious,
+    LocationUp,
     MoveToTrash,
     NewFile,
     NewFolder,
@@ -67,6 +70,9 @@ impl Action {
         match self {
             Action::Copy => Message::Copy(entity_opt),
             Action::Cut => Message::Cut(entity_opt),
+            Action::HistoryNext => Message::TabMessage(None, tab::Message::GoNext),
+            Action::HistoryPrevious => Message::TabMessage(None, tab::Message::GoPrevious),
+            Action::LocationUp => Message::TabMessage(None, tab::Message::LocationUp),
             Action::MoveToTrash => Message::MoveToTrash(entity_opt),
             Action::NewFile => Message::NewFile(entity_opt),
             Action::NewFolder => Message::NewFolder(entity_opt),
@@ -885,6 +891,12 @@ impl Application for App {
                 )
                 .on_press(move |_point_opt| {
                     Message::TabMessage(Some(entity), tab::Message::Click(None))
+                })
+                .on_back_press(move |_point_opt| {
+                    Message::TabMessage(None, tab::Message::GoPrevious)
+                })
+                .on_forward_press(move |_point_opt| {
+                    Message::TabMessage(None, tab::Message::GoNext)
                 });
                 if tab.context_menu.is_some() {
                     mouse_area = mouse_area

--- a/src/mouse_area.rs
+++ b/src/mouse_area.rs
@@ -19,6 +19,10 @@ pub struct MouseArea<'a, Message, Renderer> {
     on_right_release: Option<Box<dyn Fn(Option<Point>) -> Message + 'a>>,
     on_middle_press: Option<Box<dyn Fn(Option<Point>) -> Message + 'a>>,
     on_middle_release: Option<Box<dyn Fn(Option<Point>) -> Message + 'a>>,
+    on_back_press: Option<Box<dyn Fn(Option<Point>) -> Message + 'a>>,
+    on_back_release: Option<Box<dyn Fn(Option<Point>) -> Message + 'a>>,
+    on_forward_press: Option<Box<dyn Fn(Option<Point>) -> Message + 'a>>,
+    on_forward_release: Option<Box<dyn Fn(Option<Point>) -> Message + 'a>>,
 }
 
 impl<'a, Message, Renderer> MouseArea<'a, Message, Renderer> {
@@ -80,6 +84,34 @@ impl<'a, Message, Renderer> MouseArea<'a, Message, Renderer> {
         self.on_middle_release = Some(Box::new(message));
         self
     }
+
+     /// The message to emit on a back button press.
+    #[must_use]
+    pub fn on_back_press(mut self, message: impl Fn(Option<Point>) -> Message + 'a) -> Self {
+        self.on_back_press = Some(Box::new(message));
+        self
+    }
+    
+    /// The message to emit on a back button release.
+    #[must_use]
+    pub fn on_back_release(mut self, message: impl Fn(Option<Point>) -> Message + 'a) -> Self {
+        self.on_back_release = Some(Box::new(message));
+        self
+    }
+    
+    /// The message to emit on a forward button press.
+    #[must_use]
+    pub fn on_forward_press(mut self, message: impl Fn(Option<Point>) -> Message + 'a) -> Self {
+        self.on_forward_press = Some(Box::new(message));
+        self
+    }
+    
+    /// The message to emit on a forward button release.
+    #[must_use]
+    pub fn on_forward_release(mut self, message: impl Fn(Option<Point>) -> Message + 'a) -> Self {
+        self.on_forward_release = Some(Box::new(message));
+        self
+    }
 }
 
 /// Local state of the [`MouseArea`].
@@ -102,6 +134,10 @@ impl<'a, Message, Renderer> MouseArea<'a, Message, Renderer> {
             on_right_release: None,
             on_middle_press: None,
             on_middle_release: None,
+            on_back_press: None,
+            on_back_release: None,
+            on_forward_press: None,
+            on_forward_release: None,
         }
     }
 }
@@ -323,6 +359,38 @@ fn update<Message: Clone, Renderer>(
 
     if let Some(message) = widget.on_middle_release.as_ref() {
         if let Event::Mouse(mouse::Event::ButtonReleased(mouse::Button::Middle)) = event {
+            shell.publish(message(cursor.position_in(layout.bounds())));
+
+            return event::Status::Captured;
+        }
+    }
+
+    if let Some(message) = widget.on_back_press.as_ref() {
+        if let Event::Mouse(mouse::Event::ButtonPressed(mouse::Button::Back)) = event {
+            shell.publish(message(cursor.position_in(layout.bounds())));
+
+            return event::Status::Captured;
+        }
+    }
+    
+    if let Some(message) = widget.on_back_release.as_ref() {
+        if let Event::Mouse(mouse::Event::ButtonReleased(mouse::Button::Back)) = event {
+            shell.publish(message(cursor.position_in(layout.bounds())));
+
+            return event::Status::Captured;
+        }
+    }
+    
+    if let Some(message) = widget.on_forward_press.as_ref() {
+        if let Event::Mouse(mouse::Event::ButtonPressed(mouse::Button::Forward)) = event {
+            shell.publish(message(cursor.position_in(layout.bounds())));
+
+            return event::Status::Captured;
+        }
+    }
+    
+    if let Some(message) = widget.on_forward_release.as_ref() {
+        if let Event::Mouse(mouse::Event::ButtonReleased(mouse::Button::Forward)) = event {
             shell.publish(message(cursor.position_in(layout.bounds())));
 
             return event::Status::Captured;


### PR DESCRIPTION
Not entirely sure if this will work but `app.rs` is based on #32 to hopefully avoid a conflict.

This enables support for navigation with the back/forward buttons present on some mice.