### PR TITLE
fix: close selected preview on single click

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -2704,7 +2704,7 @@ impl Application for App {
                 match self.mode {
                     Mode::App => {
                         let show_details = !self.config.show_details;
-                        self.context_page = ContextPage::Preview(None, PreviewKind::Selected);
+                        self.context_page = ContextPage::Preview(entity_opt, PreviewKind::Selected);
                         self.core.window.show_context = show_details;
                         return cosmic::task::message(Message::SetShowDetails(show_details));
                     }

--- a/src/app.rs
+++ b/src/app.rs
@@ -3097,7 +3097,9 @@ impl Application for App {
             }
             Message::ToggleContextPage(context_page) => {
                 //TODO: ensure context menus are closed
-                if self.context_page == context_page {
+                if self.context_page == context_page
+                    || matches!(self.context_page, ContextPage::Preview(_, _))
+                {
                     self.set_show_context(!self.core.window.show_context);
                 } else {
                     self.set_show_context(true);

--- a/src/app.rs
+++ b/src/app.rs
@@ -2704,7 +2704,7 @@ impl Application for App {
                 match self.mode {
                     Mode::App => {
                         let show_details = !self.config.show_details;
-                        self.context_page = ContextPage::Preview(entity_opt, PreviewKind::Selected);
+                        self.context_page = ContextPage::Preview(None, PreviewKind::Selected);
                         self.core.window.show_context = show_details;
                         return cosmic::task::message(Message::SetShowDetails(show_details));
                     }


### PR DESCRIPTION
Fixes #834 

Use `matches!` to compare b/w `ContextPage::Preview` as first pressing on "Close" button would fail the equality check b/w `Preview(None, _)` and `Preview(Some(entity),_)`.

This fixes the two clicks needed to close Preview of Selected as first click would update `self.context_page` from `Preview(None,..)` to `Preview(Some,..)` and next click would pass equality and close Preview.

**EDIT:** prev. implementation was changing `self.context_page` from None to Some in `Preview` which fixed the original issue, but the persist preview would still require two clicks to close.

Newer commit fixes original issue + fixes two clicks required on persisted preview as well.