### PR TITLE
Support MIME subclasses in dialog scanning

### DIFF
--- a/src/dialog.rs
+++ b/src/dialog.rs
@@ -40,7 +40,7 @@ use crate::localize::LANGUAGE_SORTER;
 use crate::mounter::{MOUNTERS, MounterItem, MounterItems, MounterKey, MounterMessage};
 use crate::tab::{self, ItemMetadata, Location, SearchLocation, Tab};
 use crate::zoom::{zoom_in_view, zoom_out_view, zoom_to_default};
-use crate::{fl, home_dir, menu};
+use crate::{fl, home_dir, menu, mime_icon};
 
 #[derive(Clone, Debug)]
 pub struct DialogMessage(cosmic::Action<Message>);
@@ -1919,11 +1919,13 @@ impl Application for App {
                         items.retain(|item| {
                             // Directories are always shown
                             item.metadata.is_dir()
+                                // Check for mime type match (first because it is faster)
                                     || mimes.iter().any(|filter_mime| {
                                         if filter_mime.subtype() == mime::STAR {
                                             filter_mime.type_() == item.mime.type_()
                                         } else {
                                             *filter_mime == item.mime
+                                                || mime_icon::is_mime_subclass_of(&item.mime, filter_mime)
                                         }
                                     })
                                 // Check for glob match (last because it is slower)

--- a/src/mime_icon.rs
+++ b/src/mime_icon.rs
@@ -124,3 +124,11 @@ pub fn parent_mime_types(mime: &Mime) -> Option<Vec<Mime>> {
     let mime_icon_cache = MIME_ICON_CACHE.lock().unwrap();
     mime_icon_cache.shared_mime_info.get_parents_aliased(mime)
 }
+
+pub fn is_mime_subclass_of(mime_type: &Mime, base: &Mime) -> bool {
+    let mime_icon_cache = MIME_ICON_CACHE.lock().unwrap();
+
+    mime_icon_cache
+        .shared_mime_info
+        .mime_type_subclass(mime_type, base)
+}


### PR DESCRIPTION
Fix a bug where files with MIME types that are sub-classes of the filtered MIME types do not appear in the file dialog.

The file dialog only does strict equality checks when deciding which file MIME types match the filter list types. Augment the logic to also check if files are a subclass of the filter types.

Common examples fixed by this are ISO files. Modern Linux systems identify them as `application/vnd.efi.iso` which would not appear if the filter only had, say, `application/x-cd-image`. Now they do.

Partially fixes #1596

- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

