### PR TITLE
Fix extracting password protected archives

### DIFF
--- a/i18n/en/cosmic_files.ftl
+++ b/i18n/en/cosmic_files.ftl
@@ -185,6 +185,7 @@ no-history = No items in history.
 pending = Pending
 progress = {$percent}%
 progress-cancelled = {$percent}%, cancelled
+progress-failed = {$percent}%, failed
 progress-paused = {$percent}%, paused
 failed = Failed
 complete = Complete

--- a/src/archive.rs
+++ b/src/archive.rs
@@ -47,53 +47,58 @@ pub fn extract(
     controller: &Controller,
 ) -> Result<(), OperationError> {
     let mime = mime_for_path(path, None, false);
-    let controller = controller.clone();
     let password = password.clone();
     match mime.essence_str() {
-        "application/gzip" | "application/x-compressed-tar" => OpReader::new(path, controller)
+        "application/gzip" | "application/x-compressed-tar" => {
+            OpReader::new(path, controller.clone())
+                .map(io::BufReader::new)
+                .map(flate2::read::GzDecoder::new)
+                .map(tar::Archive::new)
+                .and_then(|mut archive| archive.unpack(new_dir))
+                .map_err(|e| OperationError::from_err(e, controller))?
+        }
+        "application/x-tar" => OpReader::new(path, controller.clone())
             .map(io::BufReader::new)
-            .map(flate2::read::GzDecoder::new)
             .map(tar::Archive::new)
-            .and_then(|mut archive| archive.unpack(&new_dir))
-            .map_err(OperationError::from_str)?,
-        "application/x-tar" => OpReader::new(path, controller)
-            .map(io::BufReader::new)
-            .map(tar::Archive::new)
-            .and_then(|mut archive| archive.unpack(&new_dir))
-            .map_err(OperationError::from_str)?,
+            .and_then(|mut archive| archive.unpack(new_dir))
+            .map_err(|e| OperationError::from_err(e, controller))?,
         "application/zip" => fs::File::open(path)
             .map(io::BufReader::new)
             .map(zip::ZipArchive::new)
-            .map_err(OperationError::from_str)?
-            .and_then(move |mut archive| zip_extract(&mut archive, &new_dir, password, controller))
+            .map_err(|e| OperationError::from_err(e, controller))?
+            .and_then(move |mut archive| {
+                zip_extract(&mut archive, new_dir, password, controller.clone())
+            })
             .map_err(|e| match e {
                 ZipError::UnsupportedArchive(ZipError::PASSWORD_REQUIRED)
-                | ZipError::InvalidPassword => OperationError {
-                    kind: OperationErrorType::PasswordRequired,
-                },
-                _ => OperationError::from_str(e),
+                | ZipError::InvalidPassword => {
+                    OperationError::from_kind(OperationErrorType::PasswordRequired, controller)
+                }
+                _ => OperationError::from_err(e, controller),
             })?,
         #[cfg(feature = "bzip2")]
         "application/x-bzip"
         | "application/x-bzip-compressed-tar"
         | "application/x-bzip2"
-        | "application/x-bzip2-compressed-tar" => OpReader::new(path, controller)
+        | "application/x-bzip2-compressed-tar" => OpReader::new(path, controller.clone())
             .map(io::BufReader::new)
             .map(bzip2::read::BzDecoder::new)
             .map(tar::Archive::new)
-            .and_then(|mut archive| archive.unpack(&new_dir))
-            .map_err(OperationError::from_str)?,
+            .and_then(|mut archive| archive.unpack(new_dir))
+            .map_err(|e| OperationError::from_err(e, controller))?,
         #[cfg(feature = "xz2")]
-        "application/x-xz" | "application/x-xz-compressed-tar" => OpReader::new(path, controller)
-            .map(io::BufReader::new)
-            .map(xz2::read::XzDecoder::new)
-            .map(tar::Archive::new)
-            .and_then(|mut archive| archive.unpack(&new_dir))
-            .map_err(OperationError::from_str)?,
-        _ => Err(OperationError::from_str(format!(
-            "unsupported mime type {:?}",
-            mime
-        )))?,
+        "application/x-xz" | "application/x-xz-compressed-tar" => {
+            OpReader::new(path, controller.clone())
+                .map(io::BufReader::new)
+                .map(xz2::read::XzDecoder::new)
+                .map(tar::Archive::new)
+                .and_then(|mut archive| archive.unpack(new_dir))
+                .map_err(|e| OperationError::from_err(e, controller))?
+        }
+        _ => Err(OperationError::from_err(
+            format!("unsupported mime type {:?}", mime),
+            controller,
+        ))?,
     }
     Ok(())
 }
@@ -135,7 +140,7 @@ fn zip_extract<R: io::Read + io::Seek, P: AsRef<Path>>(
             controller
                 .check()
                 .await
-                .map_err(|err| io::Error::new(io::ErrorKind::Other, err))
+                .map_err(|s| io::Error::other(OperationError::from_state(s, &controller)))
         })?;
 
         controller.set_progress((i as f32) / total_files as f32);
@@ -143,11 +148,10 @@ fn zip_extract<R: io::Read + io::Seek, P: AsRef<Path>>(
         let mut file = match &password {
             None => archive.by_index(i),
             Some(pwd) => archive.by_index_decrypt(i, pwd.as_bytes()),
-        }
-        .map_err(|e| e)?;
+        }?;
         let filepath = file
             .enclosed_name()
-            .ok_or(ZipError::InvalidArchive("Invalid file path".into()))?;
+            .ok_or(ZipError::InvalidArchive("Invalid file path"))?;
 
         let outpath = directory.as_ref().join(filepath);
 
@@ -206,8 +210,7 @@ fn zip_extract<R: io::Read + io::Seek, P: AsRef<Path>>(
         let mut file = match &password {
             None => archive.by_index(i),
             Some(pwd) => archive.by_index_decrypt(i, pwd.as_bytes()),
-        }
-        .map_err(|e| e)?;
+        }?;
 
         // create all pending dirs
         while let Some(pending_dir) = pending_directory_creates.pop_front() {
@@ -226,7 +229,7 @@ fn zip_extract<R: io::Read + io::Seek, P: AsRef<Path>>(
                 controller
                     .check()
                     .await
-                    .map_err(|err| io::Error::new(io::ErrorKind::Other, err))
+                    .map_err(|s| io::Error::other(OperationError::from_state(s, &controller)))
             })?;
 
             let count = file.read(&mut buffer)?;

--- a/src/operation/reader.rs
+++ b/src/operation/reader.rs
@@ -1,5 +1,7 @@
 use std::{fs, io, path::Path};
 
+use crate::operation::OperationError;
+
 use super::Controller;
 
 // Special reader just for operations, handling cancel and progress
@@ -29,7 +31,7 @@ impl io::Read for OpReader {
             self.controller
                 .check()
                 .await
-                .map_err(|err| io::Error::new(io::ErrorKind::Other, err))
+                .map_err(|s| io::Error::other(OperationError::from_state(s, &self.controller)))
         })?;
 
         let count = self.file.read(buf)?;

--- a/src/operation/recursive.rs
+++ b/src/operation/recursive.rs
@@ -7,6 +7,8 @@ use std::time::Instant;
 use std::{cell::Cell, error::Error, fs, ops::ControlFlow, path::PathBuf, rc::Rc};
 use walkdir::WalkDir;
 
+use crate::operation::OperationError;
+
 use super::{copy_unique_path, Controller, OperationSelection, ReplaceResult};
 
 pub enum Method {
@@ -52,11 +54,14 @@ impl Context {
         &mut self,
         from_to_pairs: Vec<(PathBuf, PathBuf)>,
         method: Method,
-    ) -> Result<bool, String> {
+    ) -> Result<bool, OperationError> {
         let mut ops = Vec::new();
         let mut cleanup_ops = Vec::new();
         for (from_parent, to_parent) in from_to_pairs {
-            self.controller.check().await?;
+            self.controller
+                .check()
+                .await
+                .map_err(|s| OperationError::from_state(s, &self.controller))?;
 
             if from_parent == to_parent {
                 // Skip matching source and destination
@@ -64,10 +69,16 @@ impl Context {
             }
 
             for entry in WalkDir::new(&from_parent).into_iter() {
-                self.controller.check().await?;
+                self.controller
+                    .check()
+                    .await
+                    .map_err(|s| OperationError::from_state(s, &self.controller))?;
 
                 let entry = entry.map_err(|err| {
-                    format!("failed to walk directory {:?}: {}", from_parent, err)
+                    OperationError::from_err(
+                        format!("failed to walk directory {:?}: {}", from_parent, err),
+                        &self.controller,
+                    )
                 })?;
                 let file_type = entry.file_type();
                 let from = entry.into_path();
@@ -79,21 +90,31 @@ impl Context {
                         Method::Move { cross_device_copy } => OpKind::Move { cross_device_copy },
                     }
                 } else if file_type.is_symlink() {
-                    let target = fs::read_link(&from)
-                        .map_err(|err| format!("failed to read link {:?}: {}", from, err))?;
+                    let target = fs::read_link(&from).map_err(|err| {
+                        OperationError::from_err(
+                            format!("failed to read link {:?}: {}", from, err),
+                            &self.controller,
+                        )
+                    })?;
                     OpKind::Symlink { target }
                 } else {
                     //TODO: present dialog and allow continue
-                    return Err(format!("{} is not a known file type", from.display()));
+                    return Err(OperationError::from_err(
+                        format!("{} is not a known file type", from.display()),
+                        &self.controller,
+                    ));
                 };
                 let to = if from == from_parent {
                     // When copying a file, from matches from_parent, and to_parent must be used
                     to_parent.clone()
                 } else {
                     let relative = from.strip_prefix(&from_parent).map_err(|err| {
-                        format!(
-                            "failed to remove prefix {:?} from {:?}: {}",
-                            from_parent, from, err
+                        OperationError::from_err(
+                            format!(
+                                "failed to remove prefix {:?} from {:?}: {}",
+                                from_parent, from, err
+                            ),
+                            &self.controller,
                         )
                     })?;
                     //TODO: ensure to is inside of to_parent?
@@ -127,7 +148,10 @@ impl Context {
 
         let total_ops = ops.len();
         for (current_ops, mut op) in ops.into_iter().enumerate() {
-            self.controller.check().await?;
+            self.controller
+                .check()
+                .await
+                .map_err(|s| OperationError::from_state(s, &self.controller))?;
 
             let progress = Progress {
                 current_ops,
@@ -137,9 +161,12 @@ impl Context {
             };
             (self.on_progress)(&op, &progress);
             if op.run(self, progress).await.map_err(|err| {
-                format!(
-                    "failed to {:?} {:?} to {:?}: {}",
-                    op.kind, op.from, op.to, err
+                OperationError::from_err(
+                    format!(
+                        "failed to {:?} {:?} to {:?}: {}",
+                        op.kind, op.from, op.to, err
+                    ),
+                    &self.controller,
                 )
             })? {
                 // The from path is ignored in the operation selection if it is a top level item
@@ -336,9 +363,9 @@ impl Op {
                         (ctx.on_progress)(self, &progress);
 
                         // Also check if the progress was cancelled.
-                        if let Err(why) = ctx.controller.check().await {
+                        if let Err(state) = ctx.controller.check().await {
                             ctx.buf = buf_out;
-                            return Err(why.into());
+                            return Err(OperationError::from_state(state, &ctx.controller).into());
                         }
                     }
 


### PR DESCRIPTION
Closes: #1157

The fix splits the "canceled" and "failed" states for OperationError. It also preserves that state because some functions overwrote the state by rewrapping the error.