### PR TITLE
hotkeys-capslock fix for (#286)

### DIFF
--- a/src/key_bind.rs
+++ b/src/key_bind.rs
@@ -24,9 +24,13 @@ pub fn key_binds() -> HashMap<KeyBind, Action> {
     }
 
     bind!([Ctrl], Key::Character("d".into()), AddToSidebar);
+    bind!([Ctrl], Key::Character("D".into()), AddToSidebar);
     bind!([Ctrl], Key::Character("c".into()), Copy);
+    bind!([Ctrl], Key::Character("C".into()), Copy);
     bind!([Ctrl], Key::Character("x".into()), Cut);
+    bind!([Ctrl], Key::Character("X".into()), Cut);
     bind!([Ctrl], Key::Character("l".into()), EditLocation);
+    bind!([Ctrl], Key::Character("L".into()), EditLocation);
     bind!([Alt], Key::Named(Named::ArrowRight), HistoryNext);
     bind!([Alt], Key::Named(Named::ArrowLeft), HistoryPrevious);
     // Catch arrow keys
@@ -42,22 +46,31 @@ pub fn key_binds() -> HashMap<KeyBind, Action> {
     bind!([Alt], Key::Named(Named::ArrowUp), LocationUp);
     bind!([], Key::Named(Named::Delete), MoveToTrash);
     bind!([Ctrl, Shift], Key::Character("N".into()), NewFolder);
+    bind!([Ctrl, Shift], Key::Character("n".into()), NewFolder);
     bind!([], Key::Named(Named::Enter), Open);
     bind!([Ctrl], Key::Named(Named::Enter), OpenInNewTab);
     bind!([Shift], Key::Named(Named::Enter), OpenInNewWindow);
     bind!([Ctrl], Key::Character("v".into()), Paste);
+    bind!([Ctrl], Key::Character("V".into()), Paste);
     bind!([], Key::Named(Named::Space), Properties);
     bind!([], Key::Named(Named::F2), Rename);
     bind!([Ctrl], Key::Character("f".into()), SearchActivate);
+    bind!([Ctrl], Key::Character("F".into()), SearchActivate);
     bind!([Ctrl], Key::Character("a".into()), SelectAll);
+    bind!([Ctrl], Key::Character("A".into()), SelectAll);
     bind!([Ctrl], Key::Character(",".into()), Settings);
     bind!([Ctrl], Key::Character("w".into()), TabClose);
+    bind!([Ctrl], Key::Character("W".into()), TabClose);
     bind!([Ctrl], Key::Character("t".into()), TabNew);
+    bind!([Ctrl], Key::Character("T".into()), TabNew);
     bind!([Ctrl], Key::Named(Named::Tab), TabNext);
     bind!([Ctrl, Shift], Key::Named(Named::Tab), TabPrev);
     bind!([Ctrl], Key::Character("h".into()), ToggleShowHidden);
+    bind!([Ctrl], Key::Character("H".into()), ToggleShowHidden);
     bind!([Ctrl], Key::Character("q".into()), WindowClose);
+    bind!([Ctrl], Key::Character("Q".into()), WindowClose);
     bind!([Ctrl], Key::Character("n".into()), WindowNew);
+    bind!([Ctrl], Key::Character("N".into()), WindowNew);
     bind!([Ctrl], Key::Character("=".into()), ZoomIn);
     bind!([Ctrl], Key::Character("+".into()), ZoomIn);
     bind!([Ctrl], Key::Character("0".into()), ZoomDefault);


### PR DESCRIPTION
Should close #286 .
Demo:

[hotkeys-capslock.webm](https://github.com/user-attachments/assets/89bc358a-0534-4790-87d7-570ba734c278)


Note: I did try to change the macro to add nested repetition but the metavariables need to have same length to work according to the reference: https://doc.rust-lang.org/reference/macros-by-example.html#transcribing.

> If multiple metavariables appear in the same repetition, they must be bound to the same number of fragments. 
