### PR TITLE
Fixing denial of service where a tab tries to read lines from a .hidden directory

### DIFF
--- a/src/tab.rs
+++ b/src/tab.rs
@@ -545,7 +545,7 @@ pub fn scan_path(tab_path: &PathBuf, sizes: IconSizes) -> Vec<Item> {
                     }
                 };
 
-                if name == ".hidden" {
+                if name == ".hidden" && path.is_file() {
                     hidden_files = parse_hidden_file(&path);
                 }
 


### PR DESCRIPTION
fixes #766 

**changes tl;dr**
- check if `.hidden` is a _file_ (readable) before trying to read it
- for whatever reason, an infinite loop / denial of service happens (it looks like, under the hood, an `Err` doesn't bubble up properly)

repro:
```
cd ~/
mkdir demo
cd demo
mkdir .hidden
cosmic-files .
```

functionality remains the same for the following scenarios:
- hiding files via a `.hidden` text file;
- other hidden-by-default files/folders (eg: `.git`);
- toggling on/off `View > Show hidden files` both in and out of a folder with hidden files