### PR TITLE
feat: add copy-path button to details panel

### DIFF
--- a/i18n/en/cosmic_files.ftl
+++ b/i18n/en/cosmic_files.ftl
@@ -289,6 +289,7 @@ default-app = {$name} (default)
 show-details = Show details
 type = Type: {$mime}
 items = Items: {$items}
+item-path = Path: {$path}
 item-size = Size: {$size}
 item-created = Created: {$created}
 item-modified = Modified: {$modified}

--- a/src/app.rs
+++ b/src/app.rs
@@ -4329,6 +4329,9 @@ impl Application for App {
                             config_set!(favorites, favorites);
                             commands.push(self.update_config());
                         }
+                        tab::Command::CopyString(text) => {
+                            return clipboard::write(text);
+                        }
                         tab::Command::AutoScroll(scroll_speed) => {
                             // converting an f32 to an i16 here by multiplying by 10 and casting to i16
                             // further resolution isn't necessary

--- a/src/tab.rs
+++ b/src/tab.rs
@@ -1792,6 +1792,7 @@ pub enum Command {
     OpenFile(Vec<PathBuf>),
     OpenInNewTab(PathBuf),
     OpenInNewWindow(PathBuf),
+    CopyString(String),
     OpenTrash,
     Preview(PreviewKind),
     SetOpenWith(Mime, String),
@@ -1806,6 +1807,7 @@ pub enum Message {
     AddNetworkDrive,
     AutoScroll(Option<f32>),
     Click(Option<usize>),
+    CopyString(String),
     DoubleClick(Option<usize>),
     ClickRelease(Option<usize>),
     Config(TabConfig),
@@ -2452,6 +2454,32 @@ impl Item {
             "type",
             mime = self.mime.to_string()
         )));
+        if let Some(path) = self.path_opt() {
+            let path_str = path.display().to_string();
+            details = details.push(
+                widget::row::with_capacity(2)
+                    .align_y(Alignment::Start)
+                    .spacing(space_xxxs)
+                    .push(
+                        widget::text::body(fl!(
+                            "item-path",
+                            path = path_str.clone()
+                        ))
+                        .wrapping(cosmic::iced_core::text::Wrapping::WordOrGlyph)
+                        .width(Length::Fill),
+                    )
+                    .push(
+                        widget::tooltip(
+                            widget::button::icon(widget::icon::from_name("edit-copy-symbolic").size(16))
+                                .extra_small()
+                                .on_press(Message::CopyString(path_str))
+                                .class(cosmic::theme::Button::Icon),
+                            widget::text::body(fl!("copy-path")),
+                            widget::tooltip::Position::Bottom,
+                        ),
+                    ),
+            );
+        }
         let mut settings = Vec::new();
         if let Some(mime_app_cache) = mime_app_cache_opt {
             let mime_apps = mime_app_cache.get(&self.mime);
@@ -3563,6 +3591,9 @@ impl Tab {
                 self.context_menu = None;
 
                 commands.push(Command::Action(action));
+            }
+            Message::CopyString(text) => {
+                commands.push(Command::CopyString(text));
             }
             Message::ContextMenu(point_opt, _) => {
                 self.edit_location = None;


### PR DESCRIPTION
- [x] I have disclosed use of any AI generated code in my commit messages.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

Adds a copy button next to the file path in the details panel. Complements Ctrl+Shift+C (#1370) with a discoverable UI element.