### PR TITLE
Bugfix to open-with dialog to use a scrollable with a managed height

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -4290,7 +4290,10 @@ impl Application for App {
                 };
 
                 let mut column = widget::list_column();
-                for (i, app) in self.get_programs_for_mime(&mime).iter().enumerate() {
+                let available_programs = self.get_programs_for_mime(&mime);
+                let item_height = 32.0;
+
+                for (i, app) in available_programs.iter().enumerate() {
                     column = column.add(
                         widget::button::custom(
                             widget::row::with_children(vec![
@@ -4314,7 +4317,7 @@ impl Application for App {
                                 },
                             ])
                             .spacing(space_s)
-                            .height(Length::Fixed(32.0))
+                            .height(Length::Fixed(item_height))
                             .align_y(Alignment::Center),
                         )
                         .width(Length::Fill)
@@ -4331,7 +4334,21 @@ impl Application for App {
                     .secondary_action(
                         widget::button::standard(fl!("cancel")).on_press(Message::DialogCancel),
                     )
-                    .control(column);
+                    .control(
+                        widget::scrollable(column).height(if let Some(size) = self.size {
+                            let max_size = size.height - 256.0;
+                            let scrollable_height = available_programs.len() as f32
+                                * (item_height + (2.0 * space_xxs as f32));
+
+                            if scrollable_height > max_size {
+                                Length::Fill
+                            } else {
+                                Length::Shrink
+                            }
+                        } else {
+                            Length::Fill
+                        }),
+                    );
 
                 if let Some(app) = store_opt {
                     dialog = dialog.tertiary_action(


### PR DESCRIPTION
Fixes a niche issue where if you have a lot of handlers for a file type the content goes off-screen

![image](https://github.com/user-attachments/assets/cd0a3a10-6ac3-461a-8d9f-436bd5184f39)

(taken from pop-os chat)

another example:


https://github.com/user-attachments/assets/878c5c80-0ba2-45e4-8233-108ff5792d24

(for the `256.0` magic number i just poked around with various numbers until it would seamlessly transition between full height & scrollable without impacting the buttons)