### PR TITLE
feat: allow configuring archive app

### DIFF
--- a/res/com.system76.CosmicFiles.desktop
+++ b/res/com.system76.CosmicFiles.desktop
@@ -9,16 +9,3 @@ Icon=com.system76.CosmicFiles
 Categories=COSMIC;Utility;FileManager;
 Keywords=Folder;Manager;
 MimeType=inode/directory;application/gzip;application/x-compressed-tar;application/x-tar;application/zip;application/x-bzip;application/x-bzip-compressed-tar;application/x-bzip2;application/x-bzip2-compressed-tar;application/x-xz;application/x-xz-compressed-tar;
-
-Actions=Extract;ExtractTo;
-
-[Desktop Action Extract]
-Name=COSMIC Files Extract
-Exec=cosmic-files --extract %U
-NoDisplay=true
-
-[Desktop Action ExtractTo]
-Name=COSMIC Files Extract To...
-Exec=cosmic-files --extract-to %U
-NoDisplay=true
-

--- a/src/app.rs
+++ b/src/app.rs
@@ -791,9 +791,8 @@ impl App {
     fn open_file(&mut self, paths: &[impl AsRef<Path>]) -> Task<Message> {
         let mut tasks = Vec::new();
 
-        // This will be, at the end of the function, a list of all archives that 
-        // don't have a suitable app
-        let mut found_archives_paths: Vec<PathBuf> = vec![];
+        // List of archives to open ourselves
+        let mut queued_archive_paths: Vec<PathBuf> = vec![];
 
         // Associate all paths to its MIME type
         // This allows handling paths as groups if possible, such as launching a single video
@@ -840,28 +839,28 @@ impl App {
                 continue;
             } else if supported_archive_types.iter().copied().any(|t| mime == t) { // Archives handling
 
-                let mut found_archive_app = false;
+                let mut handle_archives = true;
 
-                // Checks if there are suitable apps for archives (if cosmic-files is the dafult one, fallback to extract_to)
+                // Checks for default archival app other than COSMIC Files
                 for app in self.mime_app_cache.get(&mime) {
                     if app.id == Self::APP_ID {
-                        log::debug!("Default app is cosmic-files, adding to extract_to dialog");
-                        found_archive_app = false; // Let's confirm we want the extrac_to dialog in this case
-                        break; // Stop looking
+                        log::debug!("Default archival app is cosmic-files, adding to extract_to dialog");
+                        handle_archives = true;
+                        break;
                     } else {
                         log::debug!("Found suitable archive app {} for MIME {}", app.id, mime);
 
                         if self.launch_from_mime_cache(&mime, &paths) {
-                            found_archive_app = true; // Not adding to extract_to list
+                            handle_archives = false; // Opened externally, so don't handle
                             break;
                         } else {
-                            found_archive_app = false; // Adding to extract_to list because unable to open (fallback)
+                            handle_archives = true; // Still handle if external open failed
                         }
                     }
                 }
 
-                if !found_archive_app {
-                    found_archives_paths.extend(paths.iter().cloned());
+                if handle_archives {
+                    queued_archive_paths.extend(paths.iter().cloned());
                 }
 
                 continue 'outer;
@@ -901,11 +900,10 @@ impl App {
             }
         }
 
-        // We are done with looping through file groups, let's see if there are archives to
-        // open with the extract_to dialog
-        if found_archives_paths.len() > 0 {
-            log::debug!("Paths to extract with dialog: {:?}", found_archives_paths);
-            tasks.push(self.extract_to(&found_archives_paths));
+        // Open any queued archvies with extract_to dialog
+        if queued_archive_paths.len() > 0 {
+            log::debug!("Paths to extract with dialog: {:?}", queued_archive_paths);
+            tasks.push(self.extract_to(&queued_archive_paths));
         }
 
         Task::batch(tasks)


### PR DESCRIPTION
## Change default behavior when opening archive files

fixes: #1268 

Opening an archive should mean *looking inside it first* — extracting should be an explicit action.

# Summary

This PR changes how COSMIC Files opens archive files.

**Current behavior:**  
- Only archives selected → extraction dialog opens automatically  
- Mixed selection (archive + other files) → archive opens in archive manager  

**Problem:**  
- Users often want to inspect contents before extracting, grab a single file, or check structure/safety  
- Inconsistent UX between single-archive and mixed selections  

**Proposed behavior:**  
- Double-click/open → archives always open in archive manager  
- “Extract To…” remains available via right-click  
- Default action becomes safe, predictable, and consistent  
- **If there are no suitable apps, it falls back to the extract_to dialog**

**Benefits:**  
- Non-destructive first action  
- Extraction is explicit  
- Same behavior regardless of selection type  
- Aligns with user expectations and other file managers  
- No functionality removed; extraction still one click away  

**Conclusion:**  
Opening an archive now means browsing its contents first; extraction is an explicit, deliberate action.

edit: summarized