### PR TITLE
fix: Remove inappropriate context menu options while in Recents

### DIFF
--- a/src/menu.rs
+++ b/src/menu.rs
@@ -247,14 +247,19 @@ pub fn context_menu<'a>(
             } else {
                 //TODO: need better designs for menu with no selection
                 //TODO: have things like properties but they apply to the folder?
-                children.push(menu_item(fl!("new-folder"), Action::NewFolder).into());
-                children.push(menu_item(fl!("new-file"), Action::NewFile).into());
-                children.push(menu_item(fl!("open-in-terminal"), Action::OpenTerminal).into());
-                children.push(divider::horizontal::light().into());
+                if tab.location != Location::Recents {
+                    children.push(menu_item(fl!("new-folder"), Action::NewFolder).into());
+                    children.push(menu_item(fl!("new-file"), Action::NewFile).into());
+                    children.push(menu_item(fl!("open-in-terminal"), Action::OpenTerminal).into());
+                    children.push(divider::horizontal::light().into());
+                }
+
                 if tab.mode.multiple() {
                     children.push(menu_item(fl!("select-all"), Action::SelectAll).into());
                 }
-                children.push(menu_item(fl!("paste"), Action::Paste).into());
+                if tab.location != Location::Recents {
+                    children.push(menu_item(fl!("paste"), Action::Paste).into());
+                }
 
                 //TODO: only show if cosmic-settings is found?
                 if matches!(tab.mode, tab::Mode::Desktop) {


### PR DESCRIPTION
It's not a regular folder, which means:
- It can't be modified, so the following options are removed:
  - New file
  - New folder
  - Paste
- It can't be opened as a folder, so the following options are removed:
  - Open in terminal

Fixes https://github.com/pop-os/cosmic-files/issues/968

- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

