### PR TITLE
adding in support to extract/compress zip files with passwords

### DIFF
--- a/i18n/en/cosmic_files.ftl
+++ b/i18n/en/cosmic_files.ftl
@@ -39,6 +39,9 @@ resume = Resume
 ## Compress Dialog
 create-archive = Create archive
 
+## Extract Dialog
+extract-password-required = Password required
+
 ## Empty Trash Dialog
 empty-trash = Empty trash
 empty-trash-warning = Are you sure you want to permanently delete all the items in Trash?

--- a/src/app.rs
+++ b/src/app.rs
@@ -71,6 +71,7 @@ use crate::{
     spawn_detached::spawn_detached,
     tab::{self, HeadingOptions, ItemMetadata, Location, Tab, HOVER_DURATION},
 };
+use crate::operation::{OperationError, OperationErrorType};
 
 #[derive(Clone, Debug)]
 pub enum Mode {
@@ -319,7 +320,7 @@ pub enum Message {
     PendingCancelAll,
     PendingComplete(u64, OperationSelection),
     PendingDismiss,
-    PendingError(u64, String),
+    PendingError(u64, OperationError),
     PendingPause(u64, bool),
     PendingPauseAll(bool),
     Preview(Option<Entity>),
@@ -417,9 +418,14 @@ pub enum DialogPage {
         to: PathBuf,
         name: String,
         archive_type: ArchiveType,
+        password: Option<String>
     },
     EmptyTrash,
     FailedOperation(u64),
+    ExtractPassword {
+        id: u64,
+        password: String
+    },
     MountError {
         mounter_key: MounterKey,
         item: MounterItem,
@@ -1869,6 +1875,7 @@ impl Application for App {
                             to,
                             name,
                             archive_type,
+                            password: None
                         });
                         return widget::text_input::focus(self.dialog_text_input.clone());
                     }
@@ -1944,6 +1951,7 @@ impl Application for App {
                             to,
                             name,
                             archive_type,
+                            password
                         } => {
                             let extension = archive_type.extension();
                             let name = format!("{}{}", name, extension);
@@ -1952,6 +1960,7 @@ impl Application for App {
                                 paths,
                                 to,
                                 archive_type,
+                                password
                             })
                         }
                         DialogPage::EmptyTrash => {
@@ -1959,6 +1968,21 @@ impl Application for App {
                         }
                         DialogPage::FailedOperation(id) => {
                             log::warn!("TODO: retry operation {}", id);
+                        }
+                        DialogPage::ExtractPassword {
+                            id,
+                            password
+                        } => {
+                            let (operation, _, _err) = self.failed_operations.get(&id).unwrap();
+                            let new_op = match &operation {
+                                Operation::Extract { to, paths, .. } => Operation::Extract {
+                                    to: to.clone(),
+                                    paths: paths.clone(),
+                                    password: Some(password)
+                                },
+                                _ => unreachable!()
+                            };
+                            self.operation(new_op);
                         }
                         DialogPage::MountError {
                             mounter_key,
@@ -2076,6 +2100,7 @@ impl Application for App {
                     self.operation(Operation::Extract {
                         paths,
                         to: destination,
+                        password: None
                     });
                 }
             }
@@ -2566,11 +2591,19 @@ impl Application for App {
                 if let Some((op, controller)) = self.pending_operations.remove(&id) {
                     // Only show dialog if not cancelled
                     if !controller.is_cancelled() {
-                        self.dialog_pages.push_back(DialogPage::FailedOperation(id));
+                        self.dialog_pages.push_back(
+                            match err.kind {
+                                OperationErrorType::Generic(_) => DialogPage::FailedOperation(id),
+                                OperationErrorType::PasswordRequired => DialogPage::ExtractPassword {
+                                    id: id,
+                                    password: String::from("")
+                                }
+                            }
+                        );
                     }
                     // Remove from progress
                     self.progress_operations.remove(&id);
-                    self.failed_operations.insert(id, (op, controller, err));
+                    self.failed_operations.insert(id, (op, controller, err.to_string()));
                 }
                 // Close progress notification if all relavent operations are finished
                 if !self
@@ -3564,6 +3597,7 @@ impl Application for App {
                 to,
                 name,
                 archive_type,
+                password
             } => {
                 let mut dialog = widget::dialog().title(fl!("create-archive"));
 
@@ -3596,7 +3630,7 @@ impl Application for App {
 
                 let archive_types = ArchiveType::all();
                 let selected = archive_types.iter().position(|&x| x == *archive_type);
-                dialog
+                dialog = dialog
                     .primary_action(
                         widget::button::suggested(fl!("create"))
                             .on_press_maybe(complete_maybe.clone()),
@@ -3616,9 +3650,10 @@ impl Application for App {
                                             to: to.clone(),
                                             name: name.clone(),
                                             archive_type: *archive_type,
+                                            password: password.clone(),
                                         })
                                     })
-                                    .on_submit_maybe(complete_maybe)
+                                    .on_submit_maybe(complete_maybe.clone())
                                     .into(),
                                 widget::dropdown(archive_types, selected, move |index| {
                                     Message::DialogUpdate(DialogPage::Compress {
@@ -3626,6 +3661,7 @@ impl Application for App {
                                         to: to.clone(),
                                         name: name.clone(),
                                         archive_type: archive_types[index],
+                                        password: password.clone(),
                                     })
                                 })
                                 .into(),
@@ -3635,7 +3671,29 @@ impl Application for App {
                             .into(),
                         ])
                         .spacing(space_xxs),
-                    )
+                    );
+
+                if *archive_type == ArchiveType::Zip {
+                    let password_unwrapped = password.clone().unwrap_or_else(String::default);
+                    dialog = dialog.control(
+                        widget::column::with_children(vec![
+                            widget::text::body("Password").into(),
+                            widget::text_input("", password_unwrapped).password().on_input(move |password_unwrapped| {
+                                Message::DialogUpdate(DialogPage::Compress {
+                                    paths: paths.clone(),
+                                    to: to.clone(),
+                                    name: name.clone(),
+                                    archive_type: *archive_type,
+                                    password: Some(password_unwrapped),
+                                })
+                            })
+                                .on_submit_maybe(complete_maybe)
+                                .into(),
+                        ])
+                    );
+                }
+
+                dialog
             }
             DialogPage::EmptyTrash => widget::dialog()
                 .title(fl!("empty-trash"))
@@ -3658,6 +3716,23 @@ impl Application for App {
                     //TODO: retry action
                     .primary_action(
                         widget::button::standard(fl!("cancel")).on_press(Message::DialogCancel),
+                    )
+            }
+            DialogPage::ExtractPassword {
+                id,
+                password
+            } => {
+                widget::dialog()
+                    .title("Password required")
+                    .icon(widget::icon::from_name("dialog-error").size(64))
+                    .control(widget::text_input("", password).password().on_input(move |password| {
+                        Message::DialogUpdate(DialogPage::ExtractPassword {
+                            id: *id,
+                            password
+                        })
+                    }))
+                    .primary_action(
+                        widget::button::suggested(fl!("create")).on_press(Message::DialogComplete),
                     )
             }
             DialogPage::MountError {
@@ -4661,8 +4736,9 @@ impl Application for App {
                             let _ = msg_tx
                                 .lock()
                                 .await
-                                .send(Message::PendingError(id, err.to_string()))
+                                .send(Message::PendingError(id, err))
                                 .await;
+
                         }
                     }
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -3677,7 +3677,7 @@ impl Application for App {
                     let password_unwrapped = password.clone().unwrap_or_else(String::default);
                     dialog = dialog.control(
                         widget::column::with_children(vec![
-                            widget::text::body("Password").into(),
+                            widget::text::body(fl!("password")).into(),
                             widget::text_input("", password_unwrapped).password().on_input(move |password_unwrapped| {
                                 Message::DialogUpdate(DialogPage::Compress {
                                     paths: paths.clone(),
@@ -3723,7 +3723,7 @@ impl Application for App {
                 password
             } => {
                 widget::dialog()
-                    .title("Password required")
+                    .title(fl!("extract-password-required"))
                     .icon(widget::icon::from_name("dialog-error").size(64))
                     .control(widget::text_input("", password).password().on_input(move |password| {
                         Message::DialogUpdate(DialogPage::ExtractPassword {
@@ -3732,7 +3732,7 @@ impl Application for App {
                         })
                     }))
                     .primary_action(
-                        widget::button::suggested(fl!("create")).on_press(Message::DialogComplete),
+                        widget::button::suggested(fl!("extract-here")).on_press(Message::DialogComplete),
                     )
             }
             DialogPage::MountError {

--- a/src/app.rs
+++ b/src/app.rs
@@ -3734,6 +3734,9 @@ impl Application for App {
                     .primary_action(
                         widget::button::suggested(fl!("extract-here")).on_press(Message::DialogComplete),
                     )
+                    .secondary_action(
+                        widget::button::standard(fl!("cancel")).on_press(Message::DialogCancel),
+                    )
             }
             DialogPage::MountError {
                 mounter_key: _,


### PR DESCRIPTION
apologies in advance if this is bad/jumping the gun/etc, i'm working for a client who _loves_ sending password protected zips atm, so this was a frequent pain point for me

**changes tl;dr:**
- refactor `operation::Operation::perform` to return `Result<OperationSelection, OperationError>` to bubble up specific errors
- 99% of existing errors bubble up as a `OperationErrorType::Generic(String)`, and implements the `std::fmt::Display` trait, so should be compatible across the board
- optionally ask for password when extracting a zip provides an invalid password error
- optionally ask for password when compressing a zipfile

--

 **when extracting:**
- first try to extract normally, however if an `OperationError` with `kind = OperationErrorType::PasswordRequired` is captured, open a new dialog prompting for password
- completing the new dialog tries to extract with the typed password
- if typed password incorrect, prompt again

**NB:** when a zip file has no password protection, functionality remains the same

--

**when compressing:**
- when zip is selected (by default) show a new password field
- when password is set, compress zip in `Aes256` mode with password prompted

**NB:** when no password is set, functionality remains the same