### PR TITLE
Set style and padding for text editor

### DIFF
--- a/src/tab.rs
+++ b/src/tab.rs
@@ -1313,6 +1313,7 @@ impl Item {
     }
 
     fn preview<'a>(&'a self, sizes: IconSizes) -> Element<'a, app::Message> {
+        let spacing = cosmic::theme::active().cosmic().spacing;
         // This loads the image only if thumbnailing worked
         let icon = widget::icon::icon(self.icon_handle_grid.clone())
             .content_fit(ContentFit::Contain)
@@ -1333,10 +1334,16 @@ impl Item {
                 widget::image(handle.clone()).into()
             }
             ItemThumbnail::Svg(handle) => widget::svg(handle.clone()).into(),
-            ItemThumbnail::Text(content) => widget::container(widget::text_editor(content))
-                .width(Length::Fixed(THUMBNAIL_SIZE as f32))
-                .height(Length::Fixed(THUMBNAIL_SIZE as f32))
-                .into(),
+            ItemThumbnail::Text(content) => widget::container(
+                widget::text_editor(content)
+                    .class(cosmic::theme::iced::TextEditor::Custom(Box::new(
+                        text_editor_class,
+                    )))
+                    .padding(spacing.space_xxs),
+            )
+            .width(Length::Fixed(THUMBNAIL_SIZE as f32))
+            .height(Length::Fixed(THUMBNAIL_SIZE as f32))
+            .into(),
         }
     }
 
@@ -3101,7 +3108,14 @@ impl Tab {
                             );
                         }
                         ItemThumbnail::Text(text) => {
-                            element_opt = Some(widget::text_editor(text).into())
+                            element_opt = Some(
+                                widget::text_editor(text)
+                                    .padding(space_xxs)
+                                    .class(cosmic::theme::iced::TextEditor::Custom(Box::new(
+                                        text_editor_class,
+                                    )))
+                                    .into(),
+                            )
                         }
                     }
                 }
@@ -4988,5 +5002,55 @@ impl<M> Widget<M, cosmic::Theme, cosmic::Renderer> for ArcElementWrapper<M> {
 impl<Message: 'static> From<ArcElementWrapper<Message>> for Element<'static, Message> {
     fn from(wrapper: ArcElementWrapper<Message>) -> Self {
         Element::new(wrapper)
+    }
+}
+
+fn text_editor_class(
+    theme: &cosmic::Theme,
+    status: cosmic::widget::text_editor::Status,
+) -> cosmic::iced_widget::text_editor::Style {
+    let cosmic = theme.cosmic();
+    let container = theme.current_container();
+
+    let mut background: cosmic::iced::Color = container.component.base.into();
+    background.a = 0.25;
+    let selection = cosmic.accent.base.into();
+    let value = cosmic.palette.neutral_9.into();
+    let mut placeholder = cosmic.palette.neutral_9;
+    placeholder.alpha = 0.7;
+    let placeholder = placeholder.into();
+    let icon = cosmic.background.on.into();
+
+    match status {
+        cosmic::iced_widget::text_editor::Status::Active
+        | cosmic::iced_widget::text_editor::Status::Disabled => {
+            cosmic::iced_widget::text_editor::Style {
+                background: background.into(),
+                border: cosmic::iced::Border {
+                    radius: cosmic.corner_radii.radius_m.into(),
+                    width: 2.0,
+                    color: container.component.divider.into(),
+                },
+                icon,
+                placeholder,
+                value,
+                selection,
+            }
+        }
+        cosmic::iced_widget::text_editor::Status::Hovered
+        | cosmic::iced_widget::text_editor::Status::Focused => {
+            cosmic::iced_widget::text_editor::Style {
+                background: background.into(),
+                border: cosmic::iced::Border {
+                    radius: cosmic.corner_radii.radius_m.into(),
+                    width: 2.0,
+                    color: cosmic::iced::Color::from(cosmic.accent.base),
+                },
+                icon,
+                placeholder,
+                value,
+                selection,
+            }
+        }
     }
 }


### PR DESCRIPTION
This PR updates the style and adds padding to the text editor to match the style in text inputs, text editor is currently using the default iced class.

![image](https://github.com/user-attachments/assets/5558856c-36be-4d85-8184-d0b6d5d37c5f)
