### PR TITLE
feat: multiple selection preview page

### DIFF
--- a/src/tab.rs
+++ b/src/tab.rs
@@ -45,7 +45,7 @@ use serde::{Deserialize, Serialize};
 use std::{
     cell::Cell,
     cmp::Ordering,
-    collections::{HashMap, HashSet},
+    collections::HashMap,
     error::Error,
     fmt::{self, Display},
     fs::{self, File, Metadata},

--- a/src/tab.rs
+++ b/src/tab.rs
@@ -45,7 +45,7 @@ use serde::{Deserialize, Serialize};
 use std::{
     cell::Cell,
     cmp::Ordering,
-    collections::HashMap,
+    collections::{HashMap, HashSet},
     error::Error,
     fmt::{self, Display},
     fs::{self, File, Metadata},
@@ -1516,6 +1516,51 @@ impl Item {
             }
         }
         row
+    }
+
+    pub fn preview_view_multiple<'a>(items: &[Item]) -> Element<'a, Message> {
+        let cosmic_theme::Spacing { space_m, .. } = theme::active().cosmic().spacing;
+        let mut column = widget::column().spacing(space_m);
+
+        let items_selected: Vec<&Item> = items.iter().filter(|v| v.selected).collect();
+        let (dirs_selected, files_selected) =
+            items_selected
+                .iter()
+                .fold((0u32, 0u32), |(dirs, files), &v| match &v.metadata {
+                    ItemMetadata::Path { metadata, .. } => {
+                        if metadata.is_dir() {
+                            (dirs + 1, files)
+                        } else {
+                            (dirs, files + 1)
+                        }
+                    }
+                    _ => (dirs, files),
+                });
+
+        let dirs_text = if dirs_selected == 1 {
+            "folder"
+        } else {
+            "folders"
+        };
+        let files_text = if files_selected == 1 { "file" } else { "files" };
+        let text: String;
+
+        if dirs_selected >= 1 && files_selected >= 1 {
+            text = format!(
+                "{} {}, {} {} selected",
+                dirs_selected, dirs_text, files_selected, files_text
+            );
+        } else if dirs_selected >= 1 && files_selected == 0 {
+            text = format!("{} {} selected", dirs_selected, dirs_text);
+        } else if dirs_selected == 0 && files_selected >= 1 {
+            text = format!("{} {} selected", files_selected, files_text);
+        } else {
+            log::error!("folder or a file should have been selected.");
+            text = String::new(); // do not crash if we somehow reach here.
+        }
+
+        column = column.push(widget::text::heading(text));
+        column.into()
     }
 
     pub fn preview_view<'a>(


### PR DESCRIPTION
related to #484 

show total number of dirs and files selected in preview page when more than one item is selected.

Currently added an associated function in `Item` which takes in a list of selected items and creates a simple view that shows the number of files and directories selected.

I'm not sure if this is the right approach but opening PR for further discussion.

![image](https://github.com/user-attachments/assets/8d23bc5e-a5a4-4fd4-92f0-64062cdce101)
