### PR TITLE
Add 'Ctrl' + '+' as a zoom-in shortcut

### DIFF
--- a/src/key_bind.rs
+++ b/src/key_bind.rs
@@ -55,6 +55,7 @@ pub fn key_binds() -> HashMap<KeyBind, Action> {
     bind!([Ctrl], Key::Character("q".into()), WindowClose);
     bind!([Ctrl], Key::Character("n".into()), WindowNew);
     bind!([Ctrl], Key::Character("=".into()), ZoomIn);
+    bind!([Ctrl], Key::Character("+".into()), ZoomIn);
     bind!([Ctrl], Key::Character("0".into()), ZoomDefault);
     bind!([Ctrl], Key::Character("-".into()), ZoomOut);
 


### PR DESCRIPTION
It seems the zoom in shortcut was set to 'Ctrl' + '='  to make it work better with 70% and smaller keyboards, but 'Ctrl' + '+' wasn't added. 