### PR TITLE
Generate translated desktop and metainfo files with xdgen

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1499,6 +1499,7 @@ dependencies = [
  "wayland-client",
  "xdg",
  "xdg-mime",
+ "xdgen",
  "zip",
 ]
 
@@ -2497,6 +2498,16 @@ dependencies = [
  "thiserror 2.0.18",
  "unicase",
  "xdg",
+]
+
+[[package]]
+name = "freedesktop_entry_parser"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc6d3a3635983a889f065aa9ce760384713f23a9b4a04f696f86c39a5d7a6a5a"
+dependencies = [
+ "indexmap 2.13.0",
+ "nom 8.0.0",
 ]
 
 [[package]]
@@ -8913,6 +8924,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "xdgen"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25af88f104f06d5aeb80c77e5eb85e6f6f355f86f6e34307a14befd716efe4bf"
+dependencies = [
+ "fluent",
+ "freedesktop_entry_parser",
+ "unic-langid",
+ "xmltree",
+]
+
+[[package]]
 name = "xkbcommon"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8968,10 +8991,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "xml"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8aa498d22c9bbaf482329839bc5620c46be275a19a812e9a22a2b07529a642a"
+
+[[package]]
 name = "xml-rs"
 version = "0.8.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ae8337f8a065cfc972643663ea4279e04e7256de865aa66fe25cec5fb912d3f"
+
+[[package]]
+name = "xmltree"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbc04313cab124e498ab1724e739720807b6dc405b9ed0edc5860164d2e4ff70"
+dependencies = [
+ "xml",
+]
 
 [[package]]
 name = "xmlwriter"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -128,6 +128,9 @@ fork = "0.6"
 [target.'cfg(target_os = "linux")'.dependencies]
 procfs = "0.18"
 
+[build-dependencies]
+xdgen = "0.1"
+
 [dev-dependencies]
 # cap-std = "3"
 # cap-tempfile = "3"

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,24 @@
+use std::{env, fs, path::PathBuf};
+use xdgen::{App, Context, FluentString};
+
+fn main() {
+    let id = "com.system76.CosmicFiles";
+    let ctx = Context::new("i18n", env::var("CARGO_PKG_NAME").unwrap()).unwrap();
+    let app = App::new(FluentString("cosmic-files"))
+        .comment(FluentString("comment"))
+        .keywords(FluentString("keywords"));
+    let output = PathBuf::from("target/xdgen");
+    fs::create_dir_all(&output).unwrap();
+    fs::write(
+        output.join(format!("{}.desktop", id)),
+        app.expand_desktop(format!("res/{}.desktop", id), &ctx)
+            .unwrap(),
+    )
+    .unwrap();
+    fs::write(
+        output.join(format!("{}.metainfo.xml", id)),
+        app.expand_metainfo(format!("res/{}.metainfo.xml", id), &ctx)
+            .unwrap(),
+    )
+    .unwrap();
+}

--- a/i18n/ar/cosmic_files.ftl
+++ b/i18n/ar/cosmic_files.ftl
@@ -1,4 +1,6 @@
 cosmic-files = ملفات COSMIC
+comment = مدير ملفات لسطح مكتب COSMIC
+keywords = مجلد;ملف;مدير;
 empty-folder = مجلد فارغ
 empty-folder-hidden = مجلد فارغ (يحتوي على عناصر مخفية)
 filesystem = نظام الملفات

--- a/i18n/cs/cosmic_files.ftl
+++ b/i18n/cs/cosmic_files.ftl
@@ -1,4 +1,6 @@
 cosmic-files = Soubory COSMIC
+comment = Správce souborů pro prostředí COSMIC
+keywords = Složky;Správce;Manažer;Prohlížeč;
 empty-folder = Složka je prázdná
 empty-folder-hidden = Složka je prázdná (obsahuje skryté položky)
 filesystem = Souborový systém

--- a/i18n/en/cosmic_files.ftl
+++ b/i18n/en/cosmic_files.ftl
@@ -1,4 +1,6 @@
 cosmic-files = COSMIC Files
+comment = File manager for the COSMIC desktop
+keywords = Folder;Manager;
 empty-folder = Empty folder
 empty-folder-hidden = Empty folder (has hidden items)
 no-results = No results found

--- a/i18n/es/cosmic_files.ftl
+++ b/i18n/es/cosmic_files.ftl
@@ -1,4 +1,6 @@
 cosmic-files = Archivos COSMIC
+comment = Gestor de archivos de COSMIC
+keywords = Archivos;Ficheros;Gestor;Explorador;
 empty-folder = Carpeta vacía
 empty-folder-hidden = Carpeta vacía (Contiene archivos ocultos)
 no-results = No se encontraron resultados

--- a/i18n/hu/cosmic_files.ftl
+++ b/i18n/hu/cosmic_files.ftl
@@ -1,4 +1,6 @@
 cosmic-files = COSMIC Fájlok
+comment = Fájlkezelő a COSMIC asztali környezethez 
+keywords = mappa;fájl;kezelő;
 empty-folder = Üres mappa
 empty-folder-hidden = Üres mappa (Rejtett elemeket tartalmaz)
 no-results = Nincs találat

--- a/i18n/it/cosmic_files.ftl
+++ b/i18n/it/cosmic_files.ftl
@@ -1,4 +1,6 @@
 cosmic-files = COSMIC Files
+comment = File manager di COSMIC
+keywords = File;Archivi;Cartelle;Explorer;
 empty-folder = Cartella vuota
 empty-folder-hidden = Cartella vuota (con elementi nascosti)
 no-results = Nessun risultato trovato

--- a/i18n/pl/cosmic_files.ftl
+++ b/i18n/pl/cosmic_files.ftl
@@ -1,4 +1,6 @@
 cosmic-files = Pliki COSMIC
+comment = Menedżer plików pulpitu COSMIC
+keywords = Katalogi;Pliki;Menedżer;
 empty-folder = Pusty katalog
 empty-folder-hidden = Pusty katalog (z ukrytymi plikami)
 no-results = Brak wyników

--- a/i18n/pt-BR/cosmic_files.ftl
+++ b/i18n/pt-BR/cosmic_files.ftl
@@ -1,4 +1,5 @@
 cosmic-files = Gestor de Arquivos COSMIC
+comment = Gerenciador de arquivos do COSMIC
 empty-folder = Pasta vazia
 empty-folder-hidden = Pasta vazia (contém itens ocultos)
 no-results = Nenhum item encontrado

--- a/i18n/pt/cosmic_files.ftl
+++ b/i18n/pt/cosmic_files.ftl
@@ -1,4 +1,6 @@
 cosmic-files = Ficheiros COSMIC
+comment = Gerenciador de arquivos do COSMIC
+keywords = Pastas;Gerenciador;Arquivos;Gestor;Explorer;
 empty-folder = Pasta vazia
 empty-folder-hidden = Pasta vazia (tem ficheiros ocultos)
 no-results = Nenhum resultado encontrado

--- a/i18n/sk/cosmic_files.ftl
+++ b/i18n/sk/cosmic_files.ftl
@@ -1,4 +1,6 @@
 cosmic-files = Súbory COSMIC
+comment = Správca súborov pre prostredie COSMIC
+keywords = Priečinok;Správca;Súbory;Manažér;Prehliadač;
 empty-folder = Priečinok je prázdny
 empty-folder-hidden = Priečinok je prázdny (obsahuje skryté položky)
 no-results = Neboli nájdené žiadne výsledky

--- a/i18n/sv/cosmic_files.ftl
+++ b/i18n/sv/cosmic_files.ftl
@@ -1,4 +1,6 @@
 cosmic-files = COSMIC Filer
+comment = Filhanterare för skrivbordsmiljön COSMIC
+keywords = Folder;Katalog;Mapp;Manager;
 empty-folder = Mappen är tom
 empty-folder-hidden = Mappen är tom (har dolda objekt)
 no-results = Inga resultat hittades

--- a/justfile
+++ b/justfile
@@ -17,11 +17,11 @@ applet-src := cargo-target-dir / 'release' / applet-name
 applet-dst := base-dir / 'bin' / applet-name
 
 desktop := APPID + '.desktop'
-desktop-src := 'res' / desktop
+desktop-src := 'target/xdgen' / desktop
 desktop-dst := clean(rootdir / prefix) / 'share' / 'applications' / desktop
 
 metainfo := APPID + '.metainfo.xml'
-metainfo-src := 'res' / metainfo
+metainfo-src := 'target/xdgen' / metainfo
 metainfo-dst := clean(rootdir / prefix) / 'share' / 'metainfo' / metainfo
 
 icons-src := 'res' / 'icons' / 'hicolor'

--- a/res/com.system76.CosmicFiles.desktop
+++ b/res/com.system76.CosmicFiles.desktop
@@ -1,18 +1,6 @@
-#TODO: more build-out, desktop actions, translations?
 [Desktop Entry]
 Name=COSMIC Files
-Name[ar]=ملفات COSMIC
-Name[cs]=Soubory COSMIC
-Name[zh_CN]=COSMIC 文件管理器
-Name[pl]=Pliki COSMIC
-Name[pt_BR]=Arquivos
-Name[ru]=Файлы
-Name[hu]=COSMIC Fájlok
-Name[pt]=Arquivos
-Name[sk]=Súbory COSMIC
-Name[sv]=COSMIC Filer
-Name[es]=Archivos COSMIC
-Name[it]=COSMIC File
+Comment=File manager for the COSMIC desktop
 Exec=cosmic-files %U
 Terminal=false
 Type=Application
@@ -20,13 +8,4 @@ StartupNotify=true
 Icon=com.system76.CosmicFiles
 Categories=COSMIC;Utility;FileManager;
 Keywords=Folder;Manager;
-Keywords[ar]=مجلد;ملف;مدير;
-Keywords[cs]=Složky;Správce;Manažer;Prohlížeč;
-Keywords[pl]=Katalogi;Pliki;Menedżer;
-Keywords[pt]=Pastas;Gerenciador;Arquivos;Gestor;Explorer;
-Keywords[hu]=mappa;fájl;kezelő
-Keywords[sk]=Priečinok;Správca;Súbory;Manažér;Prehliadač;
-Keywords[sv]=Folder;Katalog;Mapp;Manager;
-Keywords[es]=Archivos;Ficheros;Gestor;Explorador;
-Keywords[it]=File;Archivi;Cartelle;Explorer;
 MimeType=inode/directory;

--- a/res/com.system76.CosmicFiles.metainfo.xml
+++ b/res/com.system76.CosmicFiles.metainfo.xml
@@ -9,27 +9,7 @@
   <url type="homepage">https://github.com/pop-os/cosmic-files</url>
   <url type="bugtracker">https://github.com/pop-os/cosmic-files</url>
   <name>COSMIC Files</name>
-  <name xml:lang="ar">ملفات COSMIC</name>
-  <name xml:lang="cs">Soubory COSMIC</name>
-  <name xml:lang="pl">Pliki COSMIC</name>
-  <name xml:lang="hu">COSMIC Fájlok</name>
-  <name xml:lang="pt_BR">Arquivos</name>
-  <name xml:lang="pt">Arquivos</name>
-  <name xml:lang="sk">Súbory COSMIC</name>
-  <name xml:lang="es">Archivos COSMIC</name>
-  <name xml:lang="it">COSMIC File</name>
-  <name xml:lang="sv">COSMIC Filer</name>
   <summary>File manager for the COSMIC desktop</summary>
-  <summary xml:lang="ar">مدير ملفات لسطح مكتب COSMIC</summary>
-  <summary xml:lang="cs">Správce souborů pro prostředí COSMIC</summary>
-  <summary xml:lang="pl">Menedżer plików pulpitu COSMIC</summary>
-  <summary xml:lang="hu">Fájlkezelő a COSMIC asztali környezethez</summary>
-  <summary xml:lang="pt_BR">Gerenciador de arquivos do COSMIC</summary>
-  <summary xml:lang="pt">Gerenciador de arquivos do COSMIC</summary>
-  <summary xml:lang="sk">Správca súborov pre prostredie COSMIC</summary>
-  <summary xml:lang="es">Gestor de archivos de COSMIC</summary>
-  <summary xml:lang="it">File manager di COSMIC</summary>
-  <summary xml:lang="sv">Filhanterare för skrivbordsmiljön COSMIC</summary>
   <description>
     <p>File manager for the COSMIC desktop</p>
     <p xml:lang="ar">مدير ملفات لسطح مكتب COSMIC</p>
@@ -43,6 +23,10 @@
     <p xml:lang="it">File manager di COSMIC</p>
     <p xml:lang="sv">Filhanterare för skrivbordsmiljön COSMIC</p>
   </description>
+  <keywords>
+    <keyword>Folder</keyword>
+    <keyword>Manager</keyword>
+  </keywords>
   <launchable type="desktop-id">com.system76.CosmicFiles.desktop</launchable>
   <icon type="remote" height="256" width="256">https://raw.githubusercontent.com/pop-os/cosmic-files/master/res/icons/hicolor/256x256/apps/com.system76.CosmicFiles.svg</icon>
   <provides>

--- a/src/app.rs
+++ b/src/app.rs
@@ -2211,6 +2211,7 @@ impl Application for App {
             .icon(icon::from_name(Self::APP_ID))
             .version(env!("CARGO_PKG_VERSION"))
             .author("System76")
+            .comments(fl!("comment"))
             .license("GPL-3.0-only")
             .license_url("https://spdx.org/licenses/GPL-3.0-only")
             .developers([("Jeremy Soller", "jeremy@system76.com")])


### PR DESCRIPTION
This makes it possible to translate these in weblate. The only exception is the metainfo description, which has a complex translation format.