### PR TITLE
Save/simplify show hidden items

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -227,9 +227,7 @@ impl Action {
             Action::TabViewGrid => Message::TabView(entity_opt, tab::View::Grid),
             Action::TabViewList => Message::TabView(entity_opt, tab::View::List),
             Action::ToggleFoldersFirst => Message::ToggleFoldersFirst,
-            Action::ToggleShowHidden => {
-                Message::TabMessage(entity_opt, tab::Message::ToggleShowHidden)
-            }
+            Action::ToggleShowHidden => Message::ToggleShowHidden,
             Action::ToggleSort(sort) => {
                 Message::TabMessage(entity_opt, tab::Message::ToggleSort(*sort))
             }
@@ -382,6 +380,7 @@ pub enum Message {
     TimeConfigChange(TimeConfig),
     ToggleContextPage(ContextPage),
     ToggleFoldersFirst,
+    ToggleShowHidden,
     Undo(usize),
     UndoTrash(widget::ToastId, Arc<[PathBuf]>),
     UndoTrashStart(Vec<TrashItem>),
@@ -3442,6 +3441,11 @@ impl Application for App {
             Message::ToggleFoldersFirst => {
                 let mut config = self.config.tab;
                 config.folders_first = !config.folders_first;
+                return self.update(Message::TabConfig(config));
+            }
+            Message::ToggleShowHidden => {
+                let mut config = self.config.tab;
+                config.show_hidden = !config.show_hidden;
                 return self.update(Message::TabConfig(config));
             }
             Message::TabMessage(entity_opt, tab_message) => {

--- a/src/tab.rs
+++ b/src/tab.rs
@@ -1400,7 +1400,6 @@ pub enum Message {
     SetSort(HeadingOptions, bool),
     TabComplete(PathBuf, Vec<(String, PathBuf)>),
     Thumbnail(PathBuf, ItemThumbnail),
-    ToggleShowHidden,
     View(View),
     ToggleSort(HeadingOptions),
     Drop(Option<(Location, ClipboardPaste)>),
@@ -2798,14 +2797,23 @@ impl Tab {
             Message::Config(config) => {
                 // View is preserved for existing tabs
                 let view = self.config.view;
-                let show_hidden = self.config.show_hidden;
                 let military_time_changed = self.config.military_time != config.military_time;
+                let show_hidden_changed = self.config.show_hidden != config.show_hidden;
                 self.config = config;
                 self.config.view = view;
-                self.config.show_hidden = show_hidden;
                 if military_time_changed {
                     self.date_time_formatter = date_time_formatter(self.config.military_time);
                     self.time_formatter = time_formatter(self.config.military_time);
+                }
+                if show_hidden_changed {
+                    if let Location::Search(path, term, ..) = &self.location {
+                        cd = Some(Location::Search(
+                            path.clone(),
+                            term.clone(),
+                            self.config.show_hidden,
+                            Instant::now(),
+                        ));
+                    }
                 }
             }
             Message::ContextAction(action) => {
@@ -3496,17 +3504,6 @@ impl Tab {
                             break;
                         }
                     }
-                }
-            }
-            Message::ToggleShowHidden => {
-                self.config.show_hidden = !self.config.show_hidden;
-                if let Location::Search(path, term, ..) = &self.location {
-                    cd = Some(Location::Search(
-                        path.clone(),
-                        term.clone(),
-                        self.config.show_hidden,
-                        Instant::now(),
-                    ));
                 }
             }
             Message::View(view) => {


### PR DESCRIPTION
Closes: #1022, #605
See: #982
Original PR: #36

This commit reimplements saving the "show hidden" files setting. I simplified the implementation by making the toggle global. My original PR (#36) implemented per tab show hidden, but that complicates saving configs which is why (I think?) why the saving the toggle was scrapped.