### PR TITLE
fix: Trash icons should show the trash menu

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -96,6 +96,7 @@ pub enum Action {
     DesktopViewOptions,
     EditHistory,
     EditLocation,
+    EmptyTrash,
     ExtractHere,
     Gallery,
     HistoryNext,
@@ -155,6 +156,7 @@ impl Action {
             Action::EditLocation => {
                 Message::TabMessage(entity_opt, tab::Message::EditLocationEnable)
             }
+            Action::EmptyTrash => Message::TabMessage(None, tab::Message::EmptyTrash),
             Action::ExtractHere => Message::ExtractHere(entity_opt),
             Action::Gallery => Message::TabMessage(entity_opt, tab::Message::GalleryToggle),
             Action::HistoryNext => Message::TabMessage(entity_opt, tab::Message::GoNext),


### PR DESCRIPTION
Closes: #593

Trash bins currently show an incorrect menu with invalid actions such as opening the bin in a terminal. The menu also doesn't have an entry for emptying the trash.