### PR TITLE
drastically speed up gvfs mount directory listings

### DIFF
--- a/src/tab.rs
+++ b/src/tab.rs
@@ -2035,71 +2035,67 @@ impl Item {
 
                 let mode = metadata.mode();
 
-                    let user_name = get_user_by_uid(metadata.uid())
-                        .and_then(|user| user.name().to_str().map(ToOwned::to_owned))
-                        .unwrap_or_default();
-                    let user_path = path.clone();
-                    settings.push(
-                        widget::settings::item::builder(user_name)
-                            .description(fl!("owner"))
-                            .control(widget::dropdown(
-                                Cow::Borrowed(MODE_NAMES.as_slice()),
-                                Some(get_mode_part(mode, MODE_SHIFT_USER).try_into().unwrap()),
-                                move |selected| {
-                                    Message::SetPermissions(
-                                        user_path.clone(),
-                                        set_mode_part(
-                                            mode,
-                                            MODE_SHIFT_USER,
-                                            selected.try_into().unwrap(),
-                                        ),
-                                    )
-                                },
-                            )),
-                    );
-
-                    let group_name = get_group_by_gid(metadata.gid())
-                        .and_then(|group| group.name().to_str().map(ToOwned::to_owned))
-                        .unwrap_or_default();
-                    let group_path = path.clone();
-                    settings.push(
-                        widget::settings::item::builder(group_name)
-                            .description(fl!("group"))
-                            .control(widget::dropdown(
-                                Cow::Borrowed(MODE_NAMES.as_slice()),
-                                Some(get_mode_part(mode, MODE_SHIFT_GROUP).try_into().unwrap()),
-                                move |selected| {
-                                    Message::SetPermissions(
-                                        group_path.clone(),
-                                        set_mode_part(
-                                            mode,
-                                            MODE_SHIFT_GROUP,
-                                            selected.try_into().unwrap(),
-                                        ),
-                                    )
-                                },
-                            )),
-                    );
-
-                    let other_path = path.clone();
-                    settings.push(widget::settings::item::builder(fl!("other")).control(
-                        widget::dropdown(
+                let user_name = get_user_by_uid(metadata.uid())
+                    .and_then(|user| user.name().to_str().map(ToOwned::to_owned))
+                    .unwrap_or_default();
+                let user_path = path.clone();
+                settings.push(
+                    widget::settings::item::builder(user_name)
+                        .description(fl!("owner"))
+                        .control(widget::dropdown(
                             Cow::Borrowed(MODE_NAMES.as_slice()),
-                            Some(get_mode_part(mode, MODE_SHIFT_OTHER).try_into().unwrap()),
+                            Some(get_mode_part(mode, MODE_SHIFT_USER).try_into().unwrap()),
                             move |selected| {
                                 Message::SetPermissions(
-                                    other_path.clone(),
+                                    user_path.clone(),
                                     set_mode_part(
                                         mode,
-                                        MODE_SHIFT_OTHER,
+                                        MODE_SHIFT_USER,
                                         selected.try_into().unwrap(),
                                     ),
                                 )
                             },
-                        ),
-                    ));
-                }
+                        )),
+                );
+
+                let group_name = get_group_by_gid(metadata.gid())
+                    .and_then(|group| group.name().to_str().map(ToOwned::to_owned))
+                    .unwrap_or_default();
+                let group_path = path.clone();
+                settings.push(
+                    widget::settings::item::builder(group_name)
+                        .description(fl!("group"))
+                        .control(widget::dropdown(
+                            Cow::Borrowed(MODE_NAMES.as_slice()),
+                            Some(get_mode_part(mode, MODE_SHIFT_GROUP).try_into().unwrap()),
+                            move |selected| {
+                                Message::SetPermissions(
+                                    group_path.clone(),
+                                    set_mode_part(
+                                        mode,
+                                        MODE_SHIFT_GROUP,
+                                        selected.try_into().unwrap(),
+                                    ),
+                                )
+                            },
+                        )),
+                );
+
+                let other_path = path.clone();
+                settings.push(widget::settings::item::builder(fl!("other")).control(
+                    widget::dropdown(
+                        Cow::Borrowed(MODE_NAMES.as_slice()),
+                        Some(get_mode_part(mode, MODE_SHIFT_OTHER).try_into().unwrap()),
+                        move |selected| {
+                            Message::SetPermissions(
+                                other_path.clone(),
+                                set_mode_part(mode, MODE_SHIFT_OTHER, selected.try_into().unwrap()),
+                            )
+                        },
+                    ),
+                ));
             }
+        }
 
         if let ItemThumbnail::Image(_, Some((width, height))) = self
             .thumbnail_opt

--- a/src/tab.rs
+++ b/src/tab.rs
@@ -4875,7 +4875,7 @@ impl Tab {
         let row_height = icon_size + 2 * space_xxs;
 
         let mut children: Vec<Element<_>> = Vec::new();
-        let mut y = 0;
+        let mut y: f32 = 0.0;
 
         let rule_padding = theme::active().cosmic().corner_radii.radius_xs[0] as u16;
 
@@ -4893,7 +4893,7 @@ impl Tab {
                 }
                 item.pos_opt.set(Some((count, 0)));
                 item.rect_opt.set(Some(Rectangle::new(
-                    Point::new(space_m as f32, y as f32),
+                    Point::new(space_m as f32, y),
                     Size::new(size.width - (2 * space_m) as f32, row_height as f32),
                 )));
 
@@ -4903,7 +4903,7 @@ impl Tab {
                             .padding([0, rule_padding])
                             .into(),
                     );
-                    y += 1;
+                    y += 1.0;
                 }
 
                 let modified_text = match &item.metadata {
@@ -5164,7 +5164,7 @@ impl Tab {
                 }
 
                 count += 1;
-                y += row_height;
+                y += row_height as f32;
                 children.push(button_row);
             }
 


### PR DESCRIPTION
listing a directory inside a gvfs mount can be currently extremely laggy (ex: `DCIM/Camera` directory on my phone, which has ~1300 items, takes ~25 seconds to list everything)

**changes tl;dr**
- use `gio::prelude::FileExt::enumerate_children` to loop through a directory if it's inside a gvfs mount, rather than using `fs::read_dir`
- for gvfs directories, use a new `ItemMetadata::GvfsPath` to allow grabbing some meta directly from gio to avoid seemingly more expensive `fs::` operations
- for gvfs directories, always assume `remote = true` for the purposes of guessing mime types (to avoid having to read the file)

for me, this loads up my `DCIM/Camera` folder in ~75ms instead :D 

this is (mostly) functional, but leaving as a draft until i can fix the following:
- [x] thumbnail generation
- [x] show details
- [x] show image with `<SPACE>`