### PR TITLE
[Dialog] Fix header bar button padding

### DIFF
--- a/src/dialog.rs
+++ b/src/dialog.rs
@@ -871,6 +871,7 @@ impl Application for App {
             elements.push(
                 widget::button::icon(widget::icon::from_name("system-search-symbolic"))
                     .on_press(Message::SearchActivate)
+                    .padding(8)
                     .into(),
             )
         }
@@ -879,6 +880,7 @@ impl Application for App {
             elements.push(
                 widget::button::icon(widget::icon::from_name("folder-new-symbolic"))
                     .on_press(Message::NewFolder)
+                    .padding(8)
                     .into(),
             );
         }


### PR DESCRIPTION
Unfortunately, I seem to have missed these icon buttons previously, so the search and new folder buttons get cut off when Spacious.