### PR TITLE
style: promote idiomatic functional Rust

### DIFF
--- a/src/menu.rs
+++ b/src/menu.rs
@@ -75,49 +75,7 @@ pub fn context_menu<'a>(
         .into()
     };
 
-    struct SelectionCounter {
-        total_count: usize,
-        dirs_count: usize,
-    }
-
-    impl SelectionCounter {
-        fn new() -> Self {
-            Self {
-                total_count: 0,
-                dirs_count: 0,
-            }
-        }
-
-        fn any(&self) -> bool {
-            self.total_count > 0
-        }
-
-        fn exactly_one(&self) -> bool {
-            self.total_count == 1
-        }
-
-        fn exactly_one_dir(&self) -> bool {
-            self.dirs_count == 1
-        }
-
-        fn no_dirs(&self) -> bool {
-            self.dirs_count == 0
-        }
-
-        fn only_directories(&self) -> bool {
-            self.total_count == self.dirs_count
-        }
-    }
-
-    let selected = tab.items_opt().map_or(SelectionCounter::new(), |items| {
-        items.into_iter()
-            .filter(|i| i.selected)
-            .fold(SelectionCounter::new(), |mut counter, selection| {
-                counter.total_count += 1;
-                selection.metadata.is_dir().then(|| counter.dirs_count += 1);
-                counter
-            })
-    });
+    let selected = tab.selection_counts();
 
     let mut children: Vec<Element<_>> = Vec::with_capacity(16);
     match tab.location {

--- a/src/menu.rs
+++ b/src/menu.rs
@@ -109,14 +109,15 @@ pub fn context_menu<'a>(
         }
     }
 
-    let selected = tab.items_opt().into_iter().fold(SelectionCounter::new(),
-        |mut selections, items| {
-            let selected_iter = items.into_iter().filter(|i| i.selected);
-            selections.total_count += selected_iter.clone().count();
-            selections.dirs_count += selected_iter.filter(|i| i.metadata.is_dir()).count();
-            selections
-        }
-    );
+    let selected = tab.items_opt().map_or(SelectionCounter::new(), |items| {
+        items.into_iter()
+            .filter(|i| i.selected)
+            .fold(SelectionCounter::new(), |mut counter, selection| {
+                counter.total_count += 1;
+                selection.metadata.is_dir().then(|| counter.dirs_count += 1);
+                counter
+            })
+    });
 
     let mut children: Vec<Element<_>> = Vec::with_capacity(16);
     match tab.location {


### PR DESCRIPTION
I know this is unsolicited request, but as you're proud in writing Cosmic Desktop in Rust would be nice to promote more idiomatic functional style with less mutability. I don't mind if you throw this away as unsuitable for your needs.

Additionally I expanded the menu row to increase space between menu item name and the shortcut as translated items were too tight visually.

Working on this, however, led me to form following questions:
* This code demonstrates a lot of tedious chiseling to built context menu, but doesn't see to use [`iced_aw`](https://github.com/iced-rs/iced_aw?tab=readme-ov-file). Is there reason to build UI this way? Is there a roadmap what `libcosmic` would include in terms of standard desktop widgets?
* I found it surprising to keep mapping between _key binding_ and _action_ kept in `HashMap<>` to be iterated over to find _key binding_ for given _action_. Would it make sense to crate a type like `UIActionMap` that would hold some faster hash maps for both directions? For several key bindings in the application actually a vector with iterative search is faster than HashMap as actual hashing and bucketing takes plenty of cycles.
* Is the font final choice?

