### PR TITLE
Add thumbnail mode option

### DIFF
--- a/i18n/en/cosmic_files.ftl
+++ b/i18n/en/cosmic_files.ftl
@@ -297,6 +297,12 @@ type-to-search = Type to Search
 type-to-search-recursive = Searches the current folder and all subfolders
 type-to-search-enter-path = Enters the path to the directory or file
 
+### Thumbnail mode
+thumbnail-mode = Thumbnails
+thumbnail-mode-local = Show for local files only
+thumbnail-mode-all = Show for local and network files
+thumbnail-mode-never = Never show
+
 # Context menu
 add-to-sidebar = Add to sidebar
 compress = Compress

--- a/src/app.rs
+++ b/src/app.rs
@@ -72,7 +72,7 @@ use crate::{
     clipboard::{ClipboardCopy, ClipboardKind, ClipboardPaste},
     config::{
         AppTheme, Config, DesktopConfig, Favorite, IconSizes, TIME_CONFIG_ID, TabConfig,
-        TimeConfig, TypeToSearch,
+        ThumbnailMode, TimeConfig, TypeToSearch,
     },
     dialog::{Dialog, DialogKind, DialogMessage, DialogResult},
     fl, home_dir,
@@ -404,6 +404,7 @@ pub enum Message {
     SearchClear,
     SearchInput(String),
     SetShowDetails(bool),
+    SetThumbnailMode(ThumbnailMode),
     SetTypeToSearch(TypeToSearch),
     SystemThemeModeChange,
     Size(window::Id, Size),
@@ -1951,6 +1952,36 @@ impl App {
                     Some(self.config.type_to_search),
                     Message::SetTypeToSearch,
                 ))
+                .into(),
+            widget::settings::section()
+                .title(fl!("thumbnail-mode"))
+                .add(widget::settings::item_row(vec![
+                    widget::radio(
+                        widget::text::body(fl!("thumbnail-mode-local")),
+                        ThumbnailMode::Local,
+                        Some(self.config.thumb_cfg.thumbnail_mode),
+                        Message::SetThumbnailMode,
+                    )
+                    .into(),
+                ]))
+                .add(widget::settings::item_row(vec![
+                    widget::radio(
+                        widget::text::body(fl!("thumbnail-mode-all")),
+                        ThumbnailMode::All,
+                        Some(self.config.thumb_cfg.thumbnail_mode),
+                        Message::SetThumbnailMode,
+                    )
+                    .into(),
+                ]))
+                .add(widget::settings::item_row(vec![
+                    widget::radio(
+                        widget::text::body(fl!("thumbnail-mode-never")),
+                        ThumbnailMode::Never,
+                        Some(self.config.thumb_cfg.thumbnail_mode),
+                        Message::SetThumbnailMode,
+                    )
+                    .into(),
+                ]))
                 .into(),
             widget::settings::section()
                 .title(fl!("other"))
@@ -3726,6 +3757,12 @@ impl Application for App {
             }
             Message::SetShowDetails(show_details) => {
                 config_set!(show_details, show_details);
+                return self.update_config();
+            }
+            Message::SetThumbnailMode(thumbnail_mode) => {
+                let mut new_thumb_cfg = self.config.thumb_cfg.clone();
+                new_thumb_cfg.thumbnail_mode = thumbnail_mode;
+                config_set!(thumb_cfg, new_thumb_cfg);
                 return self.update_config();
             }
             Message::SetTypeToSearch(type_to_search) => {

--- a/src/app.rs
+++ b/src/app.rs
@@ -1419,11 +1419,17 @@ impl App {
         let tabs: Box<[_]> = self.tab_model.iter().collect();
         // Update main conf and each tab with the new config
         let commands = std::iter::once(cosmic::command::set_theme(self.config.app_theme.theme()))
-            .chain(tabs.into_iter().map(|entity| {
-                self.update(Message::TabMessage(
-                    Some(entity),
-                    tab::Message::Config(self.config.tab),
-                ))
+            .chain(tabs.into_iter().flat_map(|entity| {
+                [
+                    self.update(Message::TabMessage(
+                        Some(entity),
+                        tab::Message::Config(self.config.tab),
+                    )),
+                    self.update(Message::TabMessage(
+                        Some(entity),
+                        tab::Message::ThumbConfig(self.config.thumb_cfg),
+                    )),
+                ]
             }));
         Task::batch(commands)
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -102,6 +102,23 @@ impl Favorite {
     }
 }
 
+/// Stores configuration for when thumbnails should be generated.
+#[derive(Clone, Copy, Debug, Deserialize, Hash, Eq, PartialEq, Serialize)]
+pub enum ThumbnailMode {
+    /// Generate thumbnails for local images only
+    Local,
+    /// Generate thumbnails for local and remote images
+    All,
+    /// Never generate thumbnails
+    Never,
+}
+
+impl Default for ThumbnailMode {
+    fn default() -> Self {
+        ThumbnailMode::Local
+    }
+}
+
 #[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub enum TypeToSearch {
     Recursive,
@@ -294,6 +311,7 @@ pub struct ThumbCfg {
     pub jobs: NonZeroU16,
     pub max_mem_mb: NonZeroU16,
     pub max_size_mb: NonZeroU16,
+    pub thumbnail_mode: ThumbnailMode,
 }
 
 impl Default for ThumbCfg {
@@ -302,6 +320,7 @@ impl Default for ThumbCfg {
             jobs: 4.try_into().unwrap(),
             max_mem_mb: 2000.try_into().unwrap(),
             max_size_mb: 64.try_into().unwrap(),
+            thumbnail_mode: ThumbnailMode::default(),
         }
     }
 }

--- a/src/mounter/gvfs.rs
+++ b/src/mounter/gvfs.rs
@@ -11,7 +11,7 @@ use super::{Mounter, MounterAuth, MounterItem, MounterItems, MounterMessage};
 use crate::{
     config::IconSizes,
     err_str,
-    tab::{self, DirSize, ItemMetadata, ItemThumbnail, Location},
+    tab::{self, DirSize, ItemLocation, ItemMetadata, Location},
 };
 
 const TARGET_URI_ATTRIBUTE: &str = "standard::target-uri";
@@ -166,7 +166,8 @@ fn network_scan(uri: &str, sizes: IconSizes) -> Result<Vec<tab::Item>, String> {
             icon_handle_grid,
             icon_handle_list,
             icon_handle_list_condensed,
-            thumbnail_opt: Some(ItemThumbnail::NotImage),
+            thumbnail_opt: None,
+            item_location: ItemLocation::Remote,
             button_id: widget::Id::unique(),
             pos_opt: Cell::new(None),
             rect_opt: Cell::new(None),

--- a/src/tab.rs
+++ b/src/tab.rs
@@ -1544,6 +1544,7 @@ pub enum Message {
     DoubleClick(Option<usize>),
     ClickRelease(Option<usize>),
     Config(TabConfig),
+    ThumbConfig(ThumbCfg),
     ContextAction(Action),
     ContextMenu(Option<Point>, Option<window::Id>),
     LocationContextMenuPoint(Option<Point>),
@@ -3184,6 +3185,27 @@ impl Tab {
                     for item in items.iter_mut() {
                         item.highlighted = false;
                     }
+                }
+            }
+            Message::ThumbConfig(thumb_config) => {
+                let thumbnail_mode_changed =
+                    self.thumb_config.thumbnail_mode != thumb_config.thumbnail_mode;
+                self.thumb_config = thumb_config;
+                if thumbnail_mode_changed {
+                    // Reloads the tab if thumbnail mode was changed, so that when thumbnails are
+                    // disabled the tab immediately updates to hide them.
+                    let selected_paths = self
+                        .selected_locations()
+                        .into_iter()
+                        .filter_map(Location::into_path_opt)
+                        .collect();
+                    let location = self.location.clone();
+                    self.change_location(&location, None);
+                    commands.push(Command::ChangeLocation(
+                        self.title(),
+                        location,
+                        Some(selected_paths),
+                    ));
                 }
             }
             Message::ContextAction(action) => {


### PR DESCRIPTION
## Issues addressed

This PR attempts to address the following issues:

- https://github.com/pop-os/cosmic-files/issues/1150
- https://github.com/pop-os/cosmic-files/issues/1253
- https://github.com/pop-os/cosmic-files/issues/1216

It is also a replacement for this unmerged PR:
- https://github.com/pop-os/cosmic-files/pull/1224

## User interface changes

This PR adds an option for the user to configure how they would like to generate thumbnails:

<img width="678" height="304" alt="image" src="https://github.com/user-attachments/assets/2300281f-2137-4342-828f-eb1af7d69238" />

The default is the current behavior, where thumbnails are generated only for local files. The user will also be able to choose to generate thumbnails for remote files, or to generate no thumbnails.

## Technical details

This PR replaces https://github.com/pop-os/cosmic-files/pull/1224 with a setting that controls both the option to always generate thumbnails, as well as the option to never generate them. I think it makes sense to have both of these options combined into a single setting, and sets up possibility of adding more complex options in the future.

In order to make this change, I've modified the existing behaviour which preloads the `thumbnail_opt` property for an `Item` struct with a `Some(ItemThumbnail::NotImage)` value to prevent the thumbnail from being generated. Instead, I now include a new `item_location` property which keeps track of whether the item is local, remote, or in the trash. This allows the decision on whether or not to generate a thumbnail to be made within the Tab, avoiding the need to pass the new `thumbnail_mode` value all the way through the file scanning process.

I've also added a new method `item.allow_generate_thumbnail` to collect all the logic for whether or not a thumbnail should be generated in a single place, so it should be easier to expand this logic in the future.

A new message `tab::Message::ThumbConfig` has been added to the Tab, to enable changes to this setting to be immediately propagated to open tabs.