### PR TITLE
feat: jxl support for gallery and preview

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2092,6 +2092,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
 name = "dyn-clone"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4322,6 +4328,7 @@ dependencies = [
  "jxl-oxide-common",
  "jxl-render",
  "jxl-threadpool",
+ "lcms2",
  "tracing",
 ]
 
@@ -4467,6 +4474,29 @@ name = "lazycell"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
+
+[[package]]
+name = "lcms2"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "680ec3fa42c36e0af9ca02f20a3742a82229c7f1ee0e6754294de46a80be6f74"
+dependencies = [
+ "bytemuck",
+ "foreign-types",
+ "lcms2-sys",
+]
+
+[[package]]
+name = "lcms2-sys"
+version = "4.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "593265f9a3172180024fb62580ee31348f31be924b19416da174ebb7fb623d2e"
+dependencies = [
+ "cc",
+ "dunce",
+ "libc",
+ "pkg-config",
+]
 
 [[package]]
 name = "lebe"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,8 +70,8 @@ zip = "2.2.2"
 uzers = "0.12.1"
 md-5 = "0.10.6"
 png = "0.17.16"
-jxl-oxide = { version = "0.12.2", features = ["image"] }
 num_cpus = "1.17.0"
+jxl-oxide = { version = "0.12.2", features = ["image", "lcms2", "rayon"] }
 
 # Completion-based IO runtime to enable io_uring / IOCP file IO support.
 [dependencies.compio]


### PR DESCRIPTION
Support JXL images in preview and thumbnail 

Things that need to be solved first 

* This is causing images not to render: https://github.com/tirr-c/jxl-oxide/issues/473
* I am using unwraps with the intention of having a place holder image as mentioned here https://github.com/pop-os/cosmic-files/issues/515

Questions

Should I also wire up using a thumbnailer for the preview pane and perhaps even gallery view? Personally I don't think gallery view should use the thumbnail but preview should.

Should the gallery view not open or should it display a place holder image? A placeholder image could show a "non compatible image" format which may be more user friendly then not opening the gallery at all.

Should I change thumbnailer to use a similar function (see below) or use the nested matches for gallery and preview?
```rs
jxl" => {
                    let jxldynimg = (|| {
                        let file = File::open(path).map_err(|err| {
                            log::warn!("failed to open file {:?}: {}", path, err);
                        }).ok()?;
                        let mut limits = image::Limits::default();
                        let max_ram = max_mem * 1000 * 1000 / jobs as u64;
                        limits.max_alloc = Some(max_ram);
                        let mut jxl = JxlDecoder::new(file).map_err(|err| {
                            log::warn!("to create JxlDecoder for {:?}: {}", path, err);
                        }).ok()?;
                        let _ = jxl.set_limits(limits);
                        Some(image::DynamicImage::from_decoder(jxl).map_err(|err| {
                            log::warn!("failed to decode the file {:?}: {}", path, err);
                            }).ok()?
                        )
                    })();
                    //TODO: This will be unwrap_or(generic image)
                    jxldynimg
                }
```