### PR TITLE
[Recents] Use correct icon

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -605,7 +605,7 @@ impl App {
 
         nav_model = nav_model.insert(|b| {
             b.text(fl!("recents"))
-                .icon(widget::icon::from_name("accessories-clock-symbolic"))
+                .icon(widget::icon::from_name("document-open-recent-symbolic"))
                 .data(Location::Recents)
         });
 

--- a/src/dialog.rs
+++ b/src/dialog.rs
@@ -421,7 +421,7 @@ impl App {
 
         nav_model = nav_model.insert(|b| {
             b.text(fl!("recents"))
-                .icon(widget::icon::from_name("accessories-clock-symbolic"))
+                .icon(widget::icon::from_name("document-open-recent-symbolic"))
                 .data(Location::Recents)
         });
 

--- a/src/tab.rs
+++ b/src/tab.rs
@@ -2549,7 +2549,7 @@ impl Tab {
                 let mut row = widget::row::with_capacity(2)
                     .align_items(Alignment::Center)
                     .spacing(space_xxxs);
-                row = row.push(widget::icon::from_name("accessories-clock-symbolic").size(16));
+                row = row.push(widget::icon::from_name("document-open-recent-symbolic").size(16));
                 row = row.push(widget::text::heading(fl!("recents")));
 
                 children.push(


### PR DESCRIPTION
Use the freedesktop spec `document-open-recent-symbolic` icon, instead of `accessories-clock-symbolic`.