### PR TITLE
Fix resetting shift select range

### DIFF
--- a/src/tab.rs
+++ b/src/tab.rs
@@ -2245,8 +2245,8 @@ impl Tab {
                                 if !item.selected {
                                     self.clicked = click_i_opt;
                                     item.selected = true;
-                                    self.select_range = Some((i, i));
                                 }
+                                self.select_range = Some((i, i));
                                 self.select_focus = click_i_opt;
                                 self.selected_clicked = true;
                             } else if !dont_unset && item.selected {


### PR DESCRIPTION
Before this fix the following steps would not work correctly:

1. Select a range with shift click.
2. Select a single item that's in the currently selected range, without holding shift.
3. Hold shift and click another item to select a new range.

Instead of the item selected in step 2 being the start or end of the range, the original range from step one is used to get the start or end of the new range.

This fix makes sure the range gets reset when selecting an item in step 2.