### PR TITLE
fix: don't allow pasted contents to include the destination.

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -1111,7 +1111,8 @@ impl Application for App {
                     }
                 }
             }
-            Message::PasteContents(to, contents) => {
+            Message::PasteContents(to, mut contents) => {
+                contents.paths.retain(|p| p != &to);
                 if !contents.paths.is_empty() {
                     match contents.kind {
                         ClipboardKind::Copy => {


### PR DESCRIPTION
This fixes #104 . It also fixes an issue where cutting and pasting a folder onto itself deletes it.