### PR TITLE
open multiple files in one app instance if possible

### DIFF
--- a/src/mime_app.rs
+++ b/src/mime_app.rs
@@ -17,7 +17,14 @@ pub fn exec_to_command(exec: &str, path_opt: Vec<Option<PathBuf>>) -> Option<pro
     for arg in args {
         if arg.starts_with('%') {
             match arg.as_str() {
-                "%f" | "%F" | "%u" | "%U" => {
+                "%f" | "%u" => {
+                    if !path_opt.is_empty() {
+                        if let Some(Some(path)) = &path_opt.first() {
+                            command.arg(path);
+                        }
+                    }
+                }
+                "%F" | "%U" => {
                     if !path_opt.is_empty() {
                         path_opt.iter().for_each(|path| {
                             if let Some(path) = &path {

--- a/src/mime_app.rs
+++ b/src/mime_app.rs
@@ -10,7 +10,7 @@ use std::{
     cmp::Ordering, collections::HashMap, env, path::PathBuf, process, sync::Mutex, time::Instant,
 };
 
-pub fn exec_to_command(exec: &str, path_opt: Option<PathBuf>) -> Option<process::Command> {
+pub fn exec_to_command(exec: &str, path_opt: Vec<Option<PathBuf>>) -> Option<process::Command> {
     let args_vec: Vec<String> = shlex::split(exec)?;
     let mut args = args_vec.iter();
     let mut command = process::Command::new(args.next()?);
@@ -18,8 +18,12 @@ pub fn exec_to_command(exec: &str, path_opt: Option<PathBuf>) -> Option<process:
         if arg.starts_with('%') {
             match arg.as_str() {
                 "%f" | "%F" | "%u" | "%U" => {
-                    if let Some(path) = &path_opt {
-                        command.arg(path);
+                    if !path_opt.is_empty() {
+                        path_opt.iter().for_each(|path| {
+                            if let Some(path) = &path {
+                                command.arg(path);
+                            }
+                        })
                     }
                 }
                 _ => {
@@ -46,7 +50,7 @@ pub struct MimeApp {
 
 impl MimeApp {
     //TODO: move to libcosmic, support multiple files
-    pub fn command(&self, path_opt: Option<PathBuf>) -> Option<process::Command> {
+    pub fn command(&self, path_opt: Vec<Option<PathBuf>>) -> Option<process::Command> {
         exec_to_command(self.exec.as_deref()?, path_opt)
     }
 }

--- a/src/tab.rs
+++ b/src/tab.rs
@@ -1957,19 +1957,21 @@ impl Tab {
                     let selections = items.iter().filter(|item| item.selected).count();
 
                     for item in items.iter() {
+                        let has_default_app = item.open_with.iter().any(|&x| x.is_default);
+
                         if item.selected {
                             if let Some(path) = &item.path_opt {
                                 if path.is_dir() {
                                     //TODO: allow opening multiple tabs?
                                     cd = Some(Location::Path(path.clone()));
-                                } else if selections == 1 {
+                                } else if selections == 1 || !has_default_app {
                                     commands.push(Command::OpenFile(path.clone()));
                                 }
                             } else {
                                 //TODO: open properties?
                             }
 
-                            if selections > 1 {
+                            if selections > 1 && has_default_app {
                                 many_items.push(item.clone());
                             }
                         }

--- a/src/tab.rs
+++ b/src/tab.rs
@@ -764,6 +764,7 @@ pub enum Command {
     LocationProperties(usize),
     MoveToTrash(Vec<PathBuf>),
     OpenFile(PathBuf),
+    OpenMultipleFiles(Vec<Item>),
     OpenInNewTab(PathBuf),
     OpenInNewWindow(PathBuf),
 }
@@ -1949,20 +1950,32 @@ impl Tab {
                 }
             }
             Message::Open => {
+                let mut many_items = Vec::new();
+
                 if let Some(ref mut items) = self.items_opt {
+                    let selections = items.iter().filter(|item| item.selected).count();
+
                     for item in items.iter() {
                         if item.selected {
                             if let Some(path) = &item.path_opt {
                                 if path.is_dir() {
                                     //TODO: allow opening multiple tabs?
                                     cd = Some(Location::Path(path.clone()));
-                                } else {
+                                } else if selections == 1 {
                                     commands.push(Command::OpenFile(path.clone()));
                                 }
                             } else {
                                 //TODO: open properties?
                             }
+
+                            if selections > 1 {
+                                many_items.push(item.clone());
+                            }
                         }
+                    }
+
+                    if !many_items.is_empty() {
+                        commands.push(Command::OpenMultipleFiles(many_items));
                     }
                 }
             }

--- a/src/tab.rs
+++ b/src/tab.rs
@@ -1957,7 +1957,7 @@ impl Tab {
                     let selections = items.iter().filter(|item| item.selected).count();
 
                     for item in items.iter() {
-                        let has_default_app = item.open_with.iter().any(|&x| x.is_default);
+                        let has_default_app = item.open_with.iter().any(|x| x.is_default);
 
                         if item.selected {
                             if let Some(path) = &item.path_opt {


### PR DESCRIPTION
This will allow to open multiple files in one app instance. So for example, we opening 3x text files, so they will be opened in COSMIC Text (default app for specific mimetype) in 3 tabs, instead of 3 apps. Don't know if this is needed or implementation is fine but I'm sure to not broke anything :sweat_smile: If there will be one file selected, it will open just like before. Only handle for multiple files is featured. I tested this on multiple files for the same type:
- 3x text files: *.rs, *.md and *.txt = opened in 3 tabs of COSMIC Text
- 2x files with the same mimetype, *.deb = opened in one instance of [Wizard](https://github.com/cosmic-utils/wizard) app, so expected (also tested it in this app ^^)
- 4x files with 2 different mimetypes, 2x *.deb and 2x *.zip files = opened in 2x different fileroller instances (so as it should I guess) and 2x deb files opened in one instance of Wizard app.

From my testing, seems to work. 