### PR TITLE
fix(tab): thumbnails not rendering for some file formats

### DIFF
--- a/src/tab.rs
+++ b/src/tab.rs
@@ -46,7 +46,7 @@ use icu::{
     },
     locale::preferences::extensions::unicode::keywords::HourCycle,
 };
-use image::ImageDecoder;
+use image::{DynamicImage, ImageDecoder, ImageReader};
 use jxl_oxide::integration::JxlDecoder;
 use mime_guess::{Mime, mime};
 use rustc_hash::FxHashMap;
@@ -1948,10 +1948,9 @@ impl ItemThumbnail {
                 Ok(status) => {
                     if status.success() {
                         match image::ImageReader::open(file.path())
-                            .and_then(image::ImageReader::with_guessed_format)
+                            .and_then(ImageReader::with_guessed_format)
                         {
-                            Ok(reader) => match reader.decode().map(image::DynamicImage::into_rgb8)
-                            {
+                            Ok(reader) => match reader.decode().map(DynamicImage::into_rgba8) {
                                 Ok(image) => {
                                     return Some((
                                         Self::Image(


### PR DESCRIPTION
This fixes an accidental change that converted images to `rgb8` instead of `rgba8`, which silently broke thumbnail rendering.

I didn't check the function name properly when I hit tab... and it still compiled and ran fine so I thought it was just broken on my end :(

fixes: 5f729829d754da3605a014c7a9ab934837650180