### PR TITLE
Fix crash for dialog in debug mode

### DIFF
--- a/src/dialog.rs
+++ b/src/dialog.rs
@@ -251,7 +251,8 @@ impl<M: Send + 'static> Dialog<M> {
         self.cosmic
             .subscription()
             .map(DialogMessage)
-            .map(self.mapper)
+            .with(self.mapper)
+            .map(|(mapper, message)| mapper(message))
     }
 
     pub fn update(&mut self, message: DialogMessage) -> Task<M> {
@@ -1709,16 +1710,17 @@ impl Application for App {
         ];
 
         for (key, mounter) in MOUNTERS.iter() {
-            let key = *key;
-            subscriptions.push(mounter.subscription().map(move |mounter_message| {
-                match mounter_message {
-                    MounterMessage::Items(items) => Message::MounterItems(key, items),
-                    _ => {
-                        log::warn!("{:?} not supported in dialog mode", mounter_message);
-                        Message::None
-                    }
-                }
-            }));
+            subscriptions.push(
+                mounter.subscription().with(*key).map(
+                    |(key, mounter_message)| match mounter_message {
+                        MounterMessage::Items(items) => Message::MounterItems(key, items),
+                        _ => {
+                            log::warn!("{:?} not supported in dialog mode", mounter_message);
+                            Message::None
+                        }
+                    },
+                ),
+            );
         }
 
         Subscription::batch(subscriptions)


### PR DESCRIPTION
`Subscription::map` must be provided a non-capturing closure. A couple places were passing capturing closures, which caused a debug assert failure. These have been fixed.

Closes #723