### PR TITLE
[Feature] settings option to change sidebar size

### DIFF
--- a/i18n/en/cosmic_files.ftl
+++ b/i18n/en/cosmic_files.ftl
@@ -245,6 +245,12 @@ match-desktop = Match desktop
 dark = Dark
 light = Light
 
+## NavBar Size
+navbar-size = Sidebar Size
+small = Small
+medium = Medium
+large = Large
+
 # Context menu
 add-to-sidebar = Add to sidebar
 compress = Compress

--- a/src/config.rs
+++ b/src/config.rs
@@ -51,6 +51,23 @@ impl AppTheme {
     }
 }
 
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub enum NavBarSize {
+    Small,
+    Medium,
+    Large,
+}
+
+impl NavBarSize {
+    pub fn size(&self) -> f32 {
+        match self {
+            NavBarSize::Small => 64.0,
+            NavBarSize::Medium => 160.0,
+            NavBarSize::Large => 280.0,
+        }
+    }
+}
+
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub enum Favorite {
     Home,
@@ -99,6 +116,7 @@ impl Favorite {
 #[serde(default)]
 pub struct Config {
     pub app_theme: AppTheme,
+    pub nav_bar_size: NavBarSize,
     pub desktop: DesktopConfig,
     pub favorites: Vec<Favorite>,
     pub show_details: bool,
@@ -139,6 +157,7 @@ impl Default for Config {
     fn default() -> Self {
         Self {
             app_theme: AppTheme::System,
+            nav_bar_size: NavBarSize::Large,
             desktop: DesktopConfig::default(),
             favorites: vec![
                 Favorite::Home,


### PR DESCRIPTION
The default sidebar size is quite wide. I added a settings option to choose between small, medium, and large presets. 

It seemed to me that with the way the UI was presently designed it would be a bit complicated to make the sidebar resizable. All I could find was using something like PaneGrid but that seemed like it would lead to a lot of refactoring.

If any changes to this design are ideal like something akin to PaneGrid or using a slider in the settings instead I would be willing to alter it. I just think this is a much needed feature.

https://github.com/user-attachments/assets/2d2ea09d-64b9-42c1-a841-f8be990abd3f

