### PR TITLE
Fixes issue #817 with thumbnails

### DIFF
--- a/src/tab.rs
+++ b/src/tab.rs
@@ -4031,7 +4031,8 @@ impl Tab {
                     widget::button::custom(
                         widget::icon::icon(item.icon_handle_grid.clone())
                             .content_fit(ContentFit::Contain)
-                            .size(icon_sizes.grid()),
+                            .size(icon_sizes.grid())
+                            .width(Length::Shrink),
                     )
                     .padding(space_xxxs)
                     .class(button_style(


### PR DESCRIPTION
Fixes the issue with thumbnails by explicitly setting the icon widget width to always be the minimum preventing overflow.

Some before-after images are below.

Before:
![image](https://github.com/user-attachments/assets/c7ea850d-043b-45d9-84a0-13324a11bc79)

After:
![image](https://github.com/user-attachments/assets/6efc94a3-1a08-4c90-b951-a91d97b5f623)


Before:
![image](https://github.com/user-attachments/assets/21b71c48-e346-4199-bba6-852f174f7bba)

After:
![image](https://github.com/user-attachments/assets/bafc5bb1-2b75-48d2-b82b-d627394518c4)

I would like to say that there are some other extremes and even in most other ones that are not very visible, that bug is still present if you look close enough.
