### PR TITLE
Faster CI (cached deps & wild linker)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,15 +8,23 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  RUST_LOG: info
 
 jobs:
   test:
     name: cosmic-files - latest
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
+      - uses: davidlattimore/wild-action@latest
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo
+            target
+          key: ${{ runner.os }}-cargo${{ hashFiles('**/Cargo.lock') }}
       - run: sudo apt-get update; sudo apt-get install libclang-dev libglib2.0-dev libxkbcommon-dev
-      - run: rustup update stable && rustup default stable
-      - run: cargo test --verbose --no-default-features
-      - run: cargo test --verbose
-      - run: cargo test --verbose --all-features
+      - run: cargo test --verbose --no-default-features -- --nocapture
+      - run: cargo test --verbose -- --nocapture
+      - run: cargo test --verbose --all-features -- --nocapture


### PR DESCRIPTION
This improves CI a bit by using [Wild](https://github.com/davidlattimore/wild), a linker written in Rust that is significantly faster than gold and lld, and caching dependencies.

Dependencies are cached based on the lock file. In other words, deps are only rebuilt if they need to be rebuilt (i.e. if the lock files changes).

Besides that, I removed the explicit rustup call in favor of an action. This prevents needlessly reinstalling Rust in CI (which didn't happen anyway; but you know, just in case).

Finally, unrelated to everything else, I enabled logs for the tests. If a test fails, the logs may prove helpful.

---

Draft since I want it to run first to make sure it works...which it should because I'm using the same CI elsewhere. :laughing: 