### PR TITLE
feat: Add open button to multi preview

### DIFF
--- a/src/tab.rs
+++ b/src/tab.rs
@@ -3299,7 +3299,13 @@ impl Tab {
                                     .take(max_real - min_real + 1)
                                 {
                                     if let Some(item) = items.get_mut(index) {
-                                        item.selected = true;
+                                        if item.hidden {
+                                            if self.config.show_hidden {
+                                                item.selected = true;
+                                            }
+                                        } else {
+                                            item.selected = true;
+                                        }
                                     }
                                 }
                             }


### PR DESCRIPTION
Will open all currently selected items. Directories will open in separate tabs for both app and desktop mode when multiple items are selected.