### PR TITLE
Add keybinds for list/grid views

### DIFF
--- a/src/key_bind.rs
+++ b/src/key_bind.rs
@@ -46,7 +46,10 @@ pub fn key_binds(mode: &tab::Mode) -> HashMap<KeyBind, Action> {
     bind!([Ctrl], Key::Character("+".into()), ZoomIn);
     bind!([Ctrl], Key::Character("0".into()), ZoomDefault);
     bind!([Ctrl], Key::Character("-".into()), ZoomOut);
-
+    // Switch view
+    bind!([Ctrl], Key::Character("1".into()), TabViewList);
+    bind!([Ctrl], Key::Character("2".into()), TabViewGrid);
+    
     // App-only keys
     if matches!(mode, tab::Mode::App) {
         bind!([Ctrl], Key::Character("d".into()), AddToSidebar);


### PR DESCRIPTION
Implements https://github.com/pop-os/cosmic-files/issues/320

I chose the same key binds as nautilus:
- `Ctrl + 1` for list
- `Ctrl + 2` for grid

![image](https://github.com/user-attachments/assets/2013a60e-f3fe-48bf-b02d-420567249cb9)
