### PR TITLE
Design matching

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -801,7 +801,7 @@ impl App {
                     widget::settings::item::builder(fl!("icon-size-list"))
                         .description(format!("{}%", list))
                         .control(
-                            widget::slider(75..=500, list, move |list| {
+                            widget::slider(50..=500, list, move |list| {
                                 Message::TabConfig(TabConfig {
                                     icon_sizes: IconSizes {
                                         list: NonZeroU16::new(list).unwrap(),

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,14 +1,11 @@
 // Copyright 2023 System76 <info@system76.com>
 // SPDX-License-Identifier: GPL-3.0-only
 
-use cosmic::iced::clipboard::dnd::DndAction;
-use cosmic::widget::dnd_destination::DragId;
-use cosmic::widget::menu::action::MenuAction;
-use cosmic::widget::menu::key_bind::KeyBind;
 use cosmic::{
     app::{message, Command, Core},
     cosmic_config, cosmic_theme, executor,
     iced::{
+        clipboard::dnd::DndAction,
         event,
         futures::{self, SinkExt},
         keyboard::{Event as KeyEvent, Key, Modifiers},
@@ -20,6 +17,8 @@ use cosmic::{
     style, theme,
     widget::{
         self,
+        dnd_destination::DragId,
+        menu::{action::MenuAction, key_bind::KeyBind},
         segmented_button::{self, Entity},
     },
     Application, ApplicationExt, Element,
@@ -42,18 +41,17 @@ use std::{
 };
 use tokio::sync::mpsc;
 
-use crate::localize::LANGUAGE_SORTER;
-use crate::tab::HOVER_DURATION;
 use crate::{
     clipboard::{ClipboardCopy, ClipboardKind, ClipboardPaste},
     config::{AppTheme, Config, Favorite, IconSizes, TabConfig, CONFIG_VERSION},
     fl, home_dir,
     key_bind::key_binds,
+    localize::LANGUAGE_SORTER,
     menu, mime_app,
     mounter::{mounters, MounterItem, MounterItems, MounterKey, Mounters},
     operation::{Operation, ReplaceResult},
     spawn_detached::spawn_detached,
-    tab::{self, HeadingOptions, ItemMetadata, Location, Tab},
+    tab::{self, HeadingOptions, ItemMetadata, Location, Tab, HOVER_DURATION},
 };
 
 #[derive(Clone, Debug)]

--- a/src/app.rs
+++ b/src/app.rs
@@ -2389,7 +2389,9 @@ impl Application for App {
 
     /// Creates a view after each update.
     fn view(&self) -> Element<Self::Message> {
-        let cosmic_theme::Spacing { space_xxs, .. } = theme::active().cosmic().spacing;
+        let cosmic_theme::Spacing {
+            space_xxs, space_s, ..
+        } = theme::active().cosmic().spacing;
 
         let mut tab_column = widget::column::with_capacity(1);
 
@@ -2409,7 +2411,8 @@ impl Application for App {
                         .drag_id(self.tab_drag_id),
                 )
                 .style(style::Container::Background)
-                .width(Length::Fill),
+                .width(Length::Fill)
+                .padding([0, space_s]),
             );
         }
 

--- a/src/key_bind.rs
+++ b/src/key_bind.rs
@@ -1,9 +1,11 @@
-use cosmic::widget::menu::key_bind::KeyBind;
-use cosmic::{iced::keyboard::Key, iced_core::keyboard::key::Named};
+use cosmic::{
+    iced::keyboard::Key,
+    iced_core::keyboard::key::Named,
+    widget::menu::key_bind::{KeyBind, Modifier},
+};
 use std::collections::HashMap;
 
 use crate::app::Action;
-use cosmic::widget::menu::key_bind::Modifier;
 
 //TODO: load from config
 pub fn key_binds() -> HashMap<KeyBind, Action> {

--- a/src/menu.rs
+++ b/src/menu.rs
@@ -1,22 +1,20 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
-use cosmic::widget::menu::key_bind::KeyBind;
-use cosmic::widget::menu::{self, ItemHeight, ItemWidth, MenuBar};
 use cosmic::{
     //TODO: export iced::widget::horizontal_rule in cosmic::widget
     iced::{widget::horizontal_rule, Alignment, Background, Border, Length},
     theme,
     widget,
+    widget::menu::{self, key_bind::KeyBind, ItemHeight, ItemWidth, MenuBar},
     Element,
 };
 use std::collections::HashMap;
 
-use crate::tab::LocationMenuAction;
 use crate::{
     app::{Action, Message},
     config::TabConfig,
     fl,
-    tab::{self, HeadingOptions, Location, Tab},
+    tab::{self, HeadingOptions, Location, LocationMenuAction, Tab},
 };
 
 macro_rules! menu_button {

--- a/src/tab.rs
+++ b/src/tab.rs
@@ -2241,7 +2241,7 @@ impl Tab {
         let mut grid = widget::grid()
             .column_spacing(column_spacing)
             .row_spacing(space_xxs)
-            .padding([space_xxxs, space_xxs].into());
+            .padding(space_xxs.into());
         let mut dnd_items: Vec<(usize, (usize, usize), &Item)> = Vec::new();
         let mut drag_w_i = usize::MAX;
         let mut drag_n_i = usize::MAX;
@@ -2384,7 +2384,7 @@ impl Tab {
             children.push(grid.into());
 
             //TODO: HACK If we don't reach the bottom of the view, go ahead and add a spacer to do that
-            /*{
+            {
                 let mut max_bottom = 0;
                 for (_, item) in items {
                     if let Some(rect) = item.rect_opt.get() {
@@ -2395,7 +2395,7 @@ impl Tab {
                     }
                 }
                 let spacer_height = height
-                    .checked_sub(max_bottom + 4 * (space_xxs as usize))
+                    .checked_sub(max_bottom + 7 * (space_xxs as usize))
                     .unwrap_or(0);
                 if spacer_height > 0 {
                     children.push(
@@ -2403,7 +2403,7 @@ impl Tab {
                             .into(),
                     )
                 }
-            }*/
+            }
         }
 
         (
@@ -2411,7 +2411,7 @@ impl Tab {
                 let mut dnd_grid = widget::grid()
                     .column_spacing(column_spacing)
                     .row_spacing(space_xxs)
-                    .padding([0, space_m].into());
+                    .padding(space_xxs.into());
 
                 let mut dnd_item_i = 0;
                 for r in drag_n_i..=drag_s_i {
@@ -2778,14 +2778,14 @@ impl Tab {
             }
         }
         //TODO: HACK If we don't reach the bottom of the view, go ahead and add a spacer to do that
-        /*{
-            let spacer_height = size.height as i32 - y as i32 - 4 * space_xxs as i32;
+        {
+            let spacer_height = size.height as i32 - y as i32 - 5 * space_xxs as i32;
             if spacer_height > 0 {
                 children.push(
                     widget::container(vertical_space(Length::Fixed(spacer_height as f32))).into(),
                 );
             }
-        }*/
+        }
         let drag_col = (!drag_items.is_empty()).then(|| {
             Element::from(widget::column::with_children(drag_items))
                 .map(|m| cosmic::app::Message::App(crate::app::Message::TabMessage(None, m)))

--- a/src/tab.rs
+++ b/src/tab.rs
@@ -2529,8 +2529,8 @@ impl Tab {
                     heading_item(fl!("size"), Length::Fixed(size_width), HeadingOptions::Size),
                 ])
                 .align_items(Alignment::Center)
-                .height(Length::Fixed(32.0))
-                .padding(space_xxs)
+                .height(Length::Fixed(space_m.into()))
+                .padding([0, space_xxs])
                 .spacing(space_xxs)
                 .into(),
             );

--- a/src/tab.rs
+++ b/src/tab.rs
@@ -2384,7 +2384,7 @@ impl Tab {
             children.push(grid.into());
 
             //TODO: HACK If we don't reach the bottom of the view, go ahead and add a spacer to do that
-            {
+            /*{
                 let mut max_bottom = 0;
                 for (_, item) in items {
                     if let Some(rect) = item.rect_opt.get() {
@@ -2403,7 +2403,7 @@ impl Tab {
                             .into(),
                     )
                 }
-            }
+            }*/
         }
 
         (
@@ -2778,14 +2778,14 @@ impl Tab {
             }
         }
         //TODO: HACK If we don't reach the bottom of the view, go ahead and add a spacer to do that
-        {
+        /*{
             let spacer_height = size.height as i32 - y as i32 - 4 * space_xxs as i32;
             if spacer_height > 0 {
                 children.push(
                     widget::container(vertical_space(Length::Fixed(spacer_height as f32))).into(),
                 );
             }
-        }
+        }*/
         let drag_col = (!drag_items.is_empty()).then(|| {
             Element::from(widget::column::with_children(drag_items))
                 .map(|m| cosmic::app::Message::App(crate::app::Message::TabMessage(None, m)))

--- a/src/tab.rs
+++ b/src/tab.rs
@@ -1915,12 +1915,15 @@ impl Tab {
             space_xxxs,
             space_xxs,
             space_s,
+            space_m,
             ..
         } = theme::active().cosmic().spacing;
         let size = self.size_opt.get().unwrap_or(Size::new(0.0, 0.0));
 
-        let mut row = widget::row::with_capacity(5).align_items(Alignment::Center);
+        let mut row = widget::row::with_capacity(7).align_items(Alignment::Center);
         let mut w = 0.0;
+
+        row = row.push(widget::horizontal_space(Length::Fixed(space_m.into())));
 
         let mut prev_button =
             widget::button(widget::icon::from_name("go-previous-symbolic").size(16))
@@ -1961,6 +1964,7 @@ impl Tab {
                             })
                             .on_submit(Message::Location(location.clone())),
                     );
+                    row = row.push(widget::horizontal_space(Length::Fixed(space_m.into())));
                     return row.into();
                 }
                 _ => {

--- a/src/tab.rs
+++ b/src/tab.rs
@@ -54,7 +54,7 @@ use crate::{
     config::{IconSizes, TabConfig, ICON_SCALE_MAX, ICON_SIZE_GRID},
     dialog::DialogKind,
     fl,
-    localize::LANGUAGE_SORTER,
+    localize::{LANGUAGE_CHRONO, LANGUAGE_SORTER},
     menu,
     mime_app::{mime_apps, MimeApp},
     mime_icon::{mime_for_path, mime_icon},

--- a/src/tab.rs
+++ b/src/tab.rs
@@ -1928,7 +1928,7 @@ impl Tab {
 
         let mut row = widget::row::with_capacity(5)
             .align_items(Alignment::Center)
-            .padding([0, space_m]);
+            .padding([space_xxxs, space_s]);
         let mut w = 0.0;
 
         let mut prev_button =
@@ -2537,8 +2537,8 @@ impl Tab {
                     heading_item(fl!("size"), Length::Fixed(size_width), HeadingOptions::Size),
                 ])
                 .align_items(Alignment::Center)
-                .height(Length::Fixed(space_m.into()))
-                .padding([0, space_xxs])
+                .height(Length::Fixed((space_m + 4).into()))
+                .padding(0)
                 .spacing(space_xxs)
                 .into(),
             );

--- a/src/tab.rs
+++ b/src/tab.rs
@@ -1920,10 +1920,8 @@ impl Tab {
         } = theme::active().cosmic().spacing;
         let size = self.size_opt.get().unwrap_or(Size::new(0.0, 0.0));
 
-        let mut row = widget::row::with_capacity(7).align_items(Alignment::Center);
+        let mut row = widget::row::with_capacity(5).align_items(Alignment::Center).padding([0, space_m]);
         let mut w = 0.0;
-
-        row = row.push(widget::horizontal_space(Length::Fixed(space_m.into())));
 
         let mut prev_button =
             widget::button(widget::icon::from_name("go-previous-symbolic").size(16))
@@ -1964,7 +1962,6 @@ impl Tab {
                             })
                             .on_submit(Message::Location(location.clone())),
                     );
-                    row = row.push(widget::horizontal_space(Length::Fixed(space_m.into())));
                     return row.into();
                 }
                 _ => {

--- a/src/tab.rs
+++ b/src/tab.rs
@@ -1921,7 +1921,6 @@ impl Tab {
             space_xxxs,
             space_xxs,
             space_s,
-            space_m,
             ..
         } = theme::active().cosmic().spacing;
         let size = self.size_opt.get().unwrap_or(Size::new(0.0, 0.0));

--- a/src/tab.rs
+++ b/src/tab.rs
@@ -1925,9 +1925,7 @@ impl Tab {
         } = theme::active().cosmic().spacing;
         let size = self.size_opt.get().unwrap_or(Size::new(0.0, 0.0));
 
-        let mut row = widget::row::with_capacity(5)
-            .align_items(Alignment::Center)
-            .padding([space_xxxs, space_s]);
+        let mut row = widget::row::with_capacity(5).align_items(Alignment::Center);
         let mut w = 0.0;
 
         let mut prev_button =
@@ -1969,7 +1967,7 @@ impl Tab {
                             })
                             .on_submit(Message::Location(location.clone())),
                     );
-                    return row.into();
+                    return row.padding([0, space_s]).into();
                 }
                 _ => {
                     //TODO: allow editing other locations
@@ -2139,8 +2137,11 @@ impl Tab {
         for child in children {
             row = row.push(child);
         }
+        let mut column = widget::column::with_capacity(2).padding([0, space_s]);
+        column = column.push(row);
+        column = column.push(horizontal_rule(1));
 
-        let mouse_area = crate::mouse_area::MouseArea::new(row)
+        let mouse_area = crate::mouse_area::MouseArea::new(column)
             .on_right_press(Message::LocationContextMenuPoint);
 
         let mut popover = widget::popover(mouse_area);
@@ -2234,7 +2235,7 @@ impl Tab {
         let mut grid = widget::grid()
             .column_spacing(column_spacing)
             .row_spacing(space_xxs)
-            .padding([0, space_m].into());
+            .padding([space_xxxs, space_xxs].into());
         let mut dnd_items: Vec<(usize, (usize, usize), &Item)> = Vec::new();
         let mut drag_w_i = usize::MAX;
         let mut drag_n_i = usize::MAX;
@@ -2537,7 +2538,7 @@ impl Tab {
                 ])
                 .align_items(Alignment::Center)
                 .height(Length::Fixed((space_m + 4).into()))
-                .padding(0)
+                .padding([0, space_xxs])
                 .spacing(space_xxs)
                 .into(),
             );

--- a/src/tab.rs
+++ b/src/tab.rs
@@ -2528,7 +2528,7 @@ impl Tab {
                     heading_item(fl!("size"), Length::Fixed(size_width), HeadingOptions::Size),
                 ])
                 .align_items(Alignment::Center)
-                .height(Length::Fixed(row_height as f32))
+                .height(Length::Fixed(32.0))
                 .padding(space_xxs)
                 .spacing(space_xxs)
                 .into(),

--- a/src/tab.rs
+++ b/src/tab.rs
@@ -1967,9 +1967,13 @@ impl Tab {
                             .on_input(|input| {
                                 Message::EditLocation(Some(Location::Path(PathBuf::from(input))))
                             })
-                            .on_submit(Message::Location(location.clone())),
+                            .on_submit(Message::Location(location.clone()))
+                            .line_height(1.0),
                     );
-                    return row.padding([0, space_s]).into();
+                    let mut column = widget::column::with_capacity(2).padding([0, space_s]);
+                    column = column.push(row);
+                    column = column.push(horizontal_rule(1));
+                    return column.into();
                 }
                 _ => {
                     //TODO: allow editing other locations

--- a/src/tab.rs
+++ b/src/tab.rs
@@ -1,9 +1,3 @@
-use cosmic::iced::clipboard::dnd::DndAction;
-use cosmic::iced::Border;
-use cosmic::iced_core::widget::tree;
-use cosmic::widget::menu::action::MenuAction;
-use cosmic::widget::menu::key_bind::KeyBind;
-use cosmic::widget::{vertical_space, Id, Widget};
 use cosmic::{
     cosmic_theme, font,
     iced::{
@@ -12,6 +6,7 @@ use cosmic::{
             text::{self, Paragraph},
         },
         alignment::{Horizontal, Vertical},
+        clipboard::dnd::DndAction,
         futures::SinkExt,
         keyboard::Modifiers,
         subscription::{self, Subscription},
@@ -21,6 +16,7 @@ use cosmic::{
             scrollable::{AbsoluteOffset, Viewport},
         },
         Alignment,
+        Border,
         Color,
         ContentFit,
         Length,
@@ -28,36 +24,42 @@ use cosmic::{
         Rectangle,
         Size,
     },
-    theme, widget, Element,
+    iced_core::widget::tree,
+    theme, widget,
+    widget::{
+        menu::{action::MenuAction, key_bind::KeyBind},
+        vertical_space, DndDestination, DndSource, Id, Widget,
+    },
+    Element,
 };
+
 use mime_guess::{mime, Mime};
 use once_cell::sync::Lazy;
 use serde::{Deserialize, Serialize};
-use std::cell::RefCell;
-use std::sync::{Arc, Mutex};
 use std::{
-    cell::Cell,
+    cell::{Cell, RefCell},
     cmp::Ordering,
     collections::HashMap,
     fmt,
     fs::{self, Metadata},
     num::NonZeroU16,
     path::PathBuf,
+    sync::{Arc, Mutex},
     time::{Duration, Instant},
 };
 
-use crate::clipboard::{ClipboardCopy, ClipboardKind, ClipboardPaste};
-use crate::localize::LANGUAGE_SORTER;
 use crate::{
     app::{self, Action},
+    clipboard::{ClipboardCopy, ClipboardKind, ClipboardPaste},
     config::{IconSizes, TabConfig, ICON_SCALE_MAX, ICON_SIZE_GRID},
     dialog::DialogKind,
-    fl, menu,
+    fl,
+    localize::LANGUAGE_SORTER,
+    menu,
     mime_app::{mime_apps, MimeApp},
     mime_icon::{mime_for_path, mime_icon},
     mouse_area,
 };
-use cosmic::widget::{DndDestination, DndSource};
 
 pub const DOUBLE_CLICK_DURATION: Duration = Duration::from_millis(500);
 pub const HOVER_DURATION: Duration = Duration::from_millis(1600);
@@ -1920,7 +1922,9 @@ impl Tab {
         } = theme::active().cosmic().spacing;
         let size = self.size_opt.get().unwrap_or(Size::new(0.0, 0.0));
 
-        let mut row = widget::row::with_capacity(5).align_items(Alignment::Center).padding([0, space_m]);
+        let mut row = widget::row::with_capacity(5)
+            .align_items(Alignment::Center)
+            .padding([0, space_m]);
         let mut w = 0.0;
 
         let mut prev_button =
@@ -2632,7 +2636,7 @@ impl Tab {
                             .width(Length::Fill)
                             .height(Length::Fixed(row_height as f32))
                             .id(item.button_id.clone())
-                            .padding(space_xxs)
+                            .padding(if icon_size < 24 { 7 } else { space_xxs })
                             .style(button_style(item.selected, true, false)),
                     )
                     .on_press(move |_| Message::Click(Some(i)))

--- a/src/tab.rs
+++ b/src/tab.rs
@@ -2479,7 +2479,10 @@ impl Tab {
         bool,
     ) {
         let cosmic_theme::Spacing {
-            space_m, space_xxs, ..
+            space_m,
+            space_s,
+            space_xxs,
+            ..
         } = theme::active().cosmic().spacing;
 
         let TabConfig {
@@ -2787,7 +2790,7 @@ impl Tab {
         (
             drag_col,
             mouse_area::MouseArea::new(
-                widget::column::with_children(children).padding([0, space_m]),
+                widget::column::with_children(children).padding([0, space_s]),
             )
             .with_id(Id::new("list-view"))
             .on_press(|_| Message::Click(None))

--- a/src/tab.rs
+++ b/src/tab.rs
@@ -1925,7 +1925,9 @@ impl Tab {
         } = theme::active().cosmic().spacing;
         let size = self.size_opt.get().unwrap_or(Size::new(0.0, 0.0));
 
-        let mut row = widget::row::with_capacity(5).align_items(Alignment::Center);
+        let mut row = widget::row::with_capacity(5)
+            .align_items(Alignment::Center)
+            .padding([space_xxxs, 0]);
         let mut w = 0.0;
 
         let mut prev_button =


### PR DESCRIPTION
Made the List view sorting headings fixed size to match the behavior of most file managers (and so that they don't become too large). The designs use 24.0 (space_m), but the text doesn't fit at that size, so 32.0 was used.

Also added some horizontal padding to the breadcrumb bar to better match the designs.

With changes:
![screenshot-2024-07-11-22-15-54](https://github.com/user-attachments/assets/6e803bb5-d564-46fd-b32a-058cdda3ac80)
Design:
![Home - list](https://github.com/user-attachments/assets/b131e63e-6955-4248-ba6d-201e56fc894f)


Unrelated, but with the latest commits, it seems a 50% list size displays properly, so maybe the bottom end of the list view size range can be lowered. :)