### PR TITLE
docs (QA): Add file drag-and-drop to regression testing checklist

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -17,6 +17,7 @@ This document provides a regression testing checklist for COSMIC Files. The chec
 
 - [ ] Right-click -> Create a new folder, then enter it.
 - [ ] Right-click in the empty folder -> Create a new file.
+- [ ] Navigate to the parent folder, create another new file, then drag it into the created folder.
 - [ ] Files can be renamed.
 - [ ] Files can be opened with non-default apps & browsing store for new apps works.
 - [ ] Normal right-click shows `Move to trash` option.


### PR DESCRIPTION
This adds a new checklist item that would detect https://github.com/pop-os/cosmic-files/issues/1438, since that's a commonly used feature that we missed and doesn't add a lot of time to the testing flow.