### PR TITLE
feat: Navigate by typing file/directory names

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -1945,6 +1945,13 @@ impl Application for App {
                         return self.update(action.message(Some(entity)));
                     }
                 }
+                if let Key::Character(char) = key {
+                    return self.update(Message::TabMessage(
+                        Some(entity),
+                        // TODO need to store keys and send them all
+                        tab::Message::SelectNextPrefix(char),
+                    ));
+                }
             }
             Message::MaybeExit => {
                 if self.window_id_opt.is_none() && self.pending_operations.is_empty() {

--- a/src/tab.rs
+++ b/src/tab.rs
@@ -1859,6 +1859,16 @@ impl Tab {
     }
 
     pub fn select_next_prefix(&mut self, prefix: &str) -> bool {
+        // Special case: when all entered characters are the same, only search for said character. This allows quickly cycling through items starting with the same character.
+        let term = match prefix.chars().next() {
+            Some(first) => if prefix.chars().all(|c| c == first) {
+                &prefix[..1]
+            } else {
+                prefix
+            },
+            None => return false,
+        };
+
         *self.cached_selected.borrow_mut() = None;
         let mut found = false;
         if let Some(ref mut items) = self.items_opt {
@@ -1873,7 +1883,7 @@ impl Tab {
             {
                 if !found
                     && (!item.hidden || self.config.show_hidden)
-                    && item.name.to_lowercase().starts_with(prefix)
+                    && item.name.to_lowercase().starts_with(term)
                 {
                     item.selected = true;
                     self.select_focus = Some(i);


### PR DESCRIPTION
This PR adds the ability to jump to a file or directory by typing the first letters of its display name. Navigation will jump to the next matching item based on the current selection. The same character can also be typed in quick succession to cycle through all items beginning with the same character.
The typed word is reset when no letter has been typed for longer than defined in `PrefixSearch::reset_delay`. Currently this value is hard coded to 500ms, but could be easily made configurable. I did not do so yet, since this involves adding another PR for the settings and I wanted to get feedback for this one first.