### PR TITLE
fix(gallery): trigger gallery view only on images

### DIFF
--- a/src/tab.rs
+++ b/src/tab.rs
@@ -2066,7 +2066,14 @@ impl Tab {
                 }
             }
             Message::GalleryToggle => {
-                self.gallery = !self.gallery;
+                if let Some(indices) = self.column_sort() {
+                    for (_, item) in indices.iter() {
+                        if item.selected && item.mime.type_() == mime::IMAGE {
+                            self.gallery = !self.gallery;
+                            break;
+                        }
+                    }
+                }
             }
             Message::GoNext => {
                 if let Some(history_i) = self.history_i.checked_add(1) {


### PR DESCRIPTION
### Overview
This pull request modifies the gallery view toggle logic to ensure that it is triggered only when the current selection is an image. The previous implementation toggled the gallery view based on any selected item, which could include non-image files.

### Related Issues
- fixes #543 