### PR TITLE
Make header button height fixed

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1212,7 +1212,7 @@ dependencies = [
 [[package]]
 name = "cosmic-config"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/libcosmic.git#10f02d9d6b629a58e0298edc5a7dea27e7a86098"
+source = "git+https://github.com/pop-os/libcosmic.git#701638009df09a254b7d077ddc4d1076cd87a147"
 dependencies = [
  "atomicwrites",
  "cosmic-config-derive",
@@ -1231,7 +1231,7 @@ dependencies = [
 [[package]]
 name = "cosmic-config-derive"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/libcosmic.git#10f02d9d6b629a58e0298edc5a7dea27e7a86098"
+source = "git+https://github.com/pop-os/libcosmic.git#701638009df09a254b7d077ddc4d1076cd87a147"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -1340,7 +1340,7 @@ dependencies = [
 [[package]]
 name = "cosmic-theme"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/libcosmic.git#10f02d9d6b629a58e0298edc5a7dea27e7a86098"
+source = "git+https://github.com/pop-os/libcosmic.git#701638009df09a254b7d077ddc4d1076cd87a147"
 dependencies = [
  "almost",
  "cosmic-config",
@@ -2783,7 +2783,7 @@ dependencies = [
 [[package]]
 name = "iced"
 version = "0.12.0"
-source = "git+https://github.com/pop-os/libcosmic.git#10f02d9d6b629a58e0298edc5a7dea27e7a86098"
+source = "git+https://github.com/pop-os/libcosmic.git#701638009df09a254b7d077ddc4d1076cd87a147"
 dependencies = [
  "dnd",
  "iced_accessibility",
@@ -2802,7 +2802,7 @@ dependencies = [
 [[package]]
 name = "iced_accessibility"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/libcosmic.git#10f02d9d6b629a58e0298edc5a7dea27e7a86098"
+source = "git+https://github.com/pop-os/libcosmic.git#701638009df09a254b7d077ddc4d1076cd87a147"
 dependencies = [
  "accesskit",
  "accesskit_unix",
@@ -2812,7 +2812,7 @@ dependencies = [
 [[package]]
 name = "iced_core"
 version = "0.12.0"
-source = "git+https://github.com/pop-os/libcosmic.git#10f02d9d6b629a58e0298edc5a7dea27e7a86098"
+source = "git+https://github.com/pop-os/libcosmic.git#701638009df09a254b7d077ddc4d1076cd87a147"
 dependencies = [
  "bitflags 2.6.0",
  "dnd",
@@ -2834,7 +2834,7 @@ dependencies = [
 [[package]]
 name = "iced_futures"
 version = "0.12.0"
-source = "git+https://github.com/pop-os/libcosmic.git#10f02d9d6b629a58e0298edc5a7dea27e7a86098"
+source = "git+https://github.com/pop-os/libcosmic.git#701638009df09a254b7d077ddc4d1076cd87a147"
 dependencies = [
  "futures",
  "iced_core",
@@ -2847,7 +2847,7 @@ dependencies = [
 [[package]]
 name = "iced_graphics"
 version = "0.12.0"
-source = "git+https://github.com/pop-os/libcosmic.git#10f02d9d6b629a58e0298edc5a7dea27e7a86098"
+source = "git+https://github.com/pop-os/libcosmic.git#701638009df09a254b7d077ddc4d1076cd87a147"
 dependencies = [
  "bitflags 2.6.0",
  "bytemuck",
@@ -2871,7 +2871,7 @@ dependencies = [
 [[package]]
 name = "iced_renderer"
 version = "0.12.0"
-source = "git+https://github.com/pop-os/libcosmic.git#10f02d9d6b629a58e0298edc5a7dea27e7a86098"
+source = "git+https://github.com/pop-os/libcosmic.git#701638009df09a254b7d077ddc4d1076cd87a147"
 dependencies = [
  "iced_graphics",
  "iced_tiny_skia",
@@ -2883,7 +2883,7 @@ dependencies = [
 [[package]]
 name = "iced_runtime"
 version = "0.12.0"
-source = "git+https://github.com/pop-os/libcosmic.git#10f02d9d6b629a58e0298edc5a7dea27e7a86098"
+source = "git+https://github.com/pop-os/libcosmic.git#701638009df09a254b7d077ddc4d1076cd87a147"
 dependencies = [
  "dnd",
  "iced_accessibility",
@@ -2897,7 +2897,7 @@ dependencies = [
 [[package]]
 name = "iced_sctk"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/libcosmic.git#10f02d9d6b629a58e0298edc5a7dea27e7a86098"
+source = "git+https://github.com/pop-os/libcosmic.git#701638009df09a254b7d077ddc4d1076cd87a147"
 dependencies = [
  "enum-repr",
  "float-cmp",
@@ -2924,7 +2924,7 @@ dependencies = [
 [[package]]
 name = "iced_style"
 version = "0.12.0"
-source = "git+https://github.com/pop-os/libcosmic.git#10f02d9d6b629a58e0298edc5a7dea27e7a86098"
+source = "git+https://github.com/pop-os/libcosmic.git#701638009df09a254b7d077ddc4d1076cd87a147"
 dependencies = [
  "iced_core",
  "once_cell",
@@ -2934,7 +2934,7 @@ dependencies = [
 [[package]]
 name = "iced_tiny_skia"
 version = "0.12.0"
-source = "git+https://github.com/pop-os/libcosmic.git#10f02d9d6b629a58e0298edc5a7dea27e7a86098"
+source = "git+https://github.com/pop-os/libcosmic.git#701638009df09a254b7d077ddc4d1076cd87a147"
 dependencies = [
  "bytemuck",
  "cosmic-text",
@@ -2951,7 +2951,7 @@ dependencies = [
 [[package]]
 name = "iced_wgpu"
 version = "0.12.0"
-source = "git+https://github.com/pop-os/libcosmic.git#10f02d9d6b629a58e0298edc5a7dea27e7a86098"
+source = "git+https://github.com/pop-os/libcosmic.git#701638009df09a254b7d077ddc4d1076cd87a147"
 dependencies = [
  "as-raw-xcb-connection",
  "bitflags 2.6.0",
@@ -2980,7 +2980,7 @@ dependencies = [
 [[package]]
 name = "iced_widget"
 version = "0.12.0"
-source = "git+https://github.com/pop-os/libcosmic.git#10f02d9d6b629a58e0298edc5a7dea27e7a86098"
+source = "git+https://github.com/pop-os/libcosmic.git#701638009df09a254b7d077ddc4d1076cd87a147"
 dependencies = [
  "dnd",
  "iced_accessibility",
@@ -2998,7 +2998,7 @@ dependencies = [
 [[package]]
 name = "iced_winit"
 version = "0.12.0"
-source = "git+https://github.com/pop-os/libcosmic.git#10f02d9d6b629a58e0298edc5a7dea27e7a86098"
+source = "git+https://github.com/pop-os/libcosmic.git#701638009df09a254b7d077ddc4d1076cd87a147"
 dependencies = [
  "dnd",
  "iced_accessibility",
@@ -3514,7 +3514,7 @@ checksum = "d8adc4bb1803a324070e64a98ae98f38934d91957a99cfb3a43dcbc01bc56439"
 [[package]]
 name = "libcosmic"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/libcosmic.git#10f02d9d6b629a58e0298edc5a7dea27e7a86098"
+source = "git+https://github.com/pop-os/libcosmic.git#701638009df09a254b7d077ddc4d1076cd87a147"
 dependencies = [
  "apply",
  "ashpd 0.9.1",

--- a/src/app.rs
+++ b/src/app.rs
@@ -3251,6 +3251,7 @@ impl Application for App {
         } else {
             elements.push(
                 widget::button::icon(widget::icon::from_name("system-search-symbolic"))
+                    .padding(8)
                     .on_press(Message::SearchActivate)
                     .into(),
             )

--- a/src/menu.rs
+++ b/src/menu.rs
@@ -283,7 +283,8 @@ pub fn dialog_menu<'a>(
             widget::button::icon(widget::icon::from_name(match tab.config.view {
                 tab::View::Grid => "view-grid-symbolic",
                 tab::View::List => "view-list-symbolic",
-            })),
+            }))
+            .padding(8),
             menu::items(
                 key_binds,
                 vec![
@@ -305,7 +306,8 @@ pub fn dialog_menu<'a>(
                 "view-sort-ascending-symbolic"
             } else {
                 "view-sort-descending-symbolic"
-            })),
+            }))
+            .padding(8),
             menu::items(
                 key_binds,
                 vec![


### PR DESCRIPTION
This matches the custom header buttons to other header bar buttons and prevents the buttons being cut off when Spacious density is used, and makes them easier to click when Compact.

The change isn't reflected in the file picker, and patching `cosmic-files` in `xdg-desktop-portal-cosmic` didn't change anything, but not sure how exactly the file picker works.