### PR TITLE
closes #980 implement reflink (copy-on-write) file copying with fallb…

### DIFF
--- a/src/operation/mod.rs
+++ b/src/operation/mod.rs
@@ -29,6 +29,7 @@ pub mod reader;
 
 use self::recursive::{Context, Method};
 pub mod recursive;
+pub mod reflink;
 
 async fn handle_replace(
     msg_tx: Arc<TokioMutex<Sender<Message>>>,

--- a/src/operation/reflink.rs
+++ b/src/operation/reflink.rs
@@ -1,0 +1,47 @@
+use std::io;
+use std::path::Path;
+
+/// Attempt to perform a reflink (copy-on-write) copy of a file
+pub async fn reflink_copy(from: &Path, to: &Path) -> Result<(), io::Error> {
+    // Use blocking IO for the reflink operation since compio doesn't expose ioctl
+    let from_path = from.to_path_buf();
+    let to_path = to.to_path_buf();
+
+    tokio::task::spawn_blocking(move || {
+        #[cfg(target_os = "linux")]
+        {
+            use libc::{ioctl, FICLONE};
+            use std::fs::File;
+            use std::os::unix::io::AsRawFd;
+
+            let src_file = File::open(&from_path)?;
+            let dst_file = File::create(&to_path)?;
+
+            let src_fd = src_file.as_raw_fd();
+            let dst_fd = dst_file.as_raw_fd();
+
+            // Call the FICLONE ioctl to perform the reflink copy
+            let result = unsafe { ioctl(dst_fd, FICLONE, src_fd) };
+
+            if result == 0 {
+                Ok(())
+            } else {
+                // Clean up on failure - remove the empty file
+                let _ = std::fs::remove_file(&to_path);
+                let errno = unsafe { *libc::__errno_location() };
+                Err(io::Error::from_raw_os_error(errno))
+            }
+        }
+
+        // For non-Linux systems, return an error indicating reflink is not supported
+        #[cfg(not(target_os = "linux"))]
+        {
+            Err(io::Error::new(
+                io::ErrorKind::Unsupported,
+                "Reflink copy not supported on this platform",
+            ))
+        }
+    })
+    .await
+    .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?
+}


### PR DESCRIPTION
This adds copy-on-write file cloning to improve storage efficiency on supported filesystems.

New `reflink.rs` module with Linux FICLONE ioctl support.
Updated copy operation to try reflink first, fall back to standard copy.
Works transparently on Btrfs, XFS, Bcachefs - falls back on others, or non-linux OS.

I think checking filesystem type is unreliable because:

Btrfs supports reflink but only on same filesystem
XFS supports reflink but has version requirements
ZFS supports reflink but via different mechanism
ext4 doesn't support reflink at all

In my opinion the cleanest approach is what we're doing:
Attempt the ioctl directly
Let the kernel tell us if it works or not
Clean up and fallback on failure

This is actually the standard approach used by tools like cp --reflink=auto - they don't pre-check, they just attempt and handle the failure gracefully.

```
/srv/opensource/cosmic/cosmic-files/target/release/tmp master
❯ btrfs filesystem du .
     Total   Exclusive  Set shared  Filename
  73.80MiB       0.00B           -  ./cosmic-files
  73.80MiB       0.00B    61.33MiB  .
  ```
  
  tested on BTRFS and EXT4