### PR TITLE
Fix slow startup

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -1553,7 +1553,6 @@ impl App {
             // Watch new paths
             for path in new_paths.iter() {
                 if !old_paths.contains(path) {
-                    //TODO: should this be recursive?
                     match watcher
                         .watcher()
                         .watch(path, notify::RecursiveMode::NonRecursive)

--- a/src/app.rs
+++ b/src/app.rs
@@ -5852,7 +5852,7 @@ impl Application for App {
                             for path in trash_bins {
                                 if let Err(e) = watcher
                                     .watcher()
-                                    .watch(&path, notify::RecursiveMode::Recursive)
+                                    .watch(&path, notify::RecursiveMode::NonRecursive)
                                 {
                                     log::warn!(
                                         "failed to add trash bin `{}` to watcher: {e:?}",


### PR DESCRIPTION
Remove unnecessary watch of sub-directories in trash bins, which causes long startup times.

fixes #970
fixes #823