### PR TITLE
adding in drag-scroll functionality when cursor is outside of scrollable viewport

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -54,6 +54,7 @@ use std::{
     sync::{Arc, Mutex},
     time::{self, Instant},
 };
+use cosmic::iced::mouse::Event::CursorMoved;
 use tokio::sync::mpsc;
 use trash::TrashItem;
 #[cfg(feature = "wayland")]
@@ -277,6 +278,7 @@ pub enum Message {
     Config(Config),
     Copy(Option<Entity>),
     CosmicSettings(&'static str),
+    CursorMoved(Point),
     Cut(Option<Entity>),
     DesktopConfig(DesktopConfig),
     DesktopViewOptions,
@@ -1925,6 +1927,10 @@ impl Application for App {
                 let paths = self.selected_paths(entity_opt);
                 let contents = ClipboardCopy::new(ClipboardKind::Copy, &paths);
                 return clipboard::write_data(contents);
+            }
+            Message::CursorMoved(pos) => {
+                let entity = self.tab_model.active();
+                return self.update(Message::TabMessage(Some(entity), tab::Message::CursorMoved(pos)));
             }
             Message::Cut(entity_opt) => {
                 let paths = self.selected_paths(entity_opt);
@@ -4536,7 +4542,8 @@ impl Application for App {
                         }
                         _ => None,
                     }
-                }
+                },
+                Event::Mouse(CursorMoved { position: pos }) => Some(Message::CursorMoved(pos)),
                 _ => None,
             }),
             Config::subscription().map(|update| {

--- a/src/mouse_area.rs
+++ b/src/mouse_area.rs
@@ -50,6 +50,7 @@ pub struct MouseArea<'a, Message> {
     on_enter: Option<Box<dyn OnEnterExit<'a, Message>>>,
     on_exit: Option<Box<dyn OnEnterExit<'a, Message>>>,
     show_drag_rect: bool,
+    cursor_offset: Option<Point>
 }
 
 impl<'a, Message> MouseArea<'a, Message> {
@@ -185,6 +186,11 @@ impl<'a, Message> MouseArea<'a, Message> {
         self
     }
 
+    pub fn cursor_offset(mut self, offset: Option<Point>) -> Self {
+        self.cursor_offset = offset;
+        self
+    }
+
     /// Sets the widget's unique identifier.
     #[must_use]
     pub fn with_id(mut self, id: Id) -> Self {
@@ -215,6 +221,8 @@ impl<'a, Message, F> OnEnterExit<'a, Message> for F where F: Fn() -> Message + '
 #[derive(Default)]
 struct State {
     last_position: Option<Point>,
+    last_virtual_position: Option<Point>,
+    last_in_bounds_position: Option<Point>,
     drag_initiated: Option<Point>,
     modifiers: Modifiers,
     prev_click: Option<(mouse::Click, Instant)>,
@@ -224,7 +232,7 @@ struct State {
 impl State {
     fn drag_rect(&self, cursor: mouse::Cursor) -> Option<Rectangle> {
         if let Some(drag_source) = self.drag_initiated {
-            if let Some(position) = cursor.position() {
+            if let Some(position) = cursor.position().or(self.last_virtual_position) {
                 if position.distance(drag_source) > 1.0 {
                     let min_x = drag_source.x.min(position.x);
                     let max_x = drag_source.x.max(position.x);
@@ -292,6 +300,7 @@ impl<'a, Message> MouseArea<'a, Message> {
             on_exit: None,
             on_scroll: None,
             show_drag_rect: false,
+            cursor_offset: None
         }
     }
 }
@@ -522,6 +531,42 @@ fn update<Message: Clone>(
             _ => {}
         }
         state.last_position = position_in;
+
+        // if we have a cursor_offset, we need to calculate our "virtual" position
+        // (where we think the ABSOLUTE cursor is) - we'll take the last in bounds position and
+        // clamp it to the layout bounds
+        if let Some(offset) = widget.cursor_offset {
+            if let Some(in_bounds_pos) = state.last_in_bounds_position {
+                let mut new_virtual_pos = Point {
+                    x: in_bounds_pos.x + offset.x,
+                    y: in_bounds_pos.y + offset.y
+                };
+
+                // clamp to the viewport
+                new_virtual_pos.x = if new_virtual_pos.x > (layout_bounds.width + layout_bounds.x) {
+                    layout_bounds.width + layout_bounds.x
+                } else if new_virtual_pos.x < 0.0 {
+                    0.0
+                } else {
+                    new_virtual_pos.x
+                };
+
+                new_virtual_pos.y = if new_virtual_pos.y > (layout_bounds.height + layout_bounds.y) {
+                    layout_bounds.height + layout_bounds.y
+                } else if new_virtual_pos.y < 0.0 {
+                    0.0
+                } else {
+                    new_virtual_pos.y
+                };
+
+                state.last_virtual_position = Some(new_virtual_pos);
+            }
+        }
+
+        // set the last in bounds position to be the ABSOLUTE version of position_in
+        if position_in.is_some() {
+            state.last_in_bounds_position = cursor.position_over(layout_bounds);
+        }
     }
 
     if state.drag_initiated.is_none() && !cursor.is_over(layout_bounds) {

--- a/src/mouse_area.rs
+++ b/src/mouse_area.rs
@@ -199,8 +199,8 @@ impl<'a, Message, F> OnMouseButton<'a, Message> for F where F: Fn(Option<Point>)
 pub trait OnDrag<'a, Message>: Fn(Option<Rectangle>) -> Message + 'a {}
 impl<'a, Message, F> OnDrag<'a, Message> for F where F: Fn(Option<Rectangle>) -> Message + 'a {}
 
-pub trait OnResize<'a, Message>: Fn(Size) -> Message + 'a {}
-impl<'a, Message, F> OnResize<'a, Message> for F where F: Fn(Size) -> Message + 'a {}
+pub trait OnResize<'a, Message>: Fn(Size, Rectangle) -> Message + 'a {}
+impl<'a, Message, F> OnResize<'a, Message> for F where F: Fn(Size, Rectangle) -> Message + 'a {}
 
 pub trait OnScroll<'a, Message>: Fn(mouse::ScrollDelta, Modifiers) -> Option<Message> + 'a {}
 impl<'a, Message, F> OnScroll<'a, Message> for F where
@@ -374,6 +374,7 @@ where
             cursor,
             shell,
             tree.state.downcast_mut::<State>(),
+            viewport,
         )
     }
 
@@ -493,6 +494,7 @@ fn update<Message: Clone>(
     cursor: mouse::Cursor,
     shell: &mut Shell<'_, Message>,
     state: &mut State,
+    viewport: &Rectangle
 ) -> event::Status {
     let layout_bounds = layout.bounds();
 
@@ -500,7 +502,7 @@ fn update<Message: Clone>(
         let size = layout_bounds.size();
         if state.size != Some(size) {
             state.size = Some(size);
-            shell.publish(message(size));
+            shell.publish(message(size, *viewport));
         }
     }
 

--- a/src/tab.rs
+++ b/src/tab.rs
@@ -2244,11 +2244,15 @@ impl Tab {
                                     y: scroll_y as f32
                                 };
 
-                                if let Some(offset) = self.virtual_cursor_offset {
+                                if let Some(virtual_cursor_offset) = self.virtual_cursor_offset {
                                     new_offset = Point {
-                                        x: new_offset.x + offset.x,
-                                        y: new_offset.y + offset.y,
+                                        x: new_offset.x + virtual_cursor_offset.x,
+                                        y: new_offset.y + virtual_cursor_offset.y,
                                     };
+                                }
+
+                                if let Some(last_scroll_position) = self.last_scroll_position {
+                                    new_offset.x = (pos.x - last_scroll_position.x);
                                 }
 
                                 self.virtual_cursor_offset = Some(new_offset);

--- a/src/tab.rs
+++ b/src/tab.rs
@@ -84,7 +84,6 @@ const MAX_SEARCH_RESULTS: usize = 200;
 const THUMBNAIL_SIZE: u32 = (ICON_SIZE_GRID as u32) * (ICON_SCALE_MAX as u32);
 
 const DRAG_SCROLL_DISTANCE: f32 = 15.0;
-const DRAG_SCROLL_RATIO_MAXIMUM: f32 = 3.0;
 
 //TODO: adjust for locales?
 const DATE_TIME_FORMAT: &str = "%b %-d, %-Y, %-I:%M %p";
@@ -2234,32 +2233,13 @@ impl Tab {
                                 // diff_y should be NEGATIVE here when close to y=0 (above the MouseArea)
                                 // and positive when below the viewport
                                 let diff_y = pos.y - drag_start_point.y;
-                                let mut scroll_y: f32 = if diff_y > 0.0 {
+                                let scroll_y: f32 = if diff_y > 0.0 {
                                     DRAG_SCROLL_DISTANCE
                                 } else if diff_y < 0.0 {
                                     DRAG_SCROLL_DISTANCE * -1.0
                                 } else {
                                     0.0
                                 };
-
-
-                                // estimate distance and use that to control speed
-                                // go up to 3x speed
-                                let quarter_height = viewport.height / 4.0;
-                                let cursor_y_distance = if diff_y > 0.0 {
-                                    pos.y - (viewport.y + viewport.height)
-                                } else if diff_y < 0.0 {
-                                    pos.y - viewport.y
-                                } else {
-                                    0.0
-                                }.abs();
-
-                                let mut speed_ratio = (cursor_y_distance / quarter_height) + 1.0;
-                                if speed_ratio > DRAG_SCROLL_RATIO_MAXIMUM {
-                                    speed_ratio = DRAG_SCROLL_RATIO_MAXIMUM;
-                                }
-
-                                scroll_y = scroll_y * speed_ratio;
 
                                 let mut new_offset = Point {
                                     x: 0.0,
@@ -2274,7 +2254,7 @@ impl Tab {
                                 }
 
                                 if let Some(last_scroll_position) = self.last_scroll_position {
-                                    new_offset.x = (pos.x - last_scroll_position.x);
+                                    new_offset.x = pos.x - last_scroll_position.x;
                                 }
 
                                 self.virtual_cursor_offset = Some(new_offset);

--- a/src/tab.rs
+++ b/src/tab.rs
@@ -4147,6 +4147,7 @@ impl Tab {
                 .on_drag_end(|_| Message::DragEnd(None))
                 .show_drag_rect(true)
                 .on_release(|_| Message::ClickRelease(None))
+                .on_resize(Message::MouseAreaResized)
                 .into(),
             true,
         )

--- a/src/tab.rs
+++ b/src/tab.rs
@@ -2298,7 +2298,20 @@ impl Tab {
                 }
             }
             Message::MouseAreaResized(_size, viewport) => {
-                self.viewport_rect = Some(viewport);
+                // if we have a scroll position, we want to subtract it from the viewport
+                // so that we don't desync when swapping
+                if let Some(scroll_pos) = self.scroll_opt {
+                    self.viewport_rect = Some(Rectangle {
+                        x: viewport.x - scroll_pos.x,
+                        y: viewport.y - scroll_pos.y,
+                        width: viewport.width,
+                        height: viewport.height
+                    });
+                }
+                else {
+                    self.viewport_rect = Some(viewport);
+                }
+
             }
             Message::DragEnd(_) => {
                 self.clicked = None;


### PR DESCRIPTION
fixes https://github.com/pop-os/cosmic-files/issues/190

**changes tl;dr**:
- when dragging to select a number of items, mouse movements outside of the of the `Scrollable`/`MouseArea` viewport aren't captured
- we now capture `Event::Mouse(CursorMoved)` in `app.rs` to track global cursor position
- we bubble that event up to the active tab, which will scroll based on where the cursor is relative to the `Scrollable` viewport

this PR works and _could_ be merged into upstream, but it's currently a bit finicky:
- items that would be in the new selection don't get highlighted until you re-enter the viewport of the `Scrollable`;
- the speed is static (set to an arbitrary `5px`), it would be nicer if it was easier to control based off of how close your cursor is to the viewport
(i'll get these sorted in the next day or 2, i'm just pushing this up as it's late and otherwise am happy)

demonstration vid:

https://github.com/user-attachments/assets/6e9512b8-746d-4e06-b587-b927fe711dba

