### PR TITLE
fix: allow context menu when shift is being pressed

### DIFF
--- a/src/tab.rs
+++ b/src/tab.rs
@@ -3312,16 +3312,14 @@ impl Tab {
             }
             Message::ContextMenu(point_opt, _) => {
                 self.edit_location = None;
-                if point_opt.is_none() || !mod_shift {
-                    self.context_menu = point_opt;
-                    self.location_context_menu_index = None;
+                self.context_menu = point_opt;
+                self.location_context_menu_index = None;
 
-                    //TODO: hack for clearing selecting when right clicking empty space
-                    if self.context_menu.is_some() && self.last_right_click.take().is_none() {
-                        if let Some(ref mut items) = self.items_opt {
-                            for item in items.iter_mut() {
-                                item.selected = false;
-                            }
+                //TODO: hack for clearing selecting when right clicking empty space
+                if self.context_menu.is_some() && self.last_right_click.take().is_none() {
+                    if let Some(ref mut items) = self.items_opt {
+                        for item in items.iter_mut() {
+                            item.selected = false;
                         }
                     }
                 }


### PR DESCRIPTION
Fixes the first part of this regression test: "Shift right-click, and right-click followed by Shift, both show Permanently delete option."