### PR TITLE
Enhance terminal handling and MIME app detection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1289,6 +1289,7 @@ dependencies = [
  "liblzma",
  "log",
  "mime_guess",
+ "notify",
  "notify-debouncer-full",
  "notify-rust",
  "once_cell",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ vergen = { version = "8", features = ["git", "gitcl"] }
 chrono = { version = "0.4", features = ["unstable-locales"] }
 cosmic-mime-apps = { git = "https://github.com/pop-os/cosmic-mime-apps.git", optional = true }
 dirs = "5.0.1"
+notify = "6.1"
 env_logger = "0.11"
 freedesktop_entry_parser = "1.3"
 gio = { version = "0.20", optional = true }


### PR DESCRIPTION
- Add notify dependency for file watching
- Improve terminal detection and default selection
- Add support for working directory in terminal launch
- Implement file watcher for MIME association changes
- Add terminal detection method with feature flag support

It is important to mention that:

I will still send the PR regarding this in the cosmic-files repository
the functionality is not 100% complete, in developer mode, when we open cosmic-settings and cosmic-files and I change the terminal and try to click on open terminal in cosmic-files, cosmic files will open the terminal that was already selected, so if I am in cosmic-terminal when I open it and switch to warp and click on open in terminal it will open the old terminal and not warp (which was selected) so we still need to implement some function for cosmic-files to get the changes in real time from the cosmic-settings terminal change
but if you close cosmic files and hit cargo run again, it opens the correct terminal (which would be warp).

continuation and correction of the PR [#935](https://github.com/pop-os/cosmic-settings/pull/935) and integrated with [#936](https://github.com/pop-os/cosmic-settings/pull/936)

Both commits have to be approved for both changes to work.

Also, it's not 100% finished yet
as I said, only when we close cosmic files and open it again (in the dev environment), it sees that the terminal has changed and then it works, it's not working as it should (which is in real time)
so I believe we still have to add a feature to cosmic-files specifically to listen for changes in this function we use to change the terminal
I still don't have any idea how to do this
if anyone has, the idea would be appreciated ;)