### PR TITLE
Fix drag select for grid view

### DIFF
--- a/src/tab.rs
+++ b/src/tab.rs
@@ -2296,13 +2296,15 @@ impl Tab {
                 Element::from(dnd_grid)
                     .map(|m| cosmic::app::Message::App(crate::app::Message::TabMessage(None, m)))
             }),
-            mouse_area::MouseArea::new(widget::column::with_children(children))
-                .on_press(|_| Message::Click(None))
-                .on_drag(Message::Drag)
-                .on_drag_end(|_| Message::DragEnd(None))
-                .show_drag_rect(true)
-                .on_release(|_| Message::ClickRelease(None))
-                .into(),
+            mouse_area::MouseArea::new(
+                widget::container(widget::column::with_children(children)).width(Length::Fill),
+            )
+            .on_press(|_| Message::Click(None))
+            .on_drag(Message::Drag)
+            .on_drag_end(|_| Message::DragEnd(None))
+            .show_drag_rect(true)
+            .on_release(|_| Message::ClickRelease(None))
+            .into(),
             true,
         )
     }


### PR DESCRIPTION
When there was a single row of files and there weren't enough files to fill the row, you couldn't initiate a drag select from the right side of these files.

Fixes #238