### PR TITLE
chore(clippy): mime_app, operation, mounter

### DIFF
--- a/src/mime_app.rs
+++ b/src/mime_app.rs
@@ -120,7 +120,7 @@ impl MimeAppCache {
                     .cache
                     .entry(mime.clone())
                     .or_insert_with(|| Vec::with_capacity(1));
-                if apps.iter().find(|x| x.id == app.id).is_none() {
+                if !apps.iter().any(|x| x.id == app.id) {
                     apps.push(MimeApp::from(app));
                 }
             }
@@ -191,11 +191,7 @@ impl MimeAppCache {
                                 .cache
                                 .entry(mime.clone())
                                 .or_insert_with(|| Vec::with_capacity(1));
-                            if apps
-                                .iter()
-                                .find(|x| filename_eq(&x.path, filename))
-                                .is_none()
-                            {
+                            if !apps.iter().any(|x| filename_eq(&x.path, filename)) {
                                 if let Some(app) =
                                     all_apps.iter().find(|x| filename_eq(&x.path, filename))
                                 {
@@ -263,9 +259,7 @@ impl MimeAppCache {
     }
 
     pub fn get(&self, key: &Mime) -> Vec<MimeApp> {
-        self.cache
-            .get(&key)
-            .map_or_else(|| Vec::new(), |x| x.clone())
+        self.cache.get(key).map_or_else(Vec::new, |x| x.clone())
     }
 }
 
@@ -292,5 +286,5 @@ pub fn terminal() -> Option<MimeApp> {
     }
 
     // Return whatever was the first terminal found
-    mime_app_cache.terminals.first().map(|x| x.clone())
+    mime_app_cache.terminals.first().cloned()
 }

--- a/src/mounter/gvfs.rs
+++ b/src/mounter/gvfs.rs
@@ -97,7 +97,7 @@ fn network_scan(uri: &str, sizes: IconSizes) -> Result<Vec<tab::Item>, String> {
                 info.icon()
                     .as_ref()
                     .and_then(|icon| gio_icon_to_path(icon, size))
-                    .map(|path| widget::icon::from_path(path))
+                    .map(widget::icon::from_path)
                     .unwrap_or(
                         widget::icon::from_name(if metadata.is_dir() {
                             "folder"
@@ -388,10 +388,7 @@ impl Gvfs {
                             let file = gio::File::for_uri(&uri);
                             let needs_mount = match file.find_enclosing_mount(gio::Cancellable::NONE) {
                                 Ok(_) => false,
-                                Err(err) => match err.kind::<gio::IOErrorEnum>() {
-                                    Some(gio::IOErrorEnum::NotMounted) => true,
-                                    _ => false
-                                }
+                                Err(err) => matches!(err.kind::<gio::IOErrorEnum>(), Some(gio::IOErrorEnum::NotMounted))
                             };
                             if needs_mount {
                                 let mount_op = mount_op(uri.clone(), event_tx.clone());
@@ -468,7 +465,6 @@ impl Mounter for Gvfs {
         Task::perform(
             async move {
                 command_tx.send(Cmd::Mount(item)).unwrap();
-                ()
             },
             |x| x,
         )
@@ -479,7 +475,6 @@ impl Mounter for Gvfs {
         Task::perform(
             async move {
                 command_tx.send(Cmd::NetworkDrive(uri)).unwrap();
-                ()
             },
             |x| x,
         )
@@ -498,7 +493,6 @@ impl Mounter for Gvfs {
         Task::perform(
             async move {
                 command_tx.send(Cmd::Unmount(item)).unwrap();
-                ()
             },
             |x| x,
         )

--- a/src/mouse_area.rs
+++ b/src/mouse_area.rs
@@ -296,7 +296,7 @@ impl<'a, Message> MouseArea<'a, Message> {
     }
 }
 
-impl<'a, Message> Widget<Message, Theme, Renderer> for MouseArea<'a, Message>
+impl<Message> Widget<Message, Theme, Renderer> for MouseArea<'_, Message>
 where
     Message: Clone,
 {
@@ -671,7 +671,7 @@ fn update<Message: Clone>(
 
     if let Some(on_scroll) = widget.on_scroll.as_ref() {
         if let Event::Mouse(mouse::Event::WheelScrolled { delta }) = event {
-            if let Some(message) = on_scroll(delta.clone(), state.modifiers) {
+            if let Some(message) = on_scroll(*delta, state.modifiers) {
                 shell.publish(message);
                 return event::Status::Captured;
             }

--- a/src/operation/mod.rs
+++ b/src/operation/mod.rs
@@ -993,7 +993,7 @@ mod tests {
                 paths: paths_clone,
                 to: to_clone,
             }
-            .perform(&sync::Mutex::new(tx).into(), Controller::new())
+            .perform(&sync::Mutex::new(tx).into(), Controller::default())
             .await
         });
 


### PR DESCRIPTION
Fixes Clippy lints for:
* src/mounter/
* src/operation/
* src/mime_app.rs
* src/mouse_area.rs (I missed two of them last time)