### PR TITLE
Fix 'Show hidden files' toggle being reset when tab config is updated

### DIFF
--- a/src/tab.rs
+++ b/src/tab.rs
@@ -2258,8 +2258,10 @@ impl Tab {
             Message::Config(config) => {
                 // View is preserved for existing tabs
                 let view = self.config.view;
+                let show_hidden = self.config.show_hidden;
                 self.config = config;
                 self.config.view = view;
+                self.config.show_hidden = show_hidden;
             }
             Message::ContextAction(action) => {
                 // Close context menu


### PR DESCRIPTION
Fixes #635 

Should the show_hidden value also be saved to the app config, or is it okay for the value to be reset when starting the application?