### PR TITLE
fix(sidebar): prevent duplicate entries of the same item

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -1352,7 +1352,10 @@ impl Application for App {
             Message::AddToSidebar(entity_opt) => {
                 let mut favorites = self.config.favorites.clone();
                 for path in self.selected_paths(entity_opt) {
-                    favorites.push(Favorite::from_path(path));
+                    let favorite = Favorite::from_path(path);
+                    if !favorites.iter().any(|f| f == &favorite) {
+                        favorites.push(favorite);
+                    }
                 }
                 config_set!(favorites, favorites);
                 return self.update_config();


### PR DESCRIPTION
### Overview
This pull request addresses a bug in the sidebar functionality of Cosmic Files, where users were able to pin the same file or directory multiple times, resulting in duplicate entries.

### Related Issues
- fixes #556 