### PR TITLE
Fix: Disables List View activation in Desktop Mode

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -4217,6 +4217,10 @@ impl Application for App {
             Message::TabView(entity_opt, view) => {
                 let entity = entity_opt.unwrap_or_else(|| self.tab_model.active());
                 if let Some(tab) = self.tab_model.data_mut::<Tab>(entity) {
+                    if matches!(tab.mode, tab::Mode::Desktop) {
+                        return Task::none();
+                    }
+
                     tab.config.view = view;
                 }
                 let mut config = self.config.tab;


### PR DESCRIPTION
Ignore TabView updates on Desktop Mode, so that desktop cannot be switched to List View.

Fixes: #1496 