### PR TITLE
Decode URL encoded recents bookmark

### DIFF
--- a/src/tab.rs
+++ b/src/tab.rs
@@ -1137,8 +1137,14 @@ pub fn scan_trash(sizes: IconSizes) -> Vec<Item> {
 }
 
 fn uri_to_path(uri: String) -> Option<PathBuf> {
-    //TODO support for external drive or cloud?
-    uri.strip_prefix("file://").map(PathBuf::from)
+    uri.parse::<url::Url>().ok().and_then(|url| {
+        //TODO support for external drive or cloud?
+        if url.scheme() == "file" {
+            url.to_file_path().ok()
+        } else {
+            None
+        }
+    })
 }
 
 pub fn scan_recents(sizes: IconSizes) -> Vec<Item> {


### PR DESCRIPTION
File paths are URL encoded in the recently-used.xbel file. Paths with spaces (or whatever) need to be decoded or else the Recents tab skips those entries.
---

An easy way to test this is to copy an image but add a space to its name e.g.:
```sh
cp img.jpg img\ meow.jpg
```

Open it. Then look at the COSMIC Files logs on the terminal. You'll see an error that is something like: "recent file path does not exist: img%20meow.jpg"
