### PR TITLE
simple fix some typos in comment or var name

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -3122,7 +3122,7 @@ impl Application for App {
 
                     self.complete_operations.insert(id, op);
                 }
-                // Close progress notification if all relavent operations are finished
+                // Close progress notification if all relevant operations are finished
                 if !self
                     .pending_operations
                     .iter()
@@ -3158,7 +3158,7 @@ impl Application for App {
                     self.failed_operations
                         .insert(id, (op, controller, err.to_string()));
                 }
-                // Close progress notification if all relavent operations are finished
+                // Close progress notification if all relevant operations are finished
                 if !self
                     .pending_operations
                     .iter()

--- a/src/clipboard.rs
+++ b/src/clipboard.rs
@@ -50,7 +50,7 @@ impl ClipboardCopy {
                     if !text_plain.is_empty() {
                         text_plain.push_str(cr_nl);
                     }
-                    //TOOD: what if the path contains CR or NL?
+                    //TODO: what if the path contains CR or NL?
                     text_plain.push_str(path_str);
                 }
                 None => {

--- a/src/operation/recursive.rs
+++ b/src/operation/recursive.rs
@@ -291,7 +291,7 @@ impl Op {
                 progress.total_bytes = Some(metadata.len());
                 (ctx.on_progress)(self, &progress);
                 if let Err(err) = to_file.set_permissions(metadata.permissions()).await {
-                    // This error is not propogated upwards as some filesystems do not support setting permissions
+                    // This error is not propagated upwards as some filesystems do not support setting permissions
                     log::warn!("failed to set permissions for {:?}: {}", self.to, err);
                 }
 

--- a/src/tab.rs
+++ b/src/tab.rs
@@ -405,12 +405,12 @@ fn time_bag(military_time: bool) -> components::Bag {
     let mut bag = components::Bag::empty();
     bag.hour = Some(components::Numeric::Numeric);
     bag.minute = Some(components::Numeric::Numeric);
-    let hour_cyle = if military_time {
+    let hour_cycle = if military_time {
         preferences::HourCycle::H23
     } else {
         preferences::HourCycle::H12
     };
-    bag.preferences = Some(preferences::Bag::from_hour_cycle(hour_cyle));
+    bag.preferences = Some(preferences::Bag::from_hour_cycle(hour_cycle));
     bag
 }
 


### PR DESCRIPTION
The typos were indicated by `typos` tool : https://github.com/crate-ci/typos/