### PR TITLE
Display file permissions in metadata list

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1261,6 +1261,7 @@ dependencies = [
  "test-log",
  "tokio",
  "trash",
+ "unix_permissions_ext",
  "url",
  "vergen",
  "xdg",
@@ -1530,7 +1531,7 @@ checksum = "67e77553c4162a157adbf834ebae5b415acbecbeafc7a74b0e886657506a7611"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -6094,6 +6095,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
 
 [[package]]
+name = "unix_permissions_ext"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7497808a85e03f612f13e9c5061e4c81cdee86e6c00adfa1096690990ccd08e9"
+
+[[package]]
 name = "url"
 version = "2.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7413,7 +7420,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.75",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,7 @@ i18n-embed-fl = "0.7"
 rust-embed = "8"
 slotmap = "1.0.7"
 zip = "2.1.6"
+unix_permissions_ext = "0.1.2"
 
 [dependencies.libcosmic]
 git = "https://github.com/pop-os/libcosmic.git"

--- a/src/tab.rs
+++ b/src/tab.rs
@@ -43,6 +43,7 @@ use std::{
     fmt,
     fs::{self, Metadata},
     num::NonZeroU16,
+    os::unix::fs::PermissionsExt,
     path::PathBuf,
     sync::{Arc, Mutex},
     time::{Duration, Instant},
@@ -198,6 +199,17 @@ fn format_size(size: u64) -> String {
     } else {
         format!("{} B", size)
     }
+}
+
+#[cfg(not(target_os = "windows"))]
+fn format_permissions(metadata: &Metadata) -> String {
+    let octal = format!("{:o}", metadata.permissions().mode());
+    octal[octal.len() - 3..].to_string()
+}
+
+#[cfg(target_os = "windows")]
+fn format_permissions(_metadata: &Metadata) -> String {
+    String::from("Not supported")
 }
 
 #[cfg(not(target_os = "windows"))]
@@ -828,6 +840,11 @@ impl Item {
                             .format_localized(TIME_FORMAT, *LANGUAGE_CHRONO)
                     )));
                 }
+
+                column = column.push(widget::text(format!(
+                    "Permissions: {}",
+                    format_permissions(metadata)
+                )));
             }
             ItemMetadata::Trash { .. } => {
                 //TODO: trash metadata

--- a/src/tab.rs
+++ b/src/tab.rs
@@ -43,11 +43,11 @@ use std::{
     fmt,
     fs::{self, Metadata},
     num::NonZeroU16,
-    os::unix::fs::PermissionsExt,
     path::PathBuf,
     sync::{Arc, Mutex},
     time::{Duration, Instant},
 };
+use unix_permissions_ext::UNIXPermissionsExt;
 
 use crate::{
     app::{self, Action},
@@ -203,8 +203,7 @@ fn format_size(size: u64) -> String {
 
 #[cfg(not(target_os = "windows"))]
 fn format_permissions(metadata: &Metadata) -> String {
-    let octal = format!("{:o}", metadata.permissions().mode());
-    octal[octal.len() - 3..].to_string()
+    metadata.permissions().stringify()
 }
 
 #[cfg(target_os = "windows")]


### PR DESCRIPTION
Displays the three digit permissions of a file in the sidebar under the other metadata. 

This seemed like an omission, the other metadata listed here made me expect to also find file permissions. I've truncated the bits down to the last 3, which is the set I think most people are interested in.

Digit based display:
![image](https://github.com/user-attachments/assets/dcc28b57-a31c-4136-8121-7fcc08fcaf13)

Character based display:
![image](https://github.com/user-attachments/assets/6251e3b8-cb7f-4658-8d0b-b6e33242b4c6)

