### PR TITLE
feat: Toggle showing hidden files/folders

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -26,7 +26,7 @@ use std::{
 };
 
 use crate::{
-    config::{AppTheme, Config, Tab as TabConfig, CONFIG_VERSION},
+    config::{AppTheme, Config, CONFIG_VERSION},
     fl, home_dir,
     key_bind::{key_binds, KeyBind},
     menu, mouse_area,
@@ -188,7 +188,7 @@ pub struct App {
 
 impl App {
     fn open_tab(&mut self, location: Location) -> Command<Message> {
-        let tab = Tab::new(location.clone(), TabConfig::default());
+        let tab = Tab::new(location.clone(), self.config.tab.clone());
         let entity = self
             .tab_model
             .insert()
@@ -1086,7 +1086,7 @@ pub(crate) mod test_utils {
     use log::{debug, trace};
     use tempfile::{tempdir, TempDir};
 
-    use crate::tab::Item;
+    use crate::{config::TabConfig, tab::Item};
 
     use super::*;
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -61,6 +61,7 @@ pub enum Action {
     TabPrev,
     TabViewGrid,
     TabViewList,
+    ToggleShowHidden,
     WindowClose,
     WindowNew,
 }
@@ -91,6 +92,7 @@ impl Action {
             Action::TabViewList => {
                 Message::TabMessage(entity_opt, tab::Message::View(tab::View::List))
             }
+            Action::ToggleShowHidden => Message::TabMessage(None, tab::Message::ToggleShowHidden),
             Action::WindowClose => Message::WindowClose,
             Action::WindowNew => Message::WindowNew,
         }
@@ -681,8 +683,7 @@ impl Application for App {
                 if let Some(tab) = self.tab_model.data_mut::<Tab>(entity) {
                     if let Some(ref mut items) = tab.items_opt {
                         for item in items.iter_mut() {
-                            if item.hidden {
-                                //TODO: option to show hidden files
+                            if !tab.config.show_hidden && item.hidden {
                                 continue;
                             }
                             item.selected = true;

--- a/src/app.rs
+++ b/src/app.rs
@@ -26,7 +26,7 @@ use std::{
 };
 
 use crate::{
-    config::{AppTheme, Config, CONFIG_VERSION},
+    config::{AppTheme, Config, Tab as TabConfig, CONFIG_VERSION},
     fl, home_dir,
     key_bind::{key_binds, KeyBind},
     menu, mouse_area,
@@ -186,7 +186,7 @@ pub struct App {
 
 impl App {
     fn open_tab(&mut self, location: Location) -> Command<Message> {
-        let tab = Tab::new(location.clone());
+        let tab = Tab::new(location.clone(), TabConfig::default());
         let entity = self
             .tab_model
             .insert()
@@ -1237,7 +1237,7 @@ pub(crate) mod test_utils {
         // New tab with items
         let location = Location::Path(path.to_owned());
         let items = location.scan();
-        let mut tab = Tab::new(location);
+        let mut tab = Tab::new(location, TabConfig::default());
         tab.items_opt = Some(items);
 
         // Ensure correct number of directories as a sanity check

--- a/src/config.rs
+++ b/src/config.rs
@@ -28,22 +28,26 @@ impl AppTheme {
 #[derive(Clone, CosmicConfigEntry, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct Config {
     pub app_theme: AppTheme,
-    pub tab: Tab,
+    pub tab: TabConfig,
 }
 
 impl Default for Config {
     fn default() -> Self {
         Self {
             app_theme: AppTheme::System,
-            tab: Tab::default(),
+            tab: TabConfig::default(),
         }
     }
 }
 
-/// Per tab config
+/// Global and local [`crate::tab::Tab`] config.
+///
+/// [`TabConfig`] contains options that are passed to each instance of [`crate::tab::Tab`].
+/// These options are set globally through the main config, but each tab may change options
+/// locally. Local changes aren't saved to the main config.
 #[derive(Clone, Debug, Eq, PartialEq, CosmicConfigEntry, Deserialize, Serialize)]
-pub struct Tab {
-    /// Show hidden files
+pub struct TabConfig {
+    /// Show hidden files and folders
     pub show_hidden: bool,
     // TODO: Other possible options
     // pub sort_by: fn(&PathBuf, &PathBuf) -> Ordering,
@@ -53,7 +57,7 @@ pub struct Tab {
     // icon_size_grid: u16,
 }
 
-impl Default for Tab {
+impl Default for TabConfig {
     fn default() -> Self {
         Self { show_hidden: false }
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -28,12 +28,33 @@ impl AppTheme {
 #[derive(Clone, CosmicConfigEntry, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct Config {
     pub app_theme: AppTheme,
+    pub tab: Tab,
 }
 
 impl Default for Config {
     fn default() -> Self {
         Self {
             app_theme: AppTheme::System,
+            tab: Tab::default(),
         }
+    }
+}
+
+/// Per tab config
+#[derive(Clone, Debug, Eq, PartialEq, CosmicConfigEntry, Deserialize, Serialize)]
+pub struct Tab {
+    /// Show hidden files
+    pub show_hidden: bool,
+    // TODO: Other possible options
+    // pub sort_by: fn(&PathBuf, &PathBuf) -> Ordering,
+    // Icon handle sizes
+    // icon_size_dialog: u16,
+    // icon_size_list: u16,
+    // icon_size_grid: u16,
+}
+
+impl Default for Tab {
+    fn default() -> Self {
+        Self { show_hidden: false }
     }
 }

--- a/src/dialog.rs
+++ b/src/dialog.rs
@@ -25,6 +25,7 @@ use std::{
 };
 
 use crate::{
+    config::Tab as TabConfig,
     fl, home_dir,
     tab::{self, Location, Tab},
 };
@@ -78,7 +79,7 @@ pub struct App {
 
 impl App {
     fn open_tab(&mut self, location: Location) -> Command<Message> {
-        let mut tab = Tab::new(location.clone());
+        let mut tab = Tab::new(location.clone(), TabConfig::default());
         tab.dialog = true;
         let entity = self
             .tab_model

--- a/src/dialog.rs
+++ b/src/dialog.rs
@@ -349,8 +349,7 @@ impl Application for App {
                 if let Some(tab) = self.tab_model.data_mut::<Tab>(entity) {
                     if let Some(ref mut items) = tab.items_opt {
                         for item in items.iter_mut() {
-                            if item.hidden {
-                                //TODO: option to show hidden files
+                            if !tab.config.show_hidden && item.hidden {
                                 continue;
                             }
                             item.selected = true;

--- a/src/dialog.rs
+++ b/src/dialog.rs
@@ -25,7 +25,7 @@ use std::{
 };
 
 use crate::{
-    config::Tab as TabConfig,
+    config::TabConfig,
     fl, home_dir,
     tab::{self, Location, Tab},
 };

--- a/src/key_bind.rs
+++ b/src/key_bind.rs
@@ -71,6 +71,7 @@ pub fn key_binds() -> HashMap<KeyBind, Action> {
     bind!([Ctrl], Key::Character("t".into()), TabNew);
     bind!([Ctrl], Key::Named(Named::Tab), TabNext);
     bind!([Ctrl, Shift], Key::Named(Named::Tab), TabPrev);
+    bind!([Ctrl], Key::Character("h".into()), ToggleShowHidden);
     bind!([Ctrl], Key::Character("q".into()), WindowClose);
     bind!([Ctrl], Key::Character("n".into()), WindowNew);
 

--- a/src/tab.rs
+++ b/src/tab.rs
@@ -23,7 +23,7 @@ use std::{
     time::{Duration, Instant},
 };
 
-use crate::{config::Tab as TabConfig, fl, home_dir, mime_icon::mime_icon};
+use crate::{config::TabConfig, fl, home_dir, mime_icon::mime_icon};
 
 const DOUBLE_CLICK_DURATION: Duration = Duration::from_millis(500);
 //TODO: configurable
@@ -1068,7 +1068,7 @@ mod tests {
             read_dir_sorted, simple_fs, sort_files, tab_click_new, NAME_LEN, NUM_DIRS, NUM_FILES,
             NUM_HIDDEN, NUM_NESTED,
         },
-        config::Tab as TabConfig,
+        config::TabConfig,
     };
 
     // Boilerplate for tab tests. Checks if simulated clicks selected items.

--- a/src/tab.rs
+++ b/src/tab.rs
@@ -380,12 +380,14 @@ impl Location {
 #[derive(Clone, Debug)]
 pub enum Message {
     Click(Option<usize>),
+    Config(TabConfig),
     EditLocation(Option<Location>),
     GoNext,
     GoPrevious,
     Location(Location),
     LocationUp,
     RightClick(usize),
+    ToggleShowHidden,
     View(View),
 }
 
@@ -603,6 +605,9 @@ impl Tab {
                 }
                 self.context_menu = None;
             }
+            Message::Config(config) => {
+                self.config = config;
+            }
             Message::EditLocation(edit_location) => {
                 self.edit_location = edit_location;
             }
@@ -651,6 +656,7 @@ impl Tab {
                     }
                 }
             }
+            Message::ToggleShowHidden => self.config.show_hidden = !self.config.show_hidden,
             Message::View(view) => {
                 self.view = view;
             }
@@ -859,15 +865,15 @@ impl Tab {
         //TODO: get from config
         let item_width = Length::Fixed(96.0);
         let item_height = Length::Fixed(116.0);
+        let TabConfig { show_hidden } = self.config;
 
         let mut children: Vec<Element<_>> = Vec::new();
         if let Some(ref items) = self.items_opt {
             let mut count = 0;
             let mut hidden = 0;
             for (i, item) in items.iter().enumerate() {
-                if item.hidden {
+                if !show_hidden && item.hidden {
                     hidden += 1;
-                    //TODO: SHOW HIDDEN OPTION
                     continue;
                 }
 
@@ -942,10 +948,10 @@ impl Tab {
         if let Some(ref items) = self.items_opt {
             let mut count = 0;
             let mut hidden = 0;
+            let TabConfig { show_hidden } = self.config;
             for (i, item) in items.iter().enumerate() {
-                if item.hidden {
+                if !show_hidden && item.hidden {
                     hidden += 1;
-                    //TODO: SHOW HIDDEN OPTION
                     continue;
                 }
 


### PR DESCRIPTION
Fixes #24 

This works by adding a type for tab configs. The new type is passed to each tab which enables ephemeral, per tab configs. For example, a user can have hidden files visible on one tab but invisible on another.

This should make it easier to fix other TODOs such as using custom heights in `Tab::grid_view()` or different icon sizes et cetera.