### PR TITLE
Clear the prefix selection buffer when changing location

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -4172,6 +4172,8 @@ impl Application for App {
                             self.activate_nav_model_location(&tab_path);
 
                             self.tab_model.text_set(entity, tab_title);
+                            // clear the prefix selection buffer when changing location
+                            self.type_select_prefix.clear();
                             commands.push(Task::batch([
                                 self.update_title(),
                                 self.update_watcher(),


### PR DESCRIPTION
This has been bugging me for some time and I'm sure it will be a noticeable improvement for other users as well. I didn't find an issue for it, but since it's a very minor one-line change, I hope it's fine that I'm just sending a PR.