### PR TITLE
[Context Menu] Use radius from theme

### DIFF
--- a/src/menu.rs
+++ b/src/menu.rs
@@ -295,14 +295,14 @@ pub fn context_menu<'a>(
                 text_color: Some(component.on.into()),
                 background: Some(Background::Color(component.base.into())),
                 border: Border {
-                    radius: 8.0.into(),
+                    radius: cosmic.radius_s().into(),
                     width: 1.0,
                     color: component.divider.into(),
                 },
                 ..Default::default()
             }
         })
-        .width(Length::Fixed(260.0))
+        .width(Length::Fixed(280.0))
         .into()
 }
 
@@ -645,7 +645,7 @@ pub fn location_context_menu<'a>(ancestor_index: usize) -> Element<'a, tab::Mess
                 text_color: Some(component.on.into()),
                 background: Some(Background::Color(component.base.into())),
                 border: Border {
-                    radius: 8.0.into(),
+                    radius: cosmic.radius_s().into(),
                     width: 1.0,
                     color: component.divider.into(),
                 },

--- a/src/tab.rs
+++ b/src/tab.rs
@@ -3020,10 +3020,7 @@ impl Tab {
                                         //TODO: use widget::image::viewer, when its zoom can be reset
                                         widget::image(widget::image::Handle::from_path(path)),
                                     )
-                                    .align_x(Alignment::Center)
-                                    .align_y(Alignment::Center)
-                                    .width(Length::Fill)
-                                    .height(Length::Fill)
+                                    .center(Length::Fill)
                                     .into(),
                                 );
                             } else {
@@ -3032,10 +3029,7 @@ impl Tab {
                                         //TODO: use widget::image::viewer, when its zoom can be reset
                                         widget::image(handle.clone()),
                                     )
-                                    .align_x(Alignment::Center)
-                                    .align_y(Alignment::Center)
-                                    .width(Length::Fill)
-                                    .height(Length::Fill)
+                                    .center(Length::Fill)
                                     .into(),
                                 );
                             }


### PR DESCRIPTION
Fixes #517.

Increased the width of the context menu slightly, to better fit the "Open in new window" item.
<sub>Wasn't able to figure out how to center thumbnails. :(</sub>