### PR TITLE
Simplify and fix drag selection and auto scroll

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -15,7 +15,6 @@ use cosmic::iced::{
 #[cfg(feature = "wayland")]
 use cosmic::iced_winit::commands::overlap_notify::overlap_notify;
 use cosmic::{
-    action,
     app::{self, context_drawer, Core, Task},
     cosmic_config, cosmic_theme, executor,
     iced::{

--- a/src/tab.rs
+++ b/src/tab.rs
@@ -2592,11 +2592,15 @@ impl Tab {
                 }
             }
             Message::Drag(rect_opt) => {
-                self.current_drag_rect = rect_opt;
+                if self.mode.multiple() {
+                    self.current_drag_rect = rect_opt;
+                }
                 if let Some(rect) = rect_opt {
                     self.context_menu = None;
                     self.location_context_menu_index = None;
-                    self.select_rect(rect, mod_ctrl, mod_shift);
+                    if self.mode.multiple() {
+                        self.select_rect(rect, mod_ctrl, mod_shift);
+                    }
                     if self.select_focus.take().is_some() {
                         // Unfocus currently focused button
                         commands.push(Command::Iced(
@@ -4301,7 +4305,7 @@ impl Tab {
                 .on_press(|_| Message::Click(None))
                 .on_drag(Message::Drag)
                 .on_drag_end(|_| Message::DragEnd(None))
-                .show_drag_rect(true)
+                .show_drag_rect(self.mode.multiple())
                 .on_release(|_| Message::ClickRelease(None))
                 .into(),
             true,
@@ -4634,7 +4638,7 @@ impl Tab {
             .on_press(|_| Message::Click(None))
             .on_drag(Message::Drag)
             .on_drag_end(|_| Message::DragEnd(None))
-            .show_drag_rect(true)
+            .show_drag_rect(self.mode.multiple())
             .on_release(|_| Message::ClickRelease(None))
             .into(),
             true,


### PR DESCRIPTION
* Fixes for drawing the drag-select rectangle.
  * Make sure the rectangle draws within bounds and doesn't draw up into the title bar or other areas of the window.
  * When dragging the mouse outside of the bounds of the window, ensure the selection rectangle updates correctly no matter where you drag.
* Fixes for detecting when to auto-scroll when dragging below the bottom. Previously, you would have to drag as far below the window as the difference between the visible height and the total content height before auto-scroll would kick in.
* Add auto-scroll to the dialog.
* Disable drag-select for the dialog when in single file/folder selection mode.

Fixes #877