### PR TITLE
Set max height for previews

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -1274,7 +1274,9 @@ impl App {
     }
 
     fn desktop_view_options(&self) -> Element<Message> {
-        let cosmic_theme::Spacing { space_l, .. } = theme::active().cosmic().spacing;
+        let cosmic_theme::Spacing {
+            space_m, space_l, ..
+        } = theme::active().cosmic().spacing;
         let config = self.config.desktop;
 
         let mut children = Vec::new();
@@ -1349,6 +1351,7 @@ impl App {
 
         widget::column::with_children(children)
             .padding([0, space_l, space_l, space_l])
+            .spacing(space_m)
             .into()
     }
 

--- a/src/tab.rs
+++ b/src/tab.rs
@@ -1400,11 +1400,11 @@ impl Item {
 
         let mut column = widget::column().spacing(space_m);
 
-        column = column.push(widget::row::with_children(vec![
-            widget::horizontal_space().into(),
-            self.preview(sizes),
-            widget::horizontal_space().into(),
-        ]));
+        column = column.push(
+            widget::container(self.preview(sizes))
+                .center_x(Length::Fill)
+                .max_height(THUMBNAIL_SIZE as f32),
+        );
 
         let mut details = widget::column().spacing(space_xxxs);
         details = details.push(widget::text::heading(self.name.clone()));
@@ -3922,15 +3922,13 @@ impl Tab {
                 }
                 Element::from(dnd_grid)
             }),
-            mouse_area::MouseArea::new(
-                widget::container(widget::column::with_children(children)).width(Length::Fill),
-            )
-            .on_press(|_| Message::Click(None))
-            .on_drag(Message::Drag)
-            .on_drag_end(|_| Message::DragEnd(None))
-            .show_drag_rect(true)
-            .on_release(|_| Message::ClickRelease(None))
-            .into(),
+            mouse_area::MouseArea::new(widget::column::with_children(children).width(Length::Fill))
+                .on_press(|_| Message::Click(None))
+                .on_drag(Message::Drag)
+                .on_drag_end(|_| Message::DragEnd(None))
+                .show_drag_rect(true)
+                .on_release(|_| Message::ClickRelease(None))
+                .into(),
             true,
         )
     }


### PR DESCRIPTION
This sets the max height of the previews to THUMBNAIL_SIZE, to match text previews. Prevents the previews from becoming too large when the desktop details window is resized horizontally, and prevents the scrollable from becoming too long with predominantly vertical images, which makes it harder to quickly see the metadata.

Not sure if a different value than THUMBNAIL_SIZE should be used (since it's calculated using not very related things), but it seems about the right size for now.

Also adds some spacing to the desktop view options, to match designs.