### PR TITLE
feat: Show count of files affected when "Apply to all" is selected in copy/move operations

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -567,6 +567,7 @@ pub enum DialogPage {
         to: tab::Item,
         multiple: bool,
         apply_to_all: bool,
+        conflict_count: usize,
         tx: mpsc::Sender<ReplaceResult>,
     },
     SetExecutableAndLaunch {
@@ -5715,6 +5716,7 @@ impl Application for App {
                 to,
                 multiple,
                 apply_to_all,
+                conflict_count,
                 tx,
             } => {
                 let military_time = self.config.tab.military_time;
@@ -5739,13 +5741,18 @@ impl Application for App {
                 if *multiple {
                     dialog
                         .control(
-                            widget::checkbox(fl!("apply-to-all"), *apply_to_all).on_toggle(
+                            widget::checkbox(
+                                format!("{} ({})" ,fl!("apply-to-all"), *conflict_count),
+                                *apply_to_all,
+                            )
+                                .on_toggle(
                                 |apply_to_all| {
                                     Message::DialogUpdate(DialogPage::Replace {
                                         from: from.clone(),
                                         to: to.clone(),
                                         multiple: *multiple,
                                         apply_to_all,
+                                        conflict_count: *conflict_count,
                                         tx: tx.clone(),
                                     })
                                 },

--- a/src/operation/mod.rs
+++ b/src/operation/mod.rs
@@ -32,6 +32,7 @@ async fn handle_replace(
     file_from: PathBuf,
     file_to: PathBuf,
     multiple: bool,
+    conflict_count: usize,
 ) -> ReplaceResult {
     let item_from = match tab::item_from_path(file_from, IconSizes::default()) {
         Ok(ok) => ok,
@@ -59,6 +60,7 @@ async fn handle_replace(
                 to: item_to,
                 multiple,
                 apply_to_all: false,
+                conflict_count,
                 tx,
             },
             Some(REPLACE_BUTTON_ID.clone()),
@@ -180,9 +182,9 @@ async fn copy_or_move(
 
         {
             let msg_tx = msg_tx.clone();
-            context = context.on_replace(move |op| {
+            context = context.on_replace(move |op, conflict_count| {
                 let msg_tx = msg_tx.clone();
-                Box::pin(handle_replace(msg_tx, op.from.clone(), op.to.clone(), true))
+                Box::pin(handle_replace(msg_tx, op.from.clone(), op.to.clone(), true, conflict_count))
             });
         }
 


### PR DESCRIPTION
This fixes the issue : #1612 (Feature request) by displaying the number of files that will be affected when selecting the Apply to all in in copy/move operations