### PR TITLE
Edit location when clicking on current directory

### DIFF
--- a/src/tab.rs
+++ b/src/tab.rs
@@ -3874,7 +3874,11 @@ impl Tab {
                         widget::button::custom(row)
                             .padding(space_xxxs)
                             .class(theme::Button::Link)
-                            .on_press(Message::Location(location.clone())),
+                            .on_press(if ancestor == path {
+                                Message::EditLocation(Some(self.location.clone().into()))
+                            } else {
+                                Message::Location(location.clone())
+                            }),
                     );
 
                     if self.location_context_menu_index.is_some() {


### PR DESCRIPTION
Closes #807 

This makes it so clicking on the name of the current directory (the last item) in the breadcrumbs puts it into edit mode. Before, it wouldn't do anything, because you're already in the dir. Now it does something useful. This change matches the behavior of Gnome Files.