### PR TITLE
fix: activate nav model entity

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -942,6 +942,7 @@ impl Application for App {
     }
 
     fn on_nav_select(&mut self, entity: Entity) -> Command<Self::Message> {
+        self.nav_model.activate(entity);
         if let Some(location) = self.nav_model.data::<Location>(entity) {
             let message = Message::TabMessage(None, tab::Message::Location(location.clone()));
             return self.update(message);


### PR DESCRIPTION
This PR allows the navigation model to activate an entity on selection.

Current:

![image](https://github.com/pop-os/cosmic-files/assets/22224438/45a91e41-9a60-4406-9583-ebc6eca49c4f)

Expected:

![image](https://github.com/pop-os/cosmic-files/assets/22224438/6be49b3e-0b0a-482f-8f86-6b89228c58e0)
