### PR TITLE
Bugfix to how virtual cursor is calculated before DragEnd when drag-scrolling

### DIFF
--- a/src/mouse_area.rs
+++ b/src/mouse_area.rs
@@ -23,7 +23,6 @@ use cosmic::{
     widget::Id,
     Element, Renderer, Theme,
 };
-use cosmic::iced::window::RedrawRequest;
 use crate::tab::DOUBLE_CLICK_DURATION;
 
 /// Emit messages on mouse events.

--- a/src/mouse_area.rs
+++ b/src/mouse_area.rs
@@ -23,7 +23,7 @@ use cosmic::{
     widget::Id,
     Element, Renderer, Theme,
 };
-
+use cosmic::iced::window::RedrawRequest;
 use crate::tab::DOUBLE_CLICK_DURATION;
 
 /// Emit messages on mouse events.
@@ -223,6 +223,7 @@ struct State {
     last_position: Option<Point>,
     last_virtual_position: Option<Point>,
     last_in_bounds_position: Option<Point>,
+    last_cursor_offset: Option<Point>,
     drag_initiated: Option<Point>,
     modifiers: Modifiers,
     prev_click: Option<(mouse::Click, Instant)>,
@@ -515,23 +516,31 @@ fn update<Message: Clone>(
         }
     }
 
-    if let Event::Mouse(mouse::Event::CursorMoved { .. }) = event {
-        let position_in = cursor.position_in(layout_bounds);
-        match (position_in, state.last_position) {
-            (None, Some(_)) => {
-                if let Some(message) = widget.on_exit.as_ref() {
-                    shell.publish(message())
-                }
+    // check if offset differs to calculate virtual position
+    let mut need_to_recalculate = false;
+    match (state.last_cursor_offset, widget.cursor_offset) {
+        // check if offset has changed between updates
+        (Some(last_cursor_offset), Some(cursor_offset)) => {
+            if last_cursor_offset != cursor_offset {
+                state.last_cursor_offset = Some(cursor_offset);
+                need_to_recalculate = true;
             }
-            (Some(_), None) => {
-                if let Some(message) = widget.on_enter.as_ref() {
-                    shell.publish(message())
-                }
-            }
-            _ => {}
-        }
-        state.last_position = position_in;
+        },
 
+        // we've started moving out of bounds
+        (None, Some(cursor_offset)) => {
+            state.last_cursor_offset = Some(cursor_offset);
+            need_to_recalculate = true;
+        },
+
+        // we've moved inbounds
+        (Some(_), None) => {
+            state.last_cursor_offset = None;
+        }
+        _ => {}
+    }
+
+    if need_to_recalculate {
         // if we have a cursor_offset, we need to calculate our "virtual" position
         // (where we think the ABSOLUTE cursor is) - we'll take the last in bounds position and
         // clamp it to the layout bounds
@@ -562,6 +571,25 @@ fn update<Message: Clone>(
                 state.last_virtual_position = Some(new_virtual_pos);
             }
         }
+    }
+
+
+    if let Event::Mouse(mouse::Event::CursorMoved { .. }) = event {
+        let position_in = cursor.position_in(layout_bounds);
+        match (position_in, state.last_position) {
+            (None, Some(_)) => {
+                if let Some(message) = widget.on_exit.as_ref() {
+                    shell.publish(message())
+                }
+            }
+            (Some(_), None) => {
+                if let Some(message) = widget.on_enter.as_ref() {
+                    shell.publish(message())
+                }
+            }
+            _ => {}
+        }
+        state.last_position = position_in;
 
         // set the last in bounds position to be the ABSOLUTE version of position_in
         if position_in.is_some() {

--- a/src/tab.rs
+++ b/src/tab.rs
@@ -2241,24 +2241,7 @@ impl Tab {
                                     0.0
                                 };
 
-                                let mut new_offset = Point {
-                                    x: 0.0,
-                                    y: scroll_y
-                                };
 
-                                if let Some(virtual_cursor_offset) = self.virtual_cursor_offset {
-                                    new_offset = Point {
-                                        x: new_offset.x + virtual_cursor_offset.x,
-                                        y: new_offset.y + virtual_cursor_offset.y,
-                                    };
-                                }
-
-                                if let Some(last_scroll_position) = self.last_scroll_position {
-                                    new_offset.x = pos.x - last_scroll_position.x;
-                                }
-
-                                self.virtual_cursor_offset = Some(new_offset);
-                                self.last_scroll_offset = Some(new_offset);
 
                                 commands.push(Command::AutoScroll(Some(scroll_y)));
                             }
@@ -2962,6 +2945,28 @@ impl Tab {
                 self.scroll_opt = Some(viewport.absolute_offset());
             }
             Message::ScrollTab(scroll_speed) => {
+                let mut new_offset = Point {
+                    x: 0.0,
+                    y: scroll_speed
+                };
+
+                if let Some(virtual_cursor_offset) = self.virtual_cursor_offset {
+                    new_offset = Point {
+                        x: new_offset.x + virtual_cursor_offset.x,
+                        y: new_offset.y + virtual_cursor_offset.y,
+                    };
+                }
+
+                if let Some(last_scroll_position) = self.last_scroll_position {
+                    if let Some(global_cursor_position) = self.global_cursor_position {
+                        new_offset.x = global_cursor_position.x - last_scroll_position.x;
+                    }
+
+                }
+
+                self.virtual_cursor_offset = Some(new_offset);
+                self.last_scroll_offset = Some(new_offset);
+
                 commands.push(Command::Iced(
                     scrollable::scroll_by(self.scrollable_id.clone(), AbsoluteOffset {
                         x: 0.0,


### PR DESCRIPTION
**changes tl;dr**
- part of #812 involved adding a subscription to auto scroll
- doing this caused a desync where the virtual cursor was getting updated far more often than the subscription itself
- this meant, unless the cursor was moved back in bounds, when the `DragEnd` event is triggered the amount of selected files was significantly more than actually selected

**steps to replicate**
- open a folder with a lot of items
- begin drag-scrolling
- let go of your mouse when you're out of bounds

https://github.com/user-attachments/assets/241dcf85-0664-443d-b835-056020d8c503

sorry i didnt catch this earlier :(
