### PR TITLE
feat: add Permanently delete functionnality

### DIFF
--- a/i18n/de/cosmic_files.ftl
+++ b/i18n/de/cosmic_files.ftl
@@ -79,6 +79,15 @@ save-file = Datei speichern
 open-with-title = Wie möchtest du „{$name}“ öffnen?
 browse-store = {$store} durchsuchen
 
+## Dauerhaft Löschen Dialog
+selected-items = {$items} gewählte Objekte
+permanently-delete-question = {$target} dauerhaft löschen?
+delete = Löschen
+permanently-delete-warning = {$target} dauerhaft löschen, {$nb_items ->
+        [one] es kann
+        *[other] Sie können
+    } nicht wiederhergestellt werden.
+
 # Umbenennen-Dialog
 rename-file = Datei umbenennen
 rename-folder = Ordner umbenennen
@@ -212,6 +221,14 @@ restored = {$items} {$items ->
         *[other] Elemente wurden
     } aus dem {trash} wiederhergestellt
 unknown-folder = unbekannter Ordner
+permanently-deleting = Lösche {$items} {$items ->
+        [one] Objekt
+        *[other] Objekte
+    } dauerhaft
+permanently-deleted = {$items} {$items ->
+        [one] Objekt
+        *[other] Objekte
+    } dauerhaft gelöscht
 
 ## Öffnen mit
 menu-open-with = Öffnen mit
@@ -229,6 +246,7 @@ calculating = Wird berechnet...
 
 ## Einstellungen
 settings = Einstellungen
+settings-show-delete-permanently = Dauerhaft löschen
 
 ### Aussehen
 appearance = Aussehen
@@ -245,6 +263,7 @@ new-file = Neue Datei
 new-folder = Neuer Ordner
 open-in-terminal = Im Terminal öffnen
 move-to-trash = In den Papierkorb verschieben
+delete-permanently = Dauerhaft löschen...
 restore-from-trash = Aus dem Papierkorb wiederherstellen
 remove-from-sidebar = Von der Seitenleiste entfernen
 sort-by-name = Nach Name sortieren

--- a/i18n/en/cosmic_files.ftl
+++ b/i18n/en/cosmic_files.ftl
@@ -83,6 +83,15 @@ browse-store = Browse {$store}
 other-apps = Other applications
 related-apps = Related applications
 
+## Permanently delete Dialog
+selected-items = the {$items} selected items
+permanently-delete-question = Permanently delete?
+delete = Delete
+permanently-delete-warning = Permanently delete {$target}, {$nb_items ->
+        [one] he
+        *[other] they
+    } can not be restored
+
 ## Rename Dialog
 rename-file = Rename file
 rename-folder = Rename folder
@@ -223,6 +232,14 @@ moved = Moved {$items} {$items ->
         [one] item
         *[other] items
     } from "{$from}" to "{$to}"
+permanently-deleting = Permanently deleting "{$items}" "{$items ->
+        [one] item
+        *[other] items
+    }"
+permanently-deleted = Permanently deleted "{$items}" "{$items ->
+        [one] item
+        *[other] items
+    }"
 renaming = Renaming "{$from}" to "{$to}"
 renamed = Renamed "{$from}" to "{$to}"
 restoring = Restoring {$items} {$items ->

--- a/i18n/fr/cosmic_files.ftl
+++ b/i18n/fr/cosmic_files.ftl
@@ -81,6 +81,15 @@ save-file = Enregistrer fichier
 open-with-title = Comment souhaitez-vous ouvrir "{$name}" ?
 browse-store = Parcourir {$store}
 
+## Permanently delete Dialog
+selected-items = les {$items} éléments sélectionnés
+permanently-delete-question = Supprimer définitivement ?
+delete = Supprimer
+permanently-delete-warning = Supprimer définitivement {$target}, {$nb_items ->
+        [one] il ne pourras pas être restauré.
+        *[other] ils ne pourront pas être restaurés.
+}
+
 ## Rename Dialog
 rename-file = Renommer le fichier
 rename-folder = Renommer le dossier
@@ -221,6 +230,14 @@ moved = {$items} {$items ->
         [one] élément déplacé
         *[other] éléments déplacés
     } depuis {$from} vers {$to}
+permanently-deleting = Suppression définitive de "{$items}" "{$items ->
+        [one] item
+        *[other] items
+    }"
+permanently-deleted = Supprimés définitivement "{$items}" "{$items ->
+        [one] item
+        *[other] items
+    }"
 renaming = Renommage de {$from} en {$to}
 renamed = {$from} renommé en {$to}
 restoring = Restauration de {$items} {$items ->

--- a/src/app.rs
+++ b/src/app.rs
@@ -315,7 +315,7 @@ pub enum Message {
     Key(Modifiers, Key, Option<SmolStr>),
     LaunchUrl(String),
     MaybeExit,
-    Modifiers(Modifiers),
+    ModifiersChanged(Modifiers),
     MounterItems(MounterKey, MounterItems),
     MountResult(MounterKey, MounterItem, Result<bool, String>),
     NavBarClose(Entity),
@@ -2627,7 +2627,7 @@ impl Application for App {
                     log::warn!("failed to open {:?}: {}", url, err);
                 }
             },
-            Message::Modifiers(modifiers) => {
+            Message::ModifiersChanged(modifiers) => {
                 self.modifiers = modifiers;
             }
             Message::MounterItems(mounter_key, mounter_items) => {
@@ -5187,7 +5187,7 @@ impl Application for App {
                     event::Status::Captured => None,
                 },
                 Event::Keyboard(KeyEvent::ModifiersChanged(modifiers)) => {
-                    Some(Message::Modifiers(modifiers))
+                    Some(Message::ModifiersChanged(modifiers))
                 }
                 Event::Window(WindowEvent::Unfocused) => Some(Message::WindowUnfocus),
                 #[cfg(all(feature = "desktop", feature = "wayland"))]

--- a/src/app.rs
+++ b/src/app.rs
@@ -5001,6 +5001,7 @@ impl Application for App {
             &self.core,
             self.tab_model.active_data::<Tab>(),
             &self.config,
+            &self.modifiers,
             &self.key_binds,
         )]
     }

--- a/src/app.rs
+++ b/src/app.rs
@@ -2629,6 +2629,11 @@ impl Application for App {
             },
             Message::ModifiersChanged(modifiers) => {
                 self.modifiers = modifiers;
+                let entity = self.tab_model.active();
+                return self.update(Message::TabMessage(
+                    Some(entity),
+                    tab::Message::ModifiersChanged(modifiers),
+                ));
             }
             Message::MounterItems(mounter_key, mounter_items) => {
                 // Check for unmounted folders

--- a/src/dialog.rs
+++ b/src/dialog.rs
@@ -1292,6 +1292,9 @@ impl Application for App {
             }
             Message::ModifiersChanged(modifiers) => {
                 self.modifiers = modifiers;
+                return self.update(Message::TabMessage(tab::Message::ModifiersChanged(
+                    modifiers,
+                )));
             }
             Message::MounterItems(mounter_key, mounter_items) => {
                 // Check for unmounted folders

--- a/src/dialog.rs
+++ b/src/dialog.rs
@@ -382,7 +382,7 @@ enum Message {
     Filename(String),
     Filter(usize),
     Key(Modifiers, Key),
-    Modifiers(Modifiers),
+    ModifiersChanged(Modifiers),
     MounterItems(MounterKey, MounterItems),
     NewFolder,
     NotifyEvents(Vec<DebouncedEvent>),
@@ -1290,7 +1290,7 @@ impl Application for App {
                     }
                 }
             }
-            Message::Modifiers(modifiers) => {
+            Message::ModifiersChanged(modifiers) => {
                 self.modifiers = modifiers;
             }
             Message::MounterItems(mounter_key, mounter_items) => {
@@ -1757,7 +1757,7 @@ impl Application for App {
                     event::Status::Captured => None,
                 },
                 Event::Keyboard(KeyEvent::ModifiersChanged(modifiers)) => {
-                    Some(Message::Modifiers(modifiers))
+                    Some(Message::ModifiersChanged(modifiers))
                 }
                 Event::Mouse(mouse::Event::CursorMoved { position: pos }) => {
                     Some(Message::CursorMoved(pos))

--- a/src/key_bind.rs
+++ b/src/key_bind.rs
@@ -68,6 +68,7 @@ pub fn key_binds(mode: &tab::Mode) -> HashMap<KeyBind, Action> {
         bind!([Ctrl], Key::Character("c".into()), Copy);
         bind!([Ctrl], Key::Character("x".into()), Cut);
         bind!([], Key::Named(Named::Delete), Delete);
+        bind!([Shift], Key::Named(Named::Delete), PermanentlyDelete);
         bind!([Shift], Key::Named(Named::Enter), OpenInNewWindow);
         bind!([Ctrl], Key::Character("v".into()), Paste);
         bind!([], Key::Named(Named::F2), Rename);

--- a/src/menu.rs
+++ b/src/menu.rs
@@ -499,6 +499,7 @@ pub fn menu_bar<'a>(
     core: &Core,
     tab_opt: Option<&Tab>,
     config: &Config,
+    modifiers: &Modifiers,
     key_binds: &HashMap<KeyBind, Action>,
 ) -> Element<'a, Message> {
     let sort_options = tab_opt.map(|tab| tab.sort_options());
@@ -529,6 +530,12 @@ pub fn menu_bar<'a>(
                 }
             }
         }
+    };
+
+    let (delete_item, delete_item_action) = if in_trash || modifiers.shift() {
+        (fl!("delete-permanently"), Action::Delete)
+    } else {
+        (fl!("move-to-trash"), Action::Delete)
     };
 
     responsive_menu_bar()
@@ -569,14 +576,11 @@ pub fn menu_bar<'a>(
                         ),
                         menu::Item::Divider,
                         menu_button_optional(
-                            if in_trash {
-                                fl!("delete-permanently")
-                            } else {
-                                fl!("move-to-trash")
-                            },
-                            Action::Delete,
-                            selected > 0,
+                            fl!("restore-from-trash"),
+                            Action::RestoreFromTrash,
+                            selected > 0 && in_trash,
                         ),
+                        menu_button_optional(delete_item, delete_item_action, selected > 0),
                         menu::Item::Divider,
                         menu::Item::Button(fl!("close-tab"), None, Action::TabClose),
                         menu::Item::Button(fl!("quit"), None, Action::WindowClose),

--- a/src/menu.rs
+++ b/src/menu.rs
@@ -2,7 +2,7 @@
 
 use cosmic::{
     app::Core,
-    iced::{Alignment, Background, Border, Length},
+    iced::{keyboard::Modifiers, Alignment, Background, Border, Length},
     theme,
     widget::{
         self, button, column, container, divider, horizontal_space,
@@ -55,6 +55,7 @@ fn menu_button_optional(
 pub fn context_menu<'a>(
     tab: &Tab,
     key_binds: &HashMap<KeyBind, Action>,
+    modifiers: &Modifiers,
 ) -> Element<'a, tab::Message> {
     let find_key = |action: &Action| -> String {
         for (key_bind, key_action) in key_binds.iter() {
@@ -216,7 +217,13 @@ pub fn context_menu<'a>(
                     children.push(menu_item(fl!("add-to-sidebar"), Action::AddToSidebar).into());
                 }
                 children.push(divider::horizontal::light().into());
-                children.push(menu_item(fl!("move-to-trash"), Action::Delete).into());
+                if modifiers.shift() && !modifiers.control() {
+                    children.push(
+                        menu_item(fl!("delete-permanently"), Action::PermanentlyDelete).into(),
+                    );
+                } else {
+                    children.push(menu_item(fl!("move-to-trash"), Action::Delete).into());
+                }
             } else {
                 //TODO: need better designs for menu with no selection
                 //TODO: have things like properties but they apply to the folder?

--- a/src/operation/mod.rs
+++ b/src/operation/mod.rs
@@ -490,6 +490,10 @@ pub enum Operation {
     NewFolder {
         path: PathBuf,
     },
+    /// Permanently delete items, skipping the trash
+    PermanentlyDelete {
+        paths: Vec<PathBuf>,
+    },
     Rename {
         from: PathBuf,
         to: PathBuf,
@@ -593,6 +597,7 @@ impl Operation {
                 name = file_name(path),
                 parent = parent_name(path)
             ),
+            Self::PermanentlyDelete { paths } => fl!("permanently-deleting", items = paths.len()),
             Self::Rename { from, to } => {
                 fl!("renaming", from = file_name(from), to = file_name(to))
             }
@@ -651,6 +656,7 @@ impl Operation {
                 name = file_name(path),
                 parent = parent_name(path)
             ),
+            Self::PermanentlyDelete { paths } => fl!("permanently-deleted", items = paths.len()),
             Self::Rename { from, to } => fl!("renamed", from = file_name(from), to = file_name(to)),
             Self::Restore { items } => fl!("restored", items = items.len()),
             Self::SetExecutableAndLaunch { path } => {
@@ -669,6 +675,7 @@ impl Operation {
             | Self::EmptyTrash
             | Self::Extract { .. }
             | Self::Move { .. }
+            | Self::PermanentlyDelete { .. }
             | Self::Restore { .. } => true,
             Self::NewFile { .. }
             | Self::NewFolder { .. }
@@ -1054,6 +1061,32 @@ impl Operation {
             .await
             .map_err(wrap_compio_spawn_error)?
             .map_err(OperationError::from_str),
+            Self::PermanentlyDelete { paths } => {
+                let total = paths.len();
+                for (idx, path) in paths.into_iter().enumerate() {
+                    controller.check().await.map_err(OperationError::from_str)?;
+
+                    controller.set_progress((idx as f32) / (total as f32));
+
+                    tokio::task::spawn_blocking(|| {
+                        if path.is_symlink() || path.is_file() {
+                            fs::remove_file(path)
+                        } else if path.is_dir() {
+                            fs::remove_dir_all(path)
+                        } else {
+                            Err(std::io::Error::new(
+                                std::io::ErrorKind::InvalidData,
+                                "File to delete is not symlink, file or directory",
+                            ))
+                        }
+                    })
+                    .await
+                    .map_err(OperationError::from_str)?
+                    .map_err(OperationError::from_str)?;
+                }
+
+                Ok(OperationSelection::default())
+            }
             Self::Rename { from, to } => compio::runtime::spawn(async move {
                 controller.check().await.map_err(OperationError::from_str)?;
                 compio::fs::rename(&from, &to)

--- a/src/tab.rs
+++ b/src/tab.rs
@@ -4855,10 +4855,12 @@ impl Tab {
         let mut popover = widget::popover(mouse_area);
 
         if let Some(point) = self.context_menu {
+            let context_menu = menu::context_menu(self, key_binds, &self.modifiers);
             popover = popover
-                .popup(menu::context_menu(self, key_binds))
+                .popup(context_menu)
                 .position(widget::popover::Position::Point(point));
         }
+
         let mut tab_column = widget::column::with_capacity(3);
         if let Some(location_view) = location_view_opt {
             tab_column = tab_column.push(location_view);

--- a/src/tab.rs
+++ b/src/tab.rs
@@ -1257,6 +1257,7 @@ pub enum Message {
     ItemUp,
     Location(Location),
     LocationUp,
+    ModifiersChanged(Modifiers),
     Open(Option<PathBuf>),
     RightClick(Option<usize>),
     MiddleClick(usize),
@@ -1898,6 +1899,7 @@ pub struct Tab {
     select_range: Option<(usize, usize)>,
     clicked: Option<usize>,
     selected_clicked: bool,
+    modifiers: Modifiers,
     last_right_click: Option<usize>,
     search_context: Option<SearchContext>,
     global_cursor_position: Option<Point>,
@@ -1994,6 +1996,7 @@ impl Tab {
             clicked: None,
             dnd_hovered: None,
             selected_clicked: false,
+            modifiers: Modifiers::default(),
             last_right_click: None,
             search_context: None,
             global_cursor_position: None,
@@ -3033,6 +3036,9 @@ impl Tab {
                         cd = Some(Location::Path(parent.to_owned()));
                     }
                 }
+            }
+            Message::ModifiersChanged(modifiers) => {
+                self.modifiers = modifiers;
             }
             Message::Open(path_opt) => {
                 match path_opt {


### PR DESCRIPTION
I have started this by rebase https://github.com/pop-os/cosmic-files/pull/359 from @dengelt.

And I have modified to handle `shift` modifier in contextual menu option and dialog menu.
As result, I have removed the _now useless_ option to enable/or not  `permanently delete` functionality.

I also rename `Modifiers` message to `ModifiersChanged` as it's directly linked to `KeyEvent::ModifiersChanged`, but I can remove the relative commit if it is preferred.