### PR TITLE
Bump `trash-rs` to fix panic for non-Unicode paths

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -713,6 +713,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block2"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c132eebf10f5cad5289222520a4a058514204aed6d791f1cf4fe8088b82d15f"
+dependencies = [
+ "objc2 0.5.2",
+]
+
+[[package]]
 name = "blocking"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3880,6 +3889,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7891e71393cd1f227313c9379a26a584ff3d7e6e7159e988851f0934c993f0f8"
 
 [[package]]
+name = "objc2-foundation"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ee638a5da3799329310ad4cfa62fbf045d5f56e3ef5ba4149e7452dcf89d5a8"
+dependencies = [
+ "bitflags 2.5.0",
+ "block2 0.5.1",
+ "libc",
+ "objc2 0.5.2",
+]
+
+[[package]]
 name = "objc_exception"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5514,17 +5535,18 @@ dependencies = [
 
 [[package]]
 name = "trash"
-version = "4.1.1"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c254b119cf49bdde3dfef21b1dc492dc8026b75566ca24aa77993eccd7cbc1b5"
+checksum = "8d8fbfb70b1fad5c0b788f9b2e1bf4d04e5ac6efa828f1ed9ee462c50ff9cf05"
 dependencies = [
  "chrono",
  "libc",
  "log",
- "objc",
+ "objc2 0.5.2",
+ "objc2-foundation",
  "once_cell",
  "scopeguard",
- "url",
+ "urlencoding",
  "windows 0.56.0",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ regex = "1"
 serde = { version = "1", features = ["serde_derive"] }
 shlex = { version = "1.3" }
 tokio = { version = "1", features = ["sync"] }
-trash = "4.1.0"
+trash = "5.0"
 xdg = { version = "2.5.2", optional = true }
 xdg-mime = "0.3"
 url = "2.5"

--- a/src/tab.rs
+++ b/src/tab.rs
@@ -448,7 +448,7 @@ pub fn scan_trash(sizes: IconSizes) -> Vec<Item> {
                 };
 
                 let original_path = entry.original_path();
-                let name = entry.name.clone();
+                let name = entry.name.to_string_lossy().to_string();
 
                 let (mime, icon_handle_grid, icon_handle_list, icon_handle_list_condensed) =
                     match metadata.size {


### PR DESCRIPTION
See: https://github.com/Byron/trash-rs/issues/105

Some operating systems or file systems support non-Unicode paths (e.g. Linux and the BSDs). `trash-rs` panicked when trashing or listing the trash with non-UTF8 names.

For COSMIC Files specifically, the program panics on start if the trash contains files with invalid Unicode names. It also panics when attempting to trash files with said names.

To replicate:
```sh
touch ''$'\250'
gio trash ''$'\250'

cosmic-files
```

Now us�rs can�trash inval�d Un�code whe�������files�����
��
�