### PR TITLE
bugfix to zooming where releasing CTRL outside of a mouse_area causes modifier to 'stick'

### DIFF
--- a/examples/copy.rs
+++ b/examples/copy.rs
@@ -1,5 +1,6 @@
 use cosmic_files::operation::{recursive::Context, Controller, ReplaceResult};
 use std::{error::Error, io, path::PathBuf};
+use cosmic_files::operation::recursive::Method;
 
 #[compio::main]
 async fn main() -> Result<(), Box<dyn Error>> {
@@ -30,13 +31,13 @@ async fn main() -> Result<(), Box<dyn Error>> {
     context
         .recursive_copy_or_move(
             vec![(PathBuf::from("test/a"), PathBuf::from("test/b"))],
-            false,
+            Method::Copy,
         )
         .await?;
     context
         .recursive_copy_or_move(
             vec![(PathBuf::from("test/b"), PathBuf::from("test/c"))],
-            true,
+            Method::Move { cross_device_copy: false },
         )
         .await?;
 

--- a/src/tab.rs
+++ b/src/tab.rs
@@ -4924,7 +4924,7 @@ impl Tab {
             .on_resize(|_, _| Message::ScrollToFocus)
             .on_back_press(move |_point_opt| Message::GoPrevious)
             .on_forward_press(move |_point_opt| Message::GoNext)
-            .on_scroll(respond_to_scroll_direction);
+            .on_scroll(|delta| respond_to_scroll_direction(delta, self.modifiers));
 
         if self.context_menu.is_some() {
             mouse_area = mouse_area.on_right_press(move |_point_opt| Message::ContextMenu(None));


### PR DESCRIPTION
**changes tl;dr**
- in the current version, zooming with mouse relies on an `on_scroll` event captured on the `mouse_area`
- if you hold CTRL while inside a mouse area, and then move your cursor out, the state never updates since the key release never reaches the mouse area
- instead, we now use the existing global modifiers to ensure zooming works as expected in this edge case

(also, fixes the `copy` example since it was erroring)

demonstration:

https://github.com/user-attachments/assets/94576f44-18db-4639-8050-a2420880147c

to replicate:
- mouse over a tab
- hold CTRL
- move to the sidebar, or elsewhere in the program (tab header, etc)
- release CTRL
- mouse over a tab again
- try to scroll up/down
