### PR TITLE
Fix drag selecting from empty area in grid view

### DIFF
--- a/src/tab.rs
+++ b/src/tab.rs
@@ -1824,6 +1824,8 @@ impl Tab {
         let mut drag_e_i = 0;
         let mut drag_s_i = 0;
 
+        let mut children = Vec::new();
+
         if let Some(items) = self.column_sort() {
             let mut count = 0;
             let mut col = 0;
@@ -1954,6 +1956,8 @@ impl Tab {
                 return (None, self.empty_view(hidden > 0), false);
             }
 
+            children.push(grid.into());
+
             //TODO: HACK If we don't reach the bottom of the view, go ahead and add a spacer to do that
             {
                 let mut max_bottom = 0;
@@ -1969,10 +1973,10 @@ impl Tab {
                     .checked_sub(max_bottom + 2 * (space_xxs as usize))
                     .unwrap_or(0);
                 if spacer_height > 0 {
-                    if col != 0 {
-                        grid = grid.insert_row();
-                    }
-                    grid = grid.push(widget::vertical_space(Length::Fixed(spacer_height as f32)));
+                    children.push(
+                        widget::container(vertical_space(Length::Fixed(spacer_height as f32)))
+                            .into(),
+                    )
                 }
             }
         }
@@ -2029,7 +2033,7 @@ impl Tab {
                 Element::from(dnd_grid)
                     .map(|m| cosmic::app::Message::App(crate::app::Message::TabMessage(None, m)))
             }),
-            mouse_area::MouseArea::new(grid)
+            mouse_area::MouseArea::new(widget::column::with_children(children))
                 .on_press(|_| Message::Click(None))
                 .on_drag(Message::Drag)
                 .on_drag_end(|_| Message::DragEnd(None))


### PR DESCRIPTION
This seems to have been broken by the latest libcosmic update.