### PR TITLE
i18n(en) add singular and plural to English and Dutch translations

### DIFF
--- a/i18n/en/cosmic_files.ftl
+++ b/i18n/en/cosmic_files.ftl
@@ -30,8 +30,14 @@ size = Size
 # Progress footer
 details = Details
 dismiss = Dismiss message
-operations-running = {$running} operations running ({$percent}%)...
-operations-running-finished = {$running} operations running ({$percent}%), {$finished} finished...
+operations-running = {$running} {$running -> 
+    [one] operation
+    *[other] operations 
+  } running ({$percent}%)...
+operations-running-finished = {$running} {$running -> 
+    [one] operation
+    *[other] operations
+  } running ({$percent}%), {$finished} finished...
 pause = Pause
 resume = Resume
 

--- a/i18n/nl/cosmic_files.ftl
+++ b/i18n/nl/cosmic_files.ftl
@@ -30,15 +30,21 @@ size = Grootte
 # Progress footer
 details = Details
 dismiss = Bericht negeren
-operations-running = {$running} bewerkingen uitvoeren ({$percent}%)...
-operations-running-finished = {$running} bewerkingen uitvoeren ({$percent}%), {$finished} voltooid...
+operations-running = {$running} {$running -> 
+    [one] bewerking
+    *[other] bewerkingen 
+  } uitvoeren ({$percent}%)...
+operations-running-finished = {$running} {$running -> 
+    [one] bewerking
+    *[other] bewerkingen 
+  } uitvoeren ({$percent}%), {$finished} voltooid...
 pause = Pauzeren
 resume = Hervatten
 
 # Dialogs
 
 ## Compress Dialog
-create-archive = Maak een archiefbestand
+create-archive = Archiefbestand maken
 
 ## Extract Dialog
 extract-password-required = Wachtwoord vereist


### PR DESCRIPTION
*Notice: changes English source language!*

adding a singular and a plural to `operations-running` and `operations-running-finished` within  `# process footer`