### PR TITLE
perf(zip): don't call `sync_all()` on every file

### DIFF
--- a/src/archive.rs
+++ b/src/archive.rs
@@ -245,7 +245,6 @@ fn zip_extract<R: io::Read + io::Seek, P: AsRef<Path>>(
                 controller.set_progress(total_progress);
             }
         }
-        outfile.sync_all()?;
         #[cfg(unix)]
         {
             // Check for real permissions, which we'll set in a second pass


### PR DESCRIPTION
Calling it on every file massively slows down extraction of zip archives containing a lot of files.
Yields a ~60x time reduction for extracting a zipped folder containing 10,000 empty txt files and about a 20x reduction for extracting niri source code (in a zip).
Makes zip archive extraction time roughly match other formats.

From what I can find, Ark also doesn't seem to do this, and instead relies on the OS to handle it.