### PR TITLE
Tab settings page and icon sizes

### DIFF
--- a/i18n/en/cosmic_files.ftl
+++ b/i18n/en/cosmic_files.ftl
@@ -32,6 +32,9 @@ properties = Properties
 
 ## Settings
 settings = Settings
+settings-tab = Tab
+settings-hidden = Hidden files
+settings-show-hidden = Show hidden files
 
 ### Appearance
 appearance = Appearance

--- a/i18n/en/cosmic_files.ftl
+++ b/i18n/en/cosmic_files.ftl
@@ -35,6 +35,9 @@ settings = Settings
 settings-tab = Tab
 settings-hidden = Hidden files
 settings-show-hidden = Show hidden files
+icon-size-list = Icon size (list)
+icon-size-grid = Icon size (grid)
+icon-zoom = Zoom
 
 ### Appearance
 appearance = Appearance

--- a/src/app.rs
+++ b/src/app.rs
@@ -219,9 +219,12 @@ impl App {
         entity: segmented_button::Entity,
         location: Location,
     ) -> Command<Message> {
+        let icon_sizes = self.config.tab.icon_sizes;
         Command::perform(
             async move {
-                match tokio::task::spawn_blocking(move || location.scan()).await {
+                match tokio::task::spawn_blocking(move || location.scan(icon_sizes))
+                    .await
+                {
                     Ok(items) => message::app(Message::TabRescan(entity, items)),
                     Err(err) => {
                         log::warn!("failed to rescan: {}", err);
@@ -357,7 +360,7 @@ impl App {
             if let Some(ref items) = tab.items_opt {
                 for item in items.iter() {
                     if item.selected {
-                        children.push(item.property_view(&self.core));
+                        children.push(item.property_view(&self.core, tab.config.icon_sizes));
                     }
                 }
             }
@@ -1123,7 +1126,7 @@ pub(crate) mod test_utils {
     use log::{debug, trace};
     use tempfile::{tempdir, TempDir};
 
-    use crate::{config::TabConfig, tab::Item};
+    use crate::{config::{TabConfig, IconSizes}, tab::Item};
 
     use super::*;
 
@@ -1274,7 +1277,7 @@ pub(crate) mod test_utils {
 
         // New tab with items
         let location = Location::Path(path.to_owned());
-        let items = location.scan();
+        let items = location.scan(IconSizes::default());
         let mut tab = Tab::new(location, TabConfig::default());
         tab.items_opt = Some(items);
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -54,13 +54,13 @@ impl Default for Config {
 /// [`TabConfig`] contains options that are passed to each instance of [`crate::tab::Tab`].
 /// These options are set globally through the main config, but each tab may change options
 /// locally. Local changes aren't saved to the main config.
-#[derive(Clone, Debug, Eq, PartialEq, CosmicConfigEntry, Deserialize, Serialize)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, CosmicConfigEntry, Deserialize, Serialize)]
 pub struct TabConfig {
     /// Show hidden files and folders
     pub show_hidden: bool,
     // TODO: Other possible options
     // pub sort_by: fn(&PathBuf, &PathBuf) -> Ordering,
-    // Icon handle zoom percents
+    // Icon zoom
     pub icon_sizes: IconSizes,
 }
 

--- a/src/dialog.rs
+++ b/src/dialog.rs
@@ -209,9 +209,10 @@ struct App {
 impl App {
     fn rescan_tab(&self) -> Command<Message> {
         let location = self.tab.location.clone();
+        let icon_sizes = self.tab.config.icon_sizes;
         Command::perform(
             async move {
-                match tokio::task::spawn_blocking(move || location.scan()).await {
+                match tokio::task::spawn_blocking(move || location.scan(icon_sizes)).await {
                     Ok(items) => message::app(Message::TabRescan(items)),
                     Err(err) => {
                         log::warn!("failed to rescan: {}", err);


### PR DESCRIPTION
This PR adds modifiable icon sizes to the settings page. I represented it as a zoom level instead of pixels.

I clamped the maximum size to an arbitrary number, so that will likely need to be changed to a better value later.

Also! I added the "show hidden" option to the settings page too since I forgot to do it before. :sweat_smile: 