### PR TITLE
thumbnail: Support jxl and plumbing for future formats.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -171,6 +171,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloc-no-stdlib"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3"
+
+[[package]]
+name = "alloc-stdlib"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94fb8275041c72129eb51b7d0322c29b8387a0386127718b096429201a5d6ece"
+dependencies = [
+ "alloc-no-stdlib",
+]
+
+[[package]]
 name = "almost"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -794,6 +809,16 @@ dependencies = [
  "futures-io",
  "futures-lite 2.6.0",
  "piper",
+]
+
+[[package]]
+name = "brotli-decompressor"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "874bb8112abecc98cbd6d81ea4fa7e94fb9449648c93cc89aa40c81c24d7de03"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
 ]
 
 [[package]]
@@ -1504,6 +1529,7 @@ dependencies = [
  "ignore",
  "image",
  "io-uring",
+ "jxl-oxide",
  "libc",
  "libcosmic",
  "log",
@@ -4171,6 +4197,186 @@ checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "jxl-bitstream"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eda699770a7f4ea38f8eb21d91b545eb6448be28e540acc7ce84498bcead4903"
+dependencies = [
+ "tracing",
+]
+
+[[package]]
+name = "jxl-coding"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6748ba8af69b87c68f8dcdf992de959c207962689bc28ddb7906abf4a0b786c9"
+dependencies = [
+ "jxl-bitstream",
+ "tracing",
+]
+
+[[package]]
+name = "jxl-color"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f316b1358c1711755b3ee8e8cb5c4a1dad12e796233088a7a513440782de80b2"
+dependencies = [
+ "jxl-bitstream",
+ "jxl-coding",
+ "jxl-grid",
+ "jxl-image",
+ "jxl-oxide-common",
+ "jxl-threadpool",
+ "tracing",
+]
+
+[[package]]
+name = "jxl-frame"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f30587a9687223a602a408555db47803c907ea47700e1f28eb14cdb3bf1527a9"
+dependencies = [
+ "jxl-bitstream",
+ "jxl-coding",
+ "jxl-grid",
+ "jxl-image",
+ "jxl-modular",
+ "jxl-oxide-common",
+ "jxl-threadpool",
+ "jxl-vardct",
+ "tracing",
+]
+
+[[package]]
+name = "jxl-grid"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "335e4371396c5729ba80a42798746d198897d3b854ba4f3684efac5f4025d84f"
+dependencies = [
+ "tracing",
+]
+
+[[package]]
+name = "jxl-image"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5f752d62577c702a94dbbce4045caf08cb58639e8a4d56464b40ecf33ffe565"
+dependencies = [
+ "jxl-bitstream",
+ "jxl-grid",
+ "jxl-oxide-common",
+ "tracing",
+]
+
+[[package]]
+name = "jxl-jbr"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ba39b083a82788a17717edbcc4b08160b51fdffc9fec640deba9e8268da1a"
+dependencies = [
+ "brotli-decompressor",
+ "jxl-bitstream",
+ "jxl-frame",
+ "jxl-grid",
+ "jxl-image",
+ "jxl-modular",
+ "jxl-oxide-common",
+ "jxl-threadpool",
+ "jxl-vardct",
+ "tracing",
+]
+
+[[package]]
+name = "jxl-modular"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f526ad8af8daea0d1cccce945f18c241f95b391d34443be018de2efbf28b44e"
+dependencies = [
+ "jxl-bitstream",
+ "jxl-coding",
+ "jxl-grid",
+ "jxl-oxide-common",
+ "jxl-threadpool",
+ "tracing",
+]
+
+[[package]]
+name = "jxl-oxide"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e45ccb25d698cdcad3a5573a7181835842711fd951c98fe38986e3cb721e775"
+dependencies = [
+ "brotli-decompressor",
+ "bytemuck",
+ "image",
+ "jxl-bitstream",
+ "jxl-color",
+ "jxl-frame",
+ "jxl-grid",
+ "jxl-image",
+ "jxl-jbr",
+ "jxl-oxide-common",
+ "jxl-render",
+ "jxl-threadpool",
+ "tracing",
+]
+
+[[package]]
+name = "jxl-oxide-common"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b62394c5021b3a9e7e0dbb2d639d555d019090c9946c39f6d3b09d390db4157b"
+dependencies = [
+ "jxl-bitstream",
+]
+
+[[package]]
+name = "jxl-render"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3f3fece78b2104450bd6d1bdbc48e3b6ef7442ef276be2a08e35b229eeff1a4"
+dependencies = [
+ "bytemuck",
+ "jxl-bitstream",
+ "jxl-coding",
+ "jxl-color",
+ "jxl-frame",
+ "jxl-grid",
+ "jxl-image",
+ "jxl-modular",
+ "jxl-oxide-common",
+ "jxl-threadpool",
+ "jxl-vardct",
+ "tracing",
+]
+
+[[package]]
+name = "jxl-threadpool"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25f15eb830aa77a7f21148d72e153562a26bfe570139bd4922eab1908dd499d3"
+dependencies = [
+ "rayon",
+ "rayon-core",
+ "tracing",
+]
+
+[[package]]
+name = "jxl-vardct"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d48ad406543de5d6cd50aaaa8b87534f82991d684d848b3190228e8fa690fff"
+dependencies = [
+ "jxl-bitstream",
+ "jxl-coding",
+ "jxl-grid",
+ "jxl-modular",
+ "jxl-oxide-common",
+ "jxl-threadpool",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,6 +70,7 @@ zip = "2.2.2"
 uzers = "0.12.1"
 md-5 = "0.10.6"
 png = "0.17.16"
+jxl-oxide = { version = "0.12.2", features = ["image"] }
 
 # Completion-based IO runtime to enable io_uring / IOCP file IO support.
 [dependencies.compio]

--- a/src/app.rs
+++ b/src/app.rs
@@ -1001,6 +1001,7 @@ impl App {
         let mut tab = Tab::new(
             location.clone(),
             self.config.tab,
+            self.config.thumb_cfg,
             Some(&self.state.sort_names),
             window_id,
         );
@@ -6114,7 +6115,7 @@ pub(crate) mod test_utils {
     use tempfile::{tempdir, TempDir};
 
     use crate::{
-        config::{IconSizes, TabConfig},
+        config::{IconSizes, TabConfig, ThumbCfg},
         tab::Item,
     };
 
@@ -6278,7 +6279,7 @@ pub(crate) mod test_utils {
         // New tab with items
         let location = Location::Path(path.to_owned());
         let (parent_item_opt, items) = location.scan(IconSizes::default());
-        let mut tab = Tab::new(location, TabConfig::default(), None);
+        let mut tab = Tab::new(location, TabConfig::default(), ThumbCfg::default(), None);
         tab.parent_item_opt = parent_item_opt;
         tab.set_items(items);
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -288,6 +288,9 @@ impl Default for DialogConfig {
             show_details: true,
             show_hidden: false,
             view: View::List,
+        }
+    }
+}
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, CosmicConfigEntry, Deserialize, Serialize)]
 #[serde(default)]
 pub struct ThumbCfg {

--- a/src/config.rs
+++ b/src/config.rs
@@ -166,6 +166,7 @@ pub struct Config {
     pub app_theme: AppTheme,
     pub dialog: DialogConfig,
     pub desktop: DesktopConfig,
+    pub thumb_cfg: ThumbCfg,
     pub favorites: Vec<Favorite>,
     pub show_details: bool,
     pub tab: TabConfig,
@@ -220,6 +221,7 @@ impl Default for Config {
             app_theme: AppTheme::System,
             desktop: DesktopConfig::default(),
             dialog: DialogConfig::default(),
+            thumb_cfg: ThumbCfg::default(),
             favorites: vec![
                 Favorite::Home,
                 Favorite::Documents,
@@ -286,6 +288,20 @@ impl Default for DialogConfig {
             show_details: true,
             show_hidden: false,
             view: View::List,
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, CosmicConfigEntry, Deserialize, Serialize)]
+#[serde(default)]
+pub struct ThumbCfg {
+    pub jobs: NonZeroU16,
+    pub max_mem_mb: NonZeroU16,
+    pub max_size_mb: NonZeroU16,
+}
+
+impl Default for ThumbCfg {
+    fn default() -> Self {
+        Self {
+            jobs: 4.try_into().unwrap(),
+            max_mem_mb: 2000.try_into().unwrap(),
+            max_size_mb: 64.try_into().unwrap(),
         }
     }
 }

--- a/src/dialog.rs
+++ b/src/dialog.rs
@@ -945,13 +945,13 @@ impl Application for App {
             },
         });
 
-        let tab_config = TabConfig {
-            view: tab::View::List,
-            folders_first: false,
-            ..Default::default()
-        };
-
-        let mut tab = Tab::new(location, flags.config.dialog_tab(), tab_config, ThumbCfg::default(), None);
+        let mut tab = Tab::new(
+            location,
+            flags.config.dialog_tab(),
+            ThumbCfg::default(),
+            None,
+            None,
+        );
         tab.mode = tab::Mode::Dialog(flags.kind.clone());
         tab.sort_name = tab::HeadingOptions::Modified;
         tab.sort_direction = false;

--- a/src/dialog.rs
+++ b/src/dialog.rs
@@ -36,7 +36,7 @@ use std::{
 
 use crate::{
     app::{Action, ContextPage, Message as AppMessage, PreviewItem, PreviewKind},
-    config::{Config, DialogConfig, Favorite, TimeConfig, TIME_CONFIG_ID},
+    config::{Config, DialogConfig, Favorite, TabConfig, ThumbCfg, TimeConfig, TIME_CONFIG_ID},
     fl, home_dir,
     key_bind::key_binds,
     localize::LANGUAGE_SORTER,
@@ -945,7 +945,13 @@ impl Application for App {
             },
         });
 
-        let mut tab = Tab::new(location, flags.config.dialog_tab(), None, None);
+        let tab_config = TabConfig {
+            view: tab::View::List,
+            folders_first: false,
+            ..Default::default()
+        };
+
+        let mut tab = Tab::new(location, flags.config.dialog_tab(), tab_config, ThumbCfg::default(), None);
         tab.mode = tab::Mode::Dialog(flags.kind.clone());
         tab.sort_name = tab::HeadingOptions::Modified;
         tab.sort_direction = false;

--- a/src/tab.rs
+++ b/src/tab.rs
@@ -1778,7 +1778,7 @@ impl ItemThumbnail {
                             }
                         },
                         Err(err) => {
-                            log::warn!("failed to turn path into file {:?}: {}", path, err);
+                            log::warn!("failed to create jxl decoder {:?}: {}", path, err);
                             None
                         }
                     },

--- a/src/tab.rs
+++ b/src/tab.rs
@@ -73,9 +73,7 @@ use walkdir::WalkDir;
 use crate::{
     app::{Action, PreviewItem, PreviewKind},
     clipboard::{ClipboardCopy, ClipboardKind, ClipboardPaste},
-    config::{
-        Config, DesktopConfig, IconSizes, TabConfig, ThumbCfg, ICON_SCALE_MAX, ICON_SIZE_GRID,
-    },
+    config::{DesktopConfig, IconSizes, TabConfig, ThumbCfg, ICON_SCALE_MAX, ICON_SIZE_GRID},
     dialog::DialogKind,
     fl,
     localize::{LANGUAGE_SORTER, LOCALE},
@@ -5572,8 +5570,6 @@ impl Tab {
     pub fn subscription(&self, preview: bool) -> Subscription<Message> {
         //TODO: how many thumbnail loads should be in flight at once?
         let jobs = self.thumb_config.jobs.get().clone() as usize;
-        let max_mem_mb = self.thumb_config.max_mem_mb.get().clone() as u64;
-
         let mut subscriptions = Vec::with_capacity(jobs + 3);
 
         if let Some(items) = &self.items_opt {
@@ -5619,8 +5615,8 @@ impl Tab {
                 };
                 if can_thumbnail {
                     let mime = item.mime.clone();
-                    let max_mb = max_mem_mb.clone();
                     let max_jobs = jobs.clone();
+                    let max_mb = self.thumb_config.max_mem_mb.get().clone() as u64;
                     let max_size = self.thumb_config.max_size_mb.get().clone() as u64;
                     subscriptions.push(Subscription::run_with_id(
                         ("thumbnail", path.clone()),

--- a/src/tab.rs
+++ b/src/tab.rs
@@ -1762,7 +1762,7 @@ impl ItemThumbnail {
         };
 
         let mut tried_supported_file = false;
-        if !check_size("image", 64 * 1000 * 1000) {
+        if !check_size("image", max_size_mb * 1000 * 1000) {
             return ItemThumbnail::NotImage;
         }
         // First try built-in image thumbnailer


### PR DESCRIPTION
This will allow using jxl-oxide for thumbnail creation, it seems to be working well for me but it's a draft for a couple reasons, the primary one is im not sure the best resource limit to set. I feel like this should be set in a configuration, but even then I don't know what defaults should be used.

the current value I found to be necessary for some of my images, but likely way to high for lower end systems. (that being said, hitting an oom case in cosmic-files is much better then having a thumbnailer oom since oomd will actually kill cosmic-files instead of the entire compositor)