### PR TITLE
Don't thumbnail thumbnails

### DIFF
--- a/src/tab.rs
+++ b/src/tab.rs
@@ -91,7 +91,7 @@ use crate::{
     mounter::MOUNTERS,
     mouse_area,
     operation::{Controller, OperationError},
-    thumbnail_cacher::{CachedThumbnail, ThumbnailCacher, ThumbnailSize},
+    thumbnail_cacher::{CachedThumbnail, THUMBNAIL_CACHE_BASE_DIR, ThumbnailCacher, ThumbnailSize},
     thumbnailer::thumbnailer,
 };
 use uzers::{get_group_by_gid, get_user_by_uid};
@@ -6011,7 +6011,10 @@ impl Tab {
                     #[cfg(feature = "gvfs")]
                     ItemMetadata::GvfsPath { .. } => true,
                     _ => false,
-                };
+                } && THUMBNAIL_CACHE_BASE_DIR
+                    .as_deref()
+                    .map(|cache| !path.starts_with(cache))
+                    .unwrap_or_default();
                 if can_thumbnail {
                     let mime = item.mime.clone();
                     let max_jobs = jobs;

--- a/src/thumbnail_cacher.rs
+++ b/src/thumbnail_cacher.rs
@@ -357,7 +357,7 @@ pub enum CachedThumbnail {
     Failed,
 }
 
-static THUMBNAIL_CACHE_BASE_DIR: LazyLock<Option<PathBuf>> = LazyLock::new(|| {
+pub static THUMBNAIL_CACHE_BASE_DIR: LazyLock<Option<PathBuf>> = LazyLock::new(|| {
     if let Some(cache_dir) = dirs::cache_dir() {
         return Some(cache_dir.join("thumbnails"));
     }


### PR DESCRIPTION
Closes: #1470

According to the issue, GNOME just skips files under any folder named "thumbnails." ~~I implemented the same logic here.~~ This implementation only skips the thumbnailing folder as defined by the [Thumbnail Managing Standard](https://specifications.freedesktop.org/thumbnail/latest/) of Freedesktop.

---

I tested this by browsing to folders with thumbnails in my cache and observing that thumbnails weren't created.