### PR TITLE
Update location edit selection behavior

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -153,7 +153,7 @@ impl Action {
             Action::DesktopViewOptions => Message::DesktopViewOptions,
             Action::EditHistory => Message::ToggleContextPage(ContextPage::EditHistory),
             Action::EditLocation => {
-                Message::TabMessage(entity_opt, tab::Message::EditLocationToggle)
+                Message::TabMessage(entity_opt, tab::Message::EditLocationEnable)
             }
             Action::ExtractHere => Message::ExtractHere(entity_opt),
             Action::Gallery => Message::TabMessage(entity_opt, tab::Message::GalleryToggle),
@@ -1472,6 +1472,11 @@ impl Application for App {
         if let Some(tab) = self.tab_model.data_mut::<Tab>(entity) {
             if tab.context_menu.is_some() {
                 tab.context_menu = None;
+                return Command::none();
+            }
+
+            if tab.edit_location.is_some() {
+                tab.edit_location = None;
                 return Command::none();
             }
 
@@ -2936,6 +2941,12 @@ impl Application for App {
 
             // Tracks which nav bar item to show a context menu for.
             Message::NavBarContext(entity) => {
+                // Close location editing if enabled
+                let tab_entity = self.tab_model.active();
+                if let Some(tab) = self.tab_model.data_mut::<Tab>(tab_entity) {
+                    tab.edit_location = None;
+                }
+
                 self.nav_bar_context_id = entity;
             }
 

--- a/src/dialog.rs
+++ b/src/dialog.rs
@@ -1035,6 +1035,12 @@ impl Application for App {
             return Command::none();
         }
 
+        if self.tab.edit_location.is_some() {
+            // Close location editing if enabled
+            self.tab.edit_location = None;
+            return Command::none();
+        }
+
         let had_focused_button = self.tab.select_focus_id().is_some();
         if self.tab.select_none() {
             if had_focused_button {

--- a/src/tab.rs
+++ b/src/tab.rs
@@ -972,7 +972,7 @@ pub enum Message {
     LocationMenuAction(LocationMenuAction),
     Drag(Option<Rectangle>),
     EditLocation(Option<Location>),
-    EditLocationToggle,
+    EditLocationEnable,
     OpenInNewTab(PathBuf),
     EmptyTrash,
     Gallery(bool),
@@ -2016,6 +2016,7 @@ impl Tab {
             Message::Click(click_i_opt) => {
                 self.selected_clicked = false;
                 self.context_menu = None;
+                self.edit_location = None;
                 self.location_context_menu_index = None;
                 if click_i_opt.is_none() {
                     self.clicked = click_i_opt;
@@ -2150,6 +2151,7 @@ impl Tab {
                 commands.push(Command::Action(action));
             }
             Message::ContextMenu(point_opt) => {
+                self.edit_location = None;
                 if point_opt.is_none() || !mod_shift {
                     self.context_menu = point_opt;
                     //TODO: hack for clearing selecting when right clicking empty space
@@ -2234,12 +2236,11 @@ impl Tab {
                 }
                 self.edit_location = edit_location;
             }
-            Message::EditLocationToggle => {
-                if self.edit_location.is_none() {
-                    self.edit_location = Some(self.location.clone());
-                } else {
-                    self.edit_location = None;
-                }
+            Message::EditLocationEnable => {
+                commands.push(Command::Iced(widget::text_input::focus(
+                    self.edit_location_id.clone(),
+                )));
+                self.edit_location = Some(self.location.clone());
             }
             Message::OpenInNewTab(path) => {
                 commands.push(Command::OpenInNewTab(path));


### PR DESCRIPTION
This updates the keyboard behavior around editing the location to act more like other programs like Nautilus and Firefox. 
When you hit ctrl+l, it immediately allows you to type in the location box. You can de-select the location box by hitting escape or clicking in the tab window.