### PR TITLE
Track and use modifiers per sub-window, fixes #1152

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -4689,7 +4689,7 @@ impl Application for App {
             #[cfg(all(feature = "wayland", feature = "desktop-applet"))]
             Message::Focused(id) => {
                 if let Some(w) = self.windows.get(&id) {
-                    match w.kind {
+                    match &w.kind {
                         WindowKind::Desktop(entity) => self.tab_model.activate(*entity),
                         _ => {}
                     };


### PR DESCRIPTION
The main window's modifiers were filtered by https://github.com/pop-os/cosmic-files/commit/0957f937db399bcdd907c6a7400904779232e138 in order to fix #1312, but it did not contain code to store the context menu modifiers.