### PR TITLE
add ability to pass appid through to file dialogs

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -66,6 +66,7 @@ use trash::TrashItem;
 #[cfg(all(feature = "wayland", feature = "desktop-applet"))]
 use wayland_client::{protocol::wl_output::WlOutput, Proxy};
 
+use crate::dialog::DialogSettings;
 use crate::{
     clipboard::{ClipboardCopy, ClipboardKind, ClipboardPaste},
     config::{
@@ -2562,8 +2563,9 @@ impl Application for App {
                     .map(|parent| parent.to_path_buf())
                 {
                     let (mut dialog, dialog_task) = Dialog::new(
-                        DialogKind::OpenFolder,
-                        Some(destination),
+                        DialogSettings::new()
+                            .kind(DialogKind::OpenFolder)
+                            .path(destination),
                         Message::FileDialogMessage,
                         Message::ExtractToResult,
                     );

--- a/src/dialog.rs
+++ b/src/dialog.rs
@@ -211,21 +211,21 @@ pub struct DialogSettings {
 }
 
 impl DialogSettings {
-    pub fn new() -> DialogSettings {
+    pub fn new() -> Self {
         Default::default()
     }
 
-    pub fn app_id(mut self, app_id: String) -> DialogSettings {
+    pub fn app_id(mut self, app_id: String) -> Self {
         self.app_id = app_id;
         self
     }
 
-    pub fn kind(mut self, kind: DialogKind) -> DialogSettings {
+    pub fn kind(mut self, kind: DialogKind) -> Self {
         self.kind = kind;
         self
     }
 
-    pub fn path(mut self, path: PathBuf) -> DialogSettings {
+    pub fn path(mut self, path: PathBuf) -> Self {
         self.path_opt = Some(path);
         self
     }


### PR DESCRIPTION
**changes tl;dr**
- add new `Dialog::create()` method w/ new `DialogSettings` struct
- deprecate `Dialog::new()` in favour of `Dialog::create()`

this allows passing the appid for file dialogs, eg if i'm trying to open a file/folder via an xdg portal it'll currently create a new window with the appid **com.system76.CosmicFilesDialog**. this allows the xdg portal to pass through the appid of the requester, meaning that the windows can stay stacked/associated.

this also provides a more backwards compatible way to add new settings to dialogs in the future