### PR TITLE
Refresh/reload tab view & search, fix(#146).

### DIFF
--- a/i18n/en/cosmic_files.ftl
+++ b/i18n/en/cosmic_files.ftl
@@ -2,6 +2,7 @@ cosmic-files = COSMIC Files
 empty-folder = Empty folder
 empty-folder-hidden = Empty folder (has hidden items)
 no-results = No results found
+refresh-loading = Loading...
 filesystem = Filesystem
 home = Home
 notification-in-progress = File operations are in progress.

--- a/src/key_bind.rs
+++ b/src/key_bind.rs
@@ -48,6 +48,8 @@ pub fn key_binds() -> HashMap<KeyBind, Action> {
     bind!([Ctrl], Key::Character("v".into()), Paste);
     bind!([], Key::Named(Named::Space), Properties);
     bind!([], Key::Named(Named::F2), Rename);
+    bind!([], Key::Named(Named::F5), Refresh);
+    bind!([Ctrl], Key::Character("r".into()), Refresh);
     bind!([Ctrl], Key::Character("f".into()), SearchActivate);
     bind!([Ctrl], Key::Character("a".into()), SelectAll);
     bind!([Ctrl], Key::Character(",".into()), Settings);

--- a/src/tab.rs
+++ b/src/tab.rs
@@ -1171,12 +1171,14 @@ pub struct Tab {
     pub config: TabConfig,
     pub(crate) items_opt: Option<Vec<Item>>,
     pub dnd_hovered: Option<(Location, Instant)>,
+    pub(crate) refresh_active: bool,
     scrollable_id: widget::Id,
     select_focus: Option<usize>,
     select_range: Option<(usize, usize)>,
     cached_selected: RefCell<Option<bool>>,
     clicked: Option<usize>,
     selected_clicked: bool,
+
 }
 
 fn folder_name<P: AsRef<Path>>(path: P) -> (String, bool) {
@@ -1216,6 +1218,7 @@ impl Tab {
             history,
             config,
             items_opt: None,
+            refresh_active: false,
             scrollable_id: widget::Id::unique(),
             select_focus: None,
             select_range: None,
@@ -2608,7 +2611,9 @@ impl Tab {
                         .size(64)
                         .icon()
                         .into(),
-                    widget::text(if has_hidden {
+                    widget::text(if self.refresh_active {
+                        fl!("refresh-loading")
+                    } else if has_hidden {
                         fl!("empty-folder-hidden")
                     } else if matches!(self.location, Location::Search(_, _)) {
                         fl!("no-results")


### PR DESCRIPTION
- Should close #146 
 
- Made an attempt to provide a refresh/reload view functionality and it seems to work but maybe not the best/novel way to do it. I managed to create a refresh-delay animation somehow otherwise the reload functionality would not be able to be noticed, similar to how nautilus at least from a user perspective is doing that.
 
- Demo: 

 [refresh-view.webm](https://github.com/user-attachments/assets/8cac4b9c-5328-4fbb-b11c-ffe15505845c)
 