### PR TITLE
fix: set M_MMAP_THRESHOLD to lower memory usage significantly

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -6,5 +6,11 @@ use tikv_jemallocator::Jemalloc;
 static GLOBAL: Jemalloc = Jemalloc;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Prevents glibc from hoarding memory via memory fragmentation.
+    #[cfg(all(not(feature = "jemalloc"), target_env = "gnu"))]
+    unsafe {
+        libc::mallopt(libc::M_MMAP_THRESHOLD, 65536);
+    }
+
     cosmic_files::main()
 }


### PR DESCRIPTION
Similar to https://github.com/pop-os/cosmic-bg

Reduced memory usage on my system from 300+ MB to 40 MB after navigating through a couple directories with images. Allows most memory to be reclaimed when navigating between directories.