### PR TITLE
fix(toggle-show-details): fix show-details toggle

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -2157,10 +2157,8 @@ impl Application for App {
             Message::ToggleShowDetails => {
                 let show_details = !self.config.show_details;
                 //TODO: move to update_config?
-                if show_details {
-                    self.context_page = ContextPage::Preview(None, PreviewKind::Selected);
-                    self.core.window.show_context = true;
-                }
+                self.context_page = ContextPage::Preview(None, PreviewKind::Selected);
+                self.core.window.show_context = show_details;
                 config_set!(show_details, show_details);
                 return self.update_config();
             }


### PR DESCRIPTION
### Overview

This pull request addresses an issue where a toggle in the UI always sent a true value to the component, regardless of the actual toggle state. The fix ensures that the correct value is now passed to the component, reflecting the real state of the toggle.

### Related issues
 - fixes #545 