### PR TITLE
Fix move to home location on unmount

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -2547,7 +2547,7 @@ impl Application for App {
                                     }
                                 }
                                 if !still_mounted {
-                                    unmounted.push(Location::Path(old_path));
+                                    unmounted.push(old_path);
                                 }
                             }
                         }
@@ -2562,7 +2562,12 @@ impl Application for App {
                     for entity in entities {
                         let title_opt = match self.tab_model.data_mut::<Tab>(entity) {
                             Some(tab) => {
-                                if unmounted.contains(&tab.location) {
+                                if unmounted.iter().any(|unmounted| {
+                                    tab.location
+                                        .path_opt()
+                                        .map(|location| location.starts_with(unmounted))
+                                        .unwrap_or(false)
+                                }) {
                                     tab.change_location(&home_location, None);
                                     Some(tab.title())
                                 } else {


### PR DESCRIPTION
Previously this would only work if the root of the unmounted file-system is open in a tab. This also checks for any sub-path.

fixes: #915