### PR TITLE
fix: update network path when entering uri

### DIFF
--- a/src/mounter/mod.rs
+++ b/src/mounter/mod.rs
@@ -116,7 +116,7 @@ pub trait Mounter: Send + Sync {
     fn mount(&self, item: MounterItem) -> Task<()>;
     fn network_drive(&self, uri: String) -> Task<()>;
     fn network_scan(&self, uri: &str, sizes: IconSizes) -> Option<Result<Vec<tab::Item>, String>>;
-    fn dir_info(&self, uri: &str) -> Option<(String, String)>;
+    fn dir_info(&self, uri: &str) -> Option<(String, String, Option<PathBuf>)>;
     fn unmount(&self, item: MounterItem) -> Task<()>;
     fn subscription(&self) -> Subscription<MounterMessage>;
 }

--- a/src/tab.rs
+++ b/src/tab.rs
@@ -1362,11 +1362,11 @@ pub struct EditLocation {
 
 impl EditLocation {
     pub fn resolve(&self) -> Option<Location> {
-        if let Location::Network(uri, _, path) = &self.location {
+        if let Location::Network(uri, ..) = &self.location {
             MOUNTERS
                 .values()
                 .find_map(|mounter| mounter.dir_info(uri))
-                .map(|(uri, display_name)| Location::Network(uri, display_name, path.clone()))
+                .map(|(uri, display_name, path_opt)| Location::Network(uri, display_name, path_opt))
         } else {
             let Some(selected) = self.selected else {
                 return Some(self.location.clone());


### PR DESCRIPTION
I missed the API to get the file path with #1390, so I didn't realise this was possible.

https://github.com/user-attachments/assets/e4bc12b6-9011-49b9-9d26-3624b29ead3d

closes: #1406