### PR TITLE
Adds a way to copy the file path of a file (by adding it to the right click context menu)

### DIFF
--- a/i18n/en/cosmic_files.ftl
+++ b/i18n/en/cosmic_files.ftl
@@ -337,6 +337,7 @@ quit = Quit
 edit = Edit
 cut = Cut
 copy = Copy
+copy-path = Copy file path
 paste = Paste
 select-all = Select all
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -145,6 +145,7 @@ pub enum Action {
     AddToSidebar,
     Compress,
     Copy,
+    CopyPath,
     Cut,
     CosmicSettingsDesktop,
     CosmicSettingsDisplays,
@@ -212,6 +213,7 @@ impl Action {
             Self::AddToSidebar => Message::AddToSidebar(entity_opt),
             Self::Compress => Message::Compress(entity_opt),
             Self::Copy => Message::Copy(entity_opt),
+            Self::CopyPath => Message::CopyPath(entity_opt),
             Self::Cut => Message::Cut(entity_opt),
             Self::CosmicSettingsDesktop => Message::CosmicSettings("desktop"),
             Self::CosmicSettingsDisplays => Message::CosmicSettings("displays"),
@@ -334,6 +336,7 @@ pub enum Message {
     Compress(Option<Entity>),
     Config(Config),
     Copy(Option<Entity>),
+    CopyPath(Option<Entity>),
     CosmicSettings(&'static str),
     Cut(Option<Entity>),
     Delete(Option<Entity>),
@@ -2671,6 +2674,15 @@ impl Application for App {
                 let paths = self.selected_paths(entity_opt);
                 let contents = ClipboardCopy::new(ClipboardKind::Copy, paths);
                 return clipboard::write_data(contents);
+            }
+            Message::CopyPath(entity_opt) => {
+                let paths = self.selected_paths(entity_opt);
+                let text = paths
+                    .into_iter()
+                    .filter_map(|p| p.to_str().map(|s| s.to_string()))
+                    .collect::<Vec<_>>()
+                    .join("\n");
+                return clipboard::write(text);
             }
             Message::Cut(entity_opt) => {
                 self.set_cut(entity_opt);

--- a/src/key_bind.rs
+++ b/src/key_bind.rs
@@ -67,6 +67,7 @@ pub fn key_binds(mode: &tab::Mode) -> HashMap<KeyBind, Action> {
     // App and desktop only keys
     if matches!(mode, tab::Mode::App | tab::Mode::Desktop) {
         bind!([Ctrl], Key::Character("c".into()), Copy);
+        bind!([Ctrl, Shift], Key::Character("c".into()), CopyPath);
         bind!([Ctrl], Key::Character("x".into()), Cut);
         bind!([], Key::Named(Named::Delete), Delete);
         bind!([Shift], Key::Named(Named::Delete), PermanentlyDelete);

--- a/src/menu.rs
+++ b/src/menu.rs
@@ -175,6 +175,7 @@ pub fn context_menu<'a>(
                 children.push(menu_item(fl!("rename"), Action::Rename).into());
                 children.push(menu_item(fl!("cut"), Action::Cut).into());
                 children.push(menu_item(fl!("copy"), Action::Copy).into());
+                children.push(menu_item(fl!("copy-path"), Action::CopyPath).into());
                 // Should this simply bypass trash and remove the shortcut?
                 children.push(menu_item(fl!("move-to-trash"), Action::Delete).into());
             } else if selected > 0 {
@@ -205,6 +206,7 @@ pub fn context_menu<'a>(
                     children.push(menu_item(fl!("cut"), Action::Cut).into());
                 }
                 children.push(menu_item(fl!("copy"), Action::Copy).into());
+                children.push(menu_item(fl!("copy-path"), Action::CopyPath).into());
 
                 children.push(divider::horizontal::light().into());
                 let supported_archive_types = crate::archive::SUPPORTED_ARCHIVE_TYPES;


### PR DESCRIPTION
There isn't really a way to get the full filepath for a file from the Files app. 

As an example alternative, on macOS, Apple make it so that the right click has a 'copy file name' which you can hold 'alt' to toggle into the full filepath. I'm not sure if that's too hidden, or something you want to copy - but I'm pretty sure this existed on the old desktop manager pre-COSMIC

Looks like:

<img width="1230" height="1118" alt="image" src="https://github.com/user-attachments/assets/6774c6f0-c694-41f8-8245-207312184d32" />

( I built this with Claude Code, I'm not an expert Rust person, but I stand behind the code, it feels right judging by how the other context menu items work )