### PR TITLE
Context menu fixes

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -352,6 +352,7 @@ pub enum Message {
     WindowClose,
     WindowCloseRequested(window::Id),
     WindowNew,
+    WindowUnfocus,
     ZoomDefault(Option<Entity>),
     ZoomIn(Option<Entity>),
     ZoomOut(Option<Entity>),
@@ -899,7 +900,7 @@ impl App {
         self.search_set(entity, term_opt)
     }
 
-    fn search_set(&mut self,tab: Entity, term_opt: Option<String>) -> Task<Message> {
+    fn search_set(&mut self, tab: Entity, term_opt: Option<String>) -> Task<Message> {
         let mut title_location_opt = None;
         if let Some(tab) = self.tab_model.data_mut::<Tab>(tab) {
             let location_opt = match term_opt {
@@ -3024,6 +3025,12 @@ impl Application for App {
                     ]);
                 }
             }
+            Message::WindowUnfocus => {
+                let tab_entity = self.tab_model.active();
+                if let Some(tab) = self.tab_model.data_mut::<Tab>(tab_entity) {
+                    tab.context_menu = None;
+                }
+            }
             Message::WindowCloseRequested(id) => {
                 self.remove_window(&id);
             }
@@ -4369,6 +4376,7 @@ impl Application for App {
                 Event::Keyboard(KeyEvent::ModifiersChanged(modifiers)) => {
                     Some(Message::Modifiers(modifiers))
                 }
+                Event::Window(WindowEvent::Unfocused) => Some(Message::WindowUnfocus),
                 Event::Window(WindowEvent::CloseRequested) => Some(Message::WindowClose),
                 Event::Window(WindowEvent::Opened { position: _, size }) => {
                     Some(Message::Size(size))

--- a/src/tab.rs
+++ b/src/tab.rs
@@ -3581,8 +3581,7 @@ impl Tab {
     pub fn empty_view(&self, has_hidden: bool) -> Element<Message> {
         let cosmic_theme::Spacing { space_xxs, .. } = theme::active().cosmic().spacing;
 
-        //TODO: left clicking on an empty folder does not clear context menu
-        widget::column::with_children(vec![widget::container(
+        mouse_area::MouseArea::new(widget::column::with_children(vec![widget::container(
             widget::column::with_children(match self.mode {
                 Mode::App | Mode::Dialog(_) => vec![
                     widget::icon::from_name("folder-symbolic")
@@ -3604,7 +3603,8 @@ impl Tab {
             .spacing(space_xxs),
         )
         .center(Length::Fill)
-        .into()])
+        .into()]))
+        .on_press(|_| Message::Click(None))
         .into()
     }
 


### PR DESCRIPTION
Adds the following behaviors:
-  Clicking in an empty folder clears the context menu. This also works for desktop mode when there are no icons.
- Clicking out of the COSMIC Files window clears the context menu. I was hoping this would also work for desktop mode so that clicking into an application window would clear the desktop context menu, but it doesn't look like it gets a window unfocused event.

Closes #493