### PR TITLE
fix: Only type to search in App mode

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -2984,7 +2984,8 @@ impl Application for App {
                     }
 
                     // Uncaptured keys with only shift modifiers go to the search or location box
-                    if !modifiers.logo()
+                    if matches!(self.mode, Mode::App)
+                        && !modifiers.logo()
                         && !modifiers.control()
                         && !modifiers.alt()
                         && matches!(key, Key::Character(_))


### PR DESCRIPTION
This fixes the type to search issues on the Desktop in #1384.