### PR TITLE
fix(redox): Add "process" feature to tokio

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ regex = "1"
 serde = { version = "1", features = ["serde_derive"] }
 shlex = { version = "1.3" }
 tempfile = "3"
-tokio = { version = "1", features = ["sync"] }
+tokio = { version = "1", features = ["process", "sync"] }
 trash = { git = "https://github.com/jackpot51/trash-rs.git", branch = "cosmic" }
 url = "2.5"
 walkdir = "2.5.0"


### PR DESCRIPTION
I'm going to be totally honest. I have no clue why this is compiling on Arch and Pop! _without_ the `process` feature on Tokio. However, it's failing on Redox as of today because my last patch uses [tokio::process](https://docs.rs/tokio/latest/tokio/process/) which is feature gated.

Anyway, adding process fixes building on Redox. :man_shrugging: 