### PR TITLE
ci: Disable desktop file validation until GA supports COSMIC

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
     - master
   pull_request:
 
-env: 
+env:
   CARGO_TERM_COLOR: always
 
 jobs:
@@ -16,6 +16,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - run: sudo apt-get update; sudo apt-get install desktop-file-utils libclang-dev libglib2.0-dev libxkbcommon-dev
-      - run: desktop-file-validate --no-hints ./res/com.system76.CosmicFiles.desktop
+      # Disable until GitHub Actions uses Ubuntu 26.04.
+      # - run: desktop-file-validate --no-hints ./res/com.system76.CosmicFiles.desktop
       - run: rustup update stable && rustup default stable
       - run: cargo test --verbose


### PR DESCRIPTION
As noted in https://github.com/pop-os/cosmic-files/pull/1196#issuecomment-3399135407, this check will continue to fail until GitHub Actions uses Ubuntu 26.04, which likely won't be for another year or so. This disables the check to get rid of the false negative for the time being.