### PR TITLE
fix: Update data on preview in desktop mode

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -3669,7 +3669,10 @@ impl Application for App {
                                 id,
                                 Window::new(WindowKind::Preview(entity_opt, preview_kind)),
                             );
-                            return command.map(|_id| cosmic::action::none());
+                            return Task::batch([
+                                self.update_desktop(), // Force re-calculating of directory sizes
+                                command.map(|_id| cosmic::action::none()),
+                            ]);
                         }
                     }
                 }
@@ -6243,18 +6246,39 @@ impl Application for App {
             }
         }
 
-        let mut selected_preview = None;
-        if self.core.window.show_context {
-            if let ContextPage::Preview(entity_opt, PreviewKind::Selected) = self.context_page {
-                selected_preview = Some(entity_opt.unwrap_or_else(|| self.tab_model.active()));
+        let mut selected_previews = Vec::new();
+        match self.mode {
+            Mode::App => {
+                if self.core.window.show_context {
+                    if let ContextPage::Preview(entity_opt, PreviewKind::Selected) =
+                        self.context_page
+                    {
+                        selected_previews
+                            .push(Some(entity_opt.unwrap_or_else(|| self.tab_model.active())));
+                    }
+                }
+            }
+            Mode::Desktop => {
+                for window_kind in self.windows.iter().map(|(_, window)| &window.kind) {
+                    if let WindowKind::Preview(entity_opt, _) = window_kind {
+                        selected_previews
+                            .push(Some(entity_opt.unwrap_or_else(|| self.tab_model.active())));
+                    }
+                }
             }
         }
+
         subscriptions.extend(self.tab_model.iter().filter_map(|entity| {
             let tab = self.tab_model.data::<Tab>(entity)?;
             Some(
-                tab.subscription(selected_preview == Some(entity))
-                    .with(entity)
-                    .map(|(entity, tab_msg)| Message::TabMessage(Some(entity), tab_msg)),
+                tab.subscription(
+                    selected_previews
+                        .iter()
+                        .find(|preview| preview.as_ref() == Some(entity).as_ref())
+                        .is_some(),
+                )
+                .with(entity)
+                .map(|(entity, tab_msg)| Message::TabMessage(Some(entity), tab_msg)),
             )
         }));
 


### PR DESCRIPTION
Updates data including directory sizes during preview in desktop mode. Re-calculates directory sizes each time a new preview window is created.