### PR TITLE
Handle broken favorites in sidebar

### DIFF
--- a/i18n/en/cosmic_files.ftl
+++ b/i18n/en/cosmic_files.ftl
@@ -121,6 +121,16 @@ read-write = Read and write
 ### Mode 7
 read-write-execute = Read, write, and execute
 
+## Favorite Path Error Dialog
+favorite-path-error = Error opening directory
+favorite-path-error-description =
+    Unable to open "{$path}".
+    It may not exist or you don't have permission to open it.
+    
+    Would you like to remove it from the sidebar?
+remove = Remove
+keep = Keep
+
 # Context Pages
 
 ## About

--- a/src/app.rs
+++ b/src/app.rs
@@ -477,6 +477,10 @@ pub enum DialogPage {
     SetExecutableAndLaunch {
         path: PathBuf,
     },
+    FavoritePathError {
+        path: PathBuf,
+        entity: Entity,
+    },
 }
 
 pub struct FavoriteIndex(usize);
@@ -1852,8 +1856,33 @@ impl Application for App {
     fn on_nav_select(&mut self, entity: Entity) -> Task<Self::Message> {
         self.nav_model.activate(entity);
         if let Some(location) = self.nav_model.data::<Location>(entity) {
-            let message = Message::TabMessage(None, tab::Message::Location(location.clone()));
-            return self.update(message);
+            let should_open = match location {
+                Location::Path(path) => match path.try_exists() {
+                    Ok(true) => true,
+                    Ok(false) => {
+                        log::warn!("failed to open favorite, path does not exist: {:?}", path);
+                        self.dialog_pages.push_back(DialogPage::FavoritePathError {
+                            path: path.clone(),
+                            entity,
+                        });
+                        false
+                    }
+                    Err(err) => {
+                        log::warn!("failed to open favorite for path: {:?}, {}", path, err);
+                        self.dialog_pages.push_back(DialogPage::FavoritePathError {
+                            path: path.clone(),
+                            entity,
+                        });
+                        false
+                    }
+                },
+                _ => true,
+            };
+
+            if should_open {
+                let message = Message::TabMessage(None, tab::Message::Location(location.clone()));
+                return self.update(message);
+            }
         }
 
         if let Some(data) = self.nav_model.data::<MounterData>(entity) {
@@ -2227,6 +2256,16 @@ impl Application for App {
                         }
                         DialogPage::SetExecutableAndLaunch { path } => {
                             self.operation(Operation::SetExecutableAndLaunch { path });
+                        }
+                        DialogPage::FavoritePathError { entity, .. } => {
+                            if let Some(FavoriteIndex(favorite_i)) =
+                                self.nav_model.data::<FavoriteIndex>(entity)
+                            {
+                                let mut favorites = self.config.favorites.clone();
+                                favorites.remove(*favorite_i);
+                                config_set!(favorites, favorites);
+                                return self.update_config();
+                            }
                         }
                     }
                 }
@@ -4436,6 +4475,19 @@ impl Application for App {
                         name = name
                     )))
             }
+            DialogPage::FavoritePathError { path, .. } => widget::dialog()
+                .title(fl!("favorite-path-error"))
+                .body(fl!(
+                    "favorite-path-error-description",
+                    path = path.as_os_str().to_str()
+                ))
+                .icon(widget::icon::from_name("dialog-error").size(64))
+                .primary_action(
+                    widget::button::destructive(fl!("remove")).on_press(Message::DialogComplete),
+                )
+                .secondary_action(
+                    widget::button::standard(fl!("keep")).on_press(Message::DialogCancel),
+                ),
         };
 
         Some(dialog.into())


### PR DESCRIPTION
Fixes #866 

When clicking on a favorite in the sidebar that no longer exists, it will show an error message with the option to remove the broken favorite from the sidebar.

![image](https://github.com/user-attachments/assets/22be89f8-954d-4db7-a7ed-a48d002d1135)


