### PR TITLE
Scan network items from all available mounters

### DIFF
--- a/src/tab.rs
+++ b/src/tab.rs
@@ -1032,16 +1032,17 @@ pub fn scan_recents(sizes: IconSizes) -> Vec<Item> {
 }
 
 pub fn scan_network(uri: &str, sizes: IconSizes) -> Vec<Item> {
+    let mut all_items = Vec::new();
     for (_key, mounter) in MOUNTERS.iter() {
         match mounter.network_scan(uri, sizes) {
-            Some(Ok(items)) => return items,
+            Some(Ok(items)) => all_items.extend(items),
             Some(Err(err)) => {
                 log::warn!("failed to scan {:?}: {}", uri, err);
             }
             None => {}
         }
     }
-    Vec::new()
+    all_items
 }
 
 //TODO: organize desktop items based on display


### PR DESCRIPTION
This PR updates the scan_network function to aggregate results from all registered mounters instead of returning early after the first successful scan.
Previously, the function would return items from the first mounter that responded successfully. This prevented other backends from contributing results.