### PR TITLE
Display file ownership and permissions.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1261,7 +1261,9 @@ dependencies = [
  "test-log",
  "tokio",
  "trash",
+ "unix_permissions_ext",
  "url",
+ "users",
  "vergen",
  "xdg",
  "xdg-mime",
@@ -1530,7 +1532,7 @@ checksum = "67e77553c4162a157adbf834ebae5b415acbecbeafc7a74b0e886657506a7611"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -6094,6 +6096,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
 
 [[package]]
+name = "unix_permissions_ext"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7497808a85e03f612f13e9c5061e4c81cdee86e6c00adfa1096690990ccd08e9"
+
+[[package]]
 name = "url"
 version = "2.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6110,6 +6118,16 @@ name = "urlencoding"
 version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
+
+[[package]]
+name = "users"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24cc0f6d6f267b73e5a2cadf007ba8f9bc39c6a6f9666f8cf25ea809a153b032"
+dependencies = [
+ "libc",
+ "log",
+]
 
 [[package]]
 name = "usvg"
@@ -7413,7 +7431,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.75",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,8 @@ i18n-embed-fl = "0.7"
 rust-embed = "8"
 slotmap = "1.0.7"
 zip = "2.1.6"
+unix_permissions_ext = "0.1.2"
+users = "0.11.0"
 
 [dependencies.libcosmic]
 git = "https://github.com/pop-os/libcosmic.git"

--- a/i18n/en/cosmic_files.ftl
+++ b/i18n/en/cosmic_files.ftl
@@ -58,6 +58,15 @@ apply-to-all = Apply to all
 keep-both = Keep both
 skip = Skip
 
+
+## Metadata Dialog
+owner = Owner
+group = Group
+other = Other
+read = Read
+write = Write
+execute = Execute
+
 # Context Pages
 
 ## About

--- a/src/tab.rs
+++ b/src/tab.rs
@@ -220,41 +220,30 @@ fn format_permissions_owner(metadata: &Metadata, owner: PermissionOwner) -> Stri
     };
 }
 fn format_permissions(metadata: &Metadata, owner: PermissionOwner) -> String {
-    let readable = match owner {
+    let mut perms: Vec<String> = Vec::new();
+    if match owner {
         PermissionOwner::Owner => metadata.permissions().readable_by_owner(),
         PermissionOwner::Group => metadata.permissions().readable_by_group(),
         PermissionOwner::Other => metadata.permissions().readable_by_other(),
-    };
-    let writeable = match owner {
+    } {
+        perms.push(fl!("read"));
+    }
+    if match owner {
         PermissionOwner::Owner => metadata.permissions().writable_by_owner(),
         PermissionOwner::Group => metadata.permissions().writable_by_group(),
         PermissionOwner::Other => metadata.permissions().writable_by_other(),
-    };
-    let executable = match owner {
+    } {
+        perms.push(fl!("write"));
+    }
+    if match owner {
         PermissionOwner::Owner => metadata.permissions().executable_by_owner(),
         PermissionOwner::Group => metadata.permissions().executable_by_group(),
         PermissionOwner::Other => metadata.permissions().executable_by_other(),
-    };
-    format!(
-        "{} {} {}",
-        if readable {
-            fl!("read")
-        } else {
-            String::from("")
-        },
-        if writeable {
-            fl!("write")
-        } else {
-            String::from("")
-        },
-        if executable {
-            fl!("execute")
-        } else {
-            String::from("")
-        }
-    )
-    .trim_end()
-    .to_string()
+    } {
+        perms.push(fl!("execute"));
+    }
+
+    perms.join(" ")
 }
 
 #[cfg(not(target_os = "windows"))]


### PR DESCRIPTION
This subsumes #414. Took feedback into account to display more human-readable permissions. Also, display the owner and group ownership inline with the permissions themselves. 

Decided to put this in a new PR in case the old one is preferred, this one has a bit more going on.

![image](https://github.com/user-attachments/assets/44db3062-328d-4c67-9456-e3c5da600832)
