### PR TITLE
Selection enhancements and bug fixes

### DIFF
--- a/src/mouse_area.rs
+++ b/src/mouse_area.rs
@@ -474,9 +474,7 @@ fn update<Message: Clone>(
             state.drag_initiated = cursor.position();
         }
 
-        if let Some(message) = widget.on_press.as_ref() {
-            shell.publish(message(cursor.position_in(layout_bounds)));
-
+        if widget.on_press.is_some() {
             return event::Status::Captured;
         }
     }

--- a/src/tab.rs
+++ b/src/tab.rs
@@ -979,14 +979,18 @@ impl Tab {
             && self.dialog.as_ref().map_or(true, |x| x.multiple());
         match message {
             Message::ClickRelease(click_i_opt) => {
-                if click_i_opt != self.clicked.take() {
+                if click_i_opt == self.clicked.take() {
                     return commands;
                 }
                 self.context_menu = None;
-                if let Some(l) = self.items_opt.as_mut() {
-                    for item in l.iter_mut().enumerate() {
-                        if Some(item.0) != click_i_opt {
-                            item.1.selected = false;
+                if let Some(ref mut items) = self.items_opt {
+                    for (i, item) in items.iter_mut().enumerate() {
+                        if mod_ctrl {
+                            if Some(i) == click_i_opt && item.selected {
+                                item.selected = false;
+                            }
+                        } else if Some(i) != click_i_opt {
+                            item.selected = false;
                         }
                     }
                 }
@@ -1015,7 +1019,7 @@ impl Tab {
             }
             Message::Click(click_i_opt) => {
                 self.context_menu = None;
-                if !mod_ctrl {
+                if click_i_opt.is_none() {
                     self.clicked = click_i_opt;
                 }
                 let dont_unset = mod_ctrl
@@ -1039,8 +1043,14 @@ impl Tab {
                                     }
                                 }
                             }
-                            item.selected = true;
-                        } else if !dont_unset {
+                            if !item.selected {
+                                self.clicked = click_i_opt;
+                                item.selected = true;
+                            }
+
+                            self.selected_clicked = true;
+                        } else if !dont_unset && item.selected {
+                            self.clicked = click_i_opt;
                             item.selected = false;
                         }
                     }

--- a/src/tab.rs
+++ b/src/tab.rs
@@ -2286,6 +2286,7 @@ impl Tab {
                 widget::column::with_children(children).padding([0, space_m]),
             )
             .with_id(Id::new("list-view"))
+            .on_press(|_| Message::Click(None))
             .on_drag(Message::Drag)
             .on_drag_end(|_| Message::DragEnd(None))
             .show_drag_rect(true)

--- a/src/tab.rs
+++ b/src/tab.rs
@@ -1157,16 +1157,19 @@ impl Tab {
                 }
             }
             Message::ItemDown => {
-                if let Some((row, col)) = self.select_focus_pos_opt() {
+                if let Some((row, col)) = self.select_focus_pos_opt().or(self.select_last_pos_opt())
+                {
+                    if self.select_focus.is_none() {
+                        // Select last item in current selection to focus it.
+                        self.select_position(row, col, mod_shift);
+                    }
+
                     //TODO: Shift modifier should select items in between
                     // Try to select item in next row
                     if !self.select_position(row + 1, col, mod_shift) {
                         // Ensure current item is still selected if there are no other items
                         self.select_position(row, col, mod_shift);
                     }
-                } else if let Some((row, col)) = self.select_last_pos_opt() {
-                    // Select last item in current selection to focus it
-                    self.select_position(row, col, mod_shift);
                 } else {
                     // Select first item
                     //TODO: select first in scroll
@@ -1180,7 +1183,14 @@ impl Tab {
                 }
             }
             Message::ItemLeft => {
-                if let Some((row, col)) = self.select_focus_pos_opt() {
+                if let Some((row, col)) =
+                    self.select_focus_pos_opt().or(self.select_first_pos_opt())
+                {
+                    if self.select_focus.is_none() {
+                        // Select first item in current selection to focus it.
+                        self.select_position(row, col, mod_shift);
+                    }
+
                     // Try to select previous item in current row
                     if !col
                         .checked_sub(1)
@@ -1205,9 +1215,6 @@ impl Tab {
                             self.select_position(row, col, mod_shift);
                         }
                     }
-                } else if let Some((row, col)) = self.select_first_pos_opt() {
-                    // Select first item in current selection to focus it
-                    self.select_position(row, col, mod_shift);
                 } else {
                     // Select first item
                     //TODO: select first in scroll
@@ -1221,7 +1228,12 @@ impl Tab {
                 }
             }
             Message::ItemRight => {
-                if let Some((row, col)) = self.select_focus_pos_opt() {
+                if let Some((row, col)) = self.select_focus_pos_opt().or(self.select_last_pos_opt())
+                {
+                    if self.select_focus.is_none() {
+                        // Select last item in current selection to focus it.
+                        self.select_position(row, col, mod_shift);
+                    }
                     // Try to select next item in current row
                     if !self.select_position(row, col + 1, mod_shift) {
                         // Try to select first item in next row
@@ -1230,9 +1242,6 @@ impl Tab {
                             self.select_position(row, col, mod_shift);
                         }
                     }
-                } else if let Some((row, col)) = self.select_last_pos_opt() {
-                    // Select last item in current selection to focus it
-                    self.select_position(row, col, mod_shift);
                 } else {
                     // Select first item
                     //TODO: select first in scroll
@@ -1246,7 +1255,14 @@ impl Tab {
                 }
             }
             Message::ItemUp => {
-                if let Some((row, col)) = self.select_focus_pos_opt() {
+                if let Some((row, col)) =
+                    self.select_focus_pos_opt().or(self.select_first_pos_opt())
+                {
+                    if self.select_focus.is_none() {
+                        // Select first item in current selection to focus it.
+                        self.select_position(row, col, mod_shift);
+                    }
+
                     //TODO: Shift modifier should select items in between
                     // Try to select item in last row
                     if !row
@@ -1256,9 +1272,6 @@ impl Tab {
                         // Ensure current item is still selected if there are no other items
                         self.select_position(row, col, mod_shift);
                     }
-                } else if let Some((row, col)) = self.select_first_pos_opt() {
-                    // Select first item in current selection to focus it
-                    self.select_position(row, col, mod_shift);
                 } else {
                     // Select first item
                     //TODO: select first in scroll


### PR DESCRIPTION
- Fix for extra click event. When clicking a file with the mouse, two `Click` events would get fired instead of one.
- Better ctrl + click handling. Clicking on an already selected item will deselect it on `ClickRelease`.
- Add support for drag-selecting with shift of ctrl pressed. This will now invert the selection of any items within the drag rectangle.
- Implement shift+click selection. #114
- Fix for arrow key navigation/selection after an item is clicked with the mouse. #151
- Fix a bug where drag-and-drop would sometimes get initiated inadvertently when there were files selected but you clicked and dragged in the empty area below the files. This should instead start a new drag selection.