### PR TITLE
Disable wgpu feature in cosmic-files-applet

### DIFF
--- a/cosmic-files-applet/Cargo.toml
+++ b/cosmic-files-applet/Cargo.toml
@@ -10,4 +10,4 @@ zbus = "4" # Blocking connection in zbus 5 hangs
 [dependencies.cosmic-files]
 path = ".."
 default-features = false
-features = ["desktop", "gvfs", "wayland", "wgpu", "desktop-applet"]
+features = ["desktop", "gvfs", "wayland", "desktop-applet"]


### PR DESCRIPTION
It does not seem to measurably improve performance and it causes cosmic-files-applet to use way too much VRAM.

On my system, with 3 1440p monitors, cosmic-files-applet with wgpu uses 518MB VRAM and 39MB RAM when launched. Disabling wgpu, and it uses no VRAM and 30MB RAM.