### PR TITLE
Sorter choice config + sort grid view

### DIFF
--- a/i18n/en/cosmic_files.ftl
+++ b/i18n/en/cosmic_files.ftl
@@ -82,6 +82,9 @@ new-folder = New folder
 open-in-terminal = Open in terminal
 move-to-trash = Move to trash
 restore-from-trash = Restore from trash
+sort-by-name = Sort by name
+sort-by-modified = Sort by modified
+sort-by-size = Sort by size
 
 # Menu
 

--- a/i18n/en/cosmic_files.ftl
+++ b/i18n/en/cosmic_files.ftl
@@ -64,6 +64,10 @@ settings-tab = Tab
 settings-show-hidden = Show hidden files
 icon-size-list = Icon size (list)
 icon-size-grid = Icon size (grid)
+sorting-name = Sort by
+direction = Direction
+ascending = Ascending
+descending = Descending
 
 ### Appearance
 appearance = Appearance

--- a/src/app.rs
+++ b/src/app.rs
@@ -231,6 +231,7 @@ pub struct App {
     config: Config,
     app_themes: Vec<String>,
     sort_by_names: Vec<String>,
+    sort_direction: Vec<String>,
     context_page: ContextPage,
     dialog_pages: VecDeque<DialogPage>,
     dialog_text_input: widget::Id,
@@ -530,23 +531,37 @@ impl App {
                     let tab_config = self.config.tab;
                     let sort_by_selected = tab_config.sort_name as _;
 
-                    widget::settings::item::builder(fl!("sorting-name"))
-                        .description(format!("{}", tab_config.sort_name))
-                        .control(widget::dropdown(
-                            &self.sort_by_names,
-                            Some(sort_by_selected),
-                            move |index| {
-                                Message::TabConfig(TabConfig {
-                                    sort_name: match index {
-                                        0 => HeadingOptions::Name,
-                                        1 => HeadingOptions::Modified,
-                                        2 => HeadingOptions::Size,
-                                        _ => HeadingOptions::Name,
-                                    },
-                                    ..tab_config
-                                })
-                            },
-                        ))
+                    widget::settings::item::builder(fl!("sorting-name")).control(widget::dropdown(
+                        &self.sort_by_names,
+                        Some(sort_by_selected),
+                        move |index| {
+                            Message::TabConfig(TabConfig {
+                                sort_name: match index {
+                                    0 => HeadingOptions::Name,
+                                    1 => HeadingOptions::Modified,
+                                    2 => HeadingOptions::Size,
+                                    _ => HeadingOptions::Name,
+                                },
+                                ..tab_config
+                            })
+                        },
+                    ))
+                })
+                .add({
+                    let tab_config = self.config.tab;
+                    // Ascending is true. Descending is false
+                    let direction = tab_config.sort_direction.into();
+
+                    widget::settings::item::builder(fl!("direction")).control(widget::dropdown(
+                        &self.sort_direction,
+                        Some(direction),
+                        move |index| {
+                            Message::TabConfig(TabConfig {
+                                sort_direction: index == 1,
+                                ..tab_config
+                            })
+                        },
+                    ))
                 })
                 .into(),
             widget::settings::view_section(fl!("settings-tab"))
@@ -637,6 +652,7 @@ impl Application for App {
             config: flags.config,
             app_themes,
             sort_by_names: HeadingOptions::names(),
+            sort_direction: vec![fl!("descending"), fl!("ascending")],
             context_page: ContextPage::Settings,
             dialog_pages: VecDeque::new(),
             dialog_text_input: widget::Id::unique(),

--- a/src/app.rs
+++ b/src/app.rs
@@ -78,6 +78,7 @@ pub enum Action {
     TabViewGrid,
     TabViewList,
     ToggleShowHidden,
+    ToggleSort(HeadingOptions),
     WindowClose,
     WindowNew,
 }
@@ -120,6 +121,7 @@ impl Action {
                 Message::TabMessage(entity_opt, tab::Message::View(tab::View::List))
             }
             Action::ToggleShowHidden => Message::TabMessage(None, tab::Message::ToggleShowHidden),
+            Action::ToggleSort(sort) => Message::TabMessage(None, tab::Message::ToggleSort(sort)),
             Action::WindowClose => Message::WindowClose,
             Action::WindowNew => Message::WindowNew,
         }

--- a/src/config.rs
+++ b/src/config.rs
@@ -8,6 +8,8 @@ use cosmic::{
 };
 use serde::{Deserialize, Serialize};
 
+use super::tab::HeadingOptions;
+
 pub const CONFIG_VERSION: u64 = 1;
 
 // Default icon sizes
@@ -58,9 +60,10 @@ impl Default for Config {
 pub struct TabConfig {
     /// Show hidden files and folders
     pub show_hidden: bool,
-    // TODO: Other possible options
-    // pub sort_by: fn(&PathBuf, &PathBuf) -> Ordering,
-    // Icon zoom
+    /// Sorter
+    pub sort_name: HeadingOptions,
+    pub sort_direction: bool,
+    /// Icon zoom
     pub icon_sizes: IconSizes,
 }
 
@@ -68,6 +71,8 @@ impl Default for TabConfig {
     fn default() -> Self {
         Self {
             show_hidden: false,
+            sort_name: HeadingOptions::Name,
+            sort_direction: true,
             icon_sizes: IconSizes::default(),
         }
     }

--- a/src/menu.rs
+++ b/src/menu.rs
@@ -16,7 +16,7 @@ use crate::{
     app::{Action, Message},
     fl,
     key_bind::KeyBind,
-    tab::{self, Location, Tab},
+    tab::{self, HeadingOptions, Location, Tab},
 };
 
 macro_rules! menu_button {
@@ -102,6 +102,28 @@ pub fn context_menu<'a>(
                 children.push(horizontal_rule(1).into());
                 children.push(menu_item(fl!("select-all"), Action::SelectAll).into());
                 children.push(menu_item(fl!("paste"), Action::Paste).into());
+                children.push(horizontal_rule(1).into());
+                children.push(
+                    menu_item(
+                        fl!("sort-by-name"),
+                        Action::ToggleSort(HeadingOptions::Name),
+                    )
+                    .into(),
+                );
+                children.push(
+                    menu_item(
+                        fl!("sort-by-modified"),
+                        Action::ToggleSort(HeadingOptions::Modified),
+                    )
+                    .into(),
+                );
+                children.push(
+                    menu_item(
+                        fl!("sort-by-size"),
+                        Action::ToggleSort(HeadingOptions::Size),
+                    )
+                    .into(),
+                );
             }
         }
         Location::Trash => {
@@ -113,6 +135,28 @@ pub fn context_menu<'a>(
                 children
                     .push(menu_item(fl!("restore-from-trash"), Action::RestoreFromTrash).into());
             }
+            children.push(horizontal_rule(1).into());
+            children.push(
+                menu_item(
+                    fl!("sort-by-name"),
+                    Action::ToggleSort(HeadingOptions::Name),
+                )
+                .into(),
+            );
+            children.push(
+                menu_item(
+                    fl!("sort-by-modified"),
+                    Action::ToggleSort(HeadingOptions::Modified),
+                )
+                .into(),
+            );
+            children.push(
+                menu_item(
+                    fl!("sort-by-size"),
+                    Action::ToggleSort(HeadingOptions::Size),
+                )
+                .into(),
+            );
         }
     }
 

--- a/src/menu.rs
+++ b/src/menu.rs
@@ -14,6 +14,7 @@ use std::collections::HashMap;
 
 use crate::{
     app::{Action, Message},
+    config::TabConfig,
     fl,
     key_bind::KeyBind,
     tab::{self, HeadingOptions, Location, Tab},
@@ -55,6 +56,27 @@ pub fn context_menu<'a>(
             widget::text(key)
         )
         .on_press(tab::Message::ContextAction(action))
+    };
+
+    let TabConfig {
+        sort_name,
+        sort_direction,
+        ..
+    } = tab.config;
+    let sort_item = |label, variant| {
+        menu_item(
+            format!(
+                "{} {}",
+                label,
+                match (sort_name == variant, sort_direction) {
+                    (true, true) => "\u{2B07}",
+                    (true, false) => "\u{2B06}",
+                    _ => "",
+                }
+            ),
+            Action::ToggleSort(variant),
+        )
+        .into()
     };
 
     let mut selected_dir = 0;
@@ -103,27 +125,10 @@ pub fn context_menu<'a>(
                 children.push(menu_item(fl!("select-all"), Action::SelectAll).into());
                 children.push(menu_item(fl!("paste"), Action::Paste).into());
                 children.push(horizontal_rule(1).into());
-                children.push(
-                    menu_item(
-                        fl!("sort-by-name"),
-                        Action::ToggleSort(HeadingOptions::Name),
-                    )
-                    .into(),
-                );
-                children.push(
-                    menu_item(
-                        fl!("sort-by-modified"),
-                        Action::ToggleSort(HeadingOptions::Modified),
-                    )
-                    .into(),
-                );
-                children.push(
-                    menu_item(
-                        fl!("sort-by-size"),
-                        Action::ToggleSort(HeadingOptions::Size),
-                    )
-                    .into(),
-                );
+                // TODO: Nested menu
+                children.push(sort_item(fl!("sort-by-name"), HeadingOptions::Name));
+                children.push(sort_item(fl!("sort-by-modified"), HeadingOptions::Modified));
+                children.push(sort_item(fl!("sort-by-size"), HeadingOptions::Size));
             }
         }
         Location::Trash => {
@@ -136,27 +141,10 @@ pub fn context_menu<'a>(
                     .push(menu_item(fl!("restore-from-trash"), Action::RestoreFromTrash).into());
             }
             children.push(horizontal_rule(1).into());
-            children.push(
-                menu_item(
-                    fl!("sort-by-name"),
-                    Action::ToggleSort(HeadingOptions::Name),
-                )
-                .into(),
-            );
-            children.push(
-                menu_item(
-                    fl!("sort-by-modified"),
-                    Action::ToggleSort(HeadingOptions::Modified),
-                )
-                .into(),
-            );
-            children.push(
-                menu_item(
-                    fl!("sort-by-size"),
-                    Action::ToggleSort(HeadingOptions::Size),
-                )
-                .into(),
-            );
+            // TODO: Nested menu
+            children.push(sort_item(fl!("sort-by-name"), HeadingOptions::Name));
+            children.push(sort_item(fl!("sort-by-modified"), HeadingOptions::Modified));
+            children.push(sort_item(fl!("sort-by-size"), HeadingOptions::Size));
         }
     }
 

--- a/src/tab.rs
+++ b/src/tab.rs
@@ -1605,8 +1605,8 @@ impl Tab {
             //TODO: HACK If we don't reach the bottom of the view, go ahead and add a spacer to do that
             {
                 let mut max_bottom = 0;
-                for item in items.iter() {
-                    if let Some(rect) = item.1.rect_opt.get() {
+                for (_, item) in items {
+                    if let Some(rect) = item.rect_opt.get() {
                         let bottom = (rect.y + rect.height).ceil() as usize;
                         if bottom > max_bottom {
                             max_bottom = bottom;

--- a/src/tab.rs
+++ b/src/tab.rs
@@ -27,6 +27,7 @@ use std::{
     cell::Cell,
     cmp::Ordering,
     collections::HashMap,
+    fmt,
     fs::{self, Metadata},
     path::PathBuf,
     time::{Duration, Instant},
@@ -620,9 +621,29 @@ pub enum View {
 }
 #[derive(Clone, Copy, Debug, Hash, PartialEq, PartialOrd, Ord, Eq, Deserialize, Serialize)]
 pub enum HeadingOptions {
-    Name,
+    Name = 0,
     Modified,
     Size,
+}
+
+impl fmt::Display for HeadingOptions {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            HeadingOptions::Name => write!(f, "{}", fl!("name")),
+            HeadingOptions::Modified => write!(f, "{}", fl!("modified")),
+            HeadingOptions::Size => write!(f, "{}", fl!("size")),
+        }
+    }
+}
+
+impl HeadingOptions {
+    pub fn names() -> Vec<String> {
+        vec![
+            HeadingOptions::Name.to_string(),
+            HeadingOptions::Modified.to_string(),
+            HeadingOptions::Size.to_string(),
+        ]
+    }
 }
 
 #[derive(Clone, Debug)]

--- a/src/tab.rs
+++ b/src/tab.rs
@@ -1533,12 +1533,12 @@ impl Tab {
             .column_spacing(column_spacing)
             .row_spacing(space_xxs)
             .padding([0, space_m].into());
-        if let Some(ref items) = self.items_opt {
+        if let Some(items) = self.column_sort() {
             let mut count = 0;
             let mut col = 0;
             let mut row = 0;
             let mut hidden = 0;
-            for (i, item) in items.iter().enumerate() {
+            for &(i, item) in items.iter() {
                 if !show_hidden && item.hidden {
                     item.pos_opt.set(None);
                     item.rect_opt.set(None);
@@ -1606,7 +1606,7 @@ impl Tab {
             {
                 let mut max_bottom = 0;
                 for item in items.iter() {
-                    if let Some(rect) = item.rect_opt.get() {
+                    if let Some(rect) = item.1.rect_opt.get() {
                         let bottom = (rect.y + rect.height).ceil() as usize;
                         if bottom > max_bottom {
                             max_bottom = bottom;


### PR DESCRIPTION
I've implemented an option to set a default sorting scheme for new tabs. This is related to but doesn't close [#149](https://github.com/pop-os/cosmic-edit/issues/149) on COSMIC Edit.

This PR also adds a feature to sort the grid view by reusing the code to sort the list view.

Finally, I've also added context menu buttons to sort the views without going to settings - this is more useful for grid view. The new context menu items are similar to what is offered in Thunar, Windows Explorer, and likely others.