### PR TITLE
Stop immediately listing hidden files in tab completion

### DIFF
--- a/src/tab.rs
+++ b/src/tab.rs
@@ -346,6 +346,10 @@ fn tab_complete(path: &Path) -> Result<Vec<(String, PathBuf)>, Box<dyn Error>> {
         let Some(file_name) = file_name_os.to_str() else {
             continue;
         };
+        // Don't list hidden files before entering a pattern
+        if pattern == "^" && file_name.starts_with('.') {
+            continue;
+        }
         if regex.is_match(file_name) {
             completions.push((file_name.to_string(), entry.path()));
         }


### PR DESCRIPTION
The tab completion feature is really nice, but if you are in a directory like the home directory with a lot of hidden files or directories, you will see all those hidden items listed instead of the non-hidden folders.

This change will hide those items when you first open the tab completion, but it will show them when you start typing the path.