### PR TITLE
Change display of date and time

### DIFF
--- a/i18n/en/cosmic_files.ftl
+++ b/i18n/en/cosmic_files.ftl
@@ -9,6 +9,7 @@ notification-in-progress = File operations are in progress.
 trash = Trash
 recents = Recents
 undo = Undo
+today = Today
 
 # List view
 name = Name


### PR DESCRIPTION
Implements  #343

It currently assumes a 12-hour clock for the time format. It would probably make sense to add a setting to be able to switch it to a 24-hour clock. Maybe it could just use whatever is configured for the time applet?