### PR TITLE
fix(applet): set mmap threshold to lower memory usage

### DIFF
--- a/cosmic-files-applet/src/main.rs
+++ b/cosmic-files-applet/src/main.rs
@@ -1,6 +1,28 @@
 mod file_manager;
 
+/// Access glibc malloc tunables.
+#[cfg(target_env = "gnu")]
+mod malloc {
+    use std::os::raw::c_int;
+
+    const M_MMAP_THRESHOLD: c_int = -3;
+
+    extern "C" {
+        fn mallopt(param: c_int, value: c_int) -> c_int;
+    }
+
+    /// Prevents glibc from hoarding memory via memory fragmentation.
+    pub fn limit_mmap_threshold() {
+        unsafe {
+            mallopt(M_MMAP_THRESHOLD, 65536);
+        }
+    }
+}
+
 fn main() -> Result<(), Box<dyn std::error::Error>> {
+    #[cfg(target_env = "gnu")]
+    malloc::limit_mmap_threshold();
+
     //TODO: move file manager service to its own daemon?
     let _conn_res = zbus::blocking::connection::Builder::session()?
         .name("org.freedesktop.FileManager1")?


### PR DESCRIPTION
Applies the same fix used in the cosmic-files app.