### PR TITLE
fix: header actions glitch in preview page

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -3645,6 +3645,7 @@ impl Application for App {
                                 actions.extend(item.preview_header().into_iter().map(|element| {
                                     element.map(move |x| Message::TabMessage(Some(entity), x))
                                 }));
+                                break;
                             }
                         }
                     }


### PR DESCRIPTION
fixes #844 

## Issue

Extending selections (ctrl+up/down), the header actions vec would get populated for each selection and would result in either additional nav buttons (in original issue) or if continuing to select more, actions would start to disappear completely.

## Proposed fix

extend actions vec once to prevent adding more header actions for subsequent selections.