### PR TITLE
Context menu fixes

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -1765,11 +1765,13 @@ impl Application for App {
             ));
         }
         items.push(cosmic::widget::menu::Item::Divider);
-        items.push(cosmic::widget::menu::Item::Button(
-            fl!("show-details"),
-            None,
-            NavMenuAction::Preview(entity),
-        ));
+        if matches!(location_opt, Some(Location::Path(..))) {
+            items.push(cosmic::widget::menu::Item::Button(
+                fl!("show-details"),
+                None,
+                NavMenuAction::Preview(entity),
+            ));
+        }
         items.push(cosmic::widget::menu::Item::Divider);
         if favorite_index_opt.is_some() {
             items.push(cosmic::widget::menu::Item::Button(

--- a/src/app.rs
+++ b/src/app.rs
@@ -1779,11 +1779,13 @@ impl Application for App {
             ));
         }
         if matches!(location_opt, Some(Location::Trash)) {
-            items.push(cosmic::widget::menu::Item::Button(
-                fl!("empty-trash"),
-                None,
-                NavMenuAction::EmptyTrash,
-            ));
+            if tab::trash_entries() > 0 {
+                items.push(cosmic::widget::menu::Item::Button(
+                    fl!("empty-trash"),
+                    None,
+                    NavMenuAction::EmptyTrash,
+                ));
+            }
         }
 
         Some(cosmic::widget::menu::items(&HashMap::new(), items))

--- a/src/app.rs
+++ b/src/app.rs
@@ -3462,8 +3462,18 @@ impl Application for App {
                 }
                 NavMenuAction::OpenInNewTab(entity) => {
                     match self.nav_model.data::<Location>(entity) {
+                        Some(Location::Network(ref uri, ref display_name)) => {
+                            return self.open_tab(
+                                Location::Network(uri.clone(), display_name.clone()),
+                                false,
+                                None,
+                            );
+                        }
                         Some(Location::Path(ref path)) => {
                             return self.open_tab(Location::Path(path.clone()), false, None);
+                        }
+                        Some(Location::Recents) => {
+                            return self.open_tab(Location::Recents, false, None);
                         }
                         Some(Location::Trash) => {
                             return self.open_tab(Location::Trash, false, None);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -97,6 +97,10 @@ pub fn main() -> Result<(), Box<dyn std::error::Error>> {
             continue;
         } else if &arg == "--trash" {
             Location::Trash
+        } else if &arg == "--recents" {
+            Location::Recents
+        } else if &arg == "--network" {
+            Location::Network("network:///".to_string(), fl!("networks"))
         } else {
             //TODO: support more URLs
             let path = match url::Url::parse(&arg) {


### PR DESCRIPTION
Closes #487

Fixes some issues with the context menu in the side bar:

- Add "Open in new tab" for Network and Recents
- Only show "Empty Trash" when there is trash
- Remove "Show Details" from all but Path locations since it doesn't actually work for them currently. Maybe support for other location types should be added in the future?
- Implement "Open in new window" for Trash, Recents, and Network