### PR TITLE
Auto focus next item on delete

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -89,8 +89,8 @@ use crate::{
     mime_icon,
     mounter::{MOUNTERS, MounterAuth, MounterItem, MounterItems, MounterKey, MounterMessage},
     operation::{
-        Controller, Operation, OperationError, OperationErrorType, OperationSelection,
-        ReplaceResult, copy_unique_path,
+        self, Controller, Operation, OperationError, OperationErrorType, OperationMetadata,
+        OperationSelection, ReplaceResult, copy_unique_path,
     },
     spawn_detached::spawn_detached,
     tab::{
@@ -1232,7 +1232,11 @@ impl App {
             )));
         }
         if !trash_paths.is_empty() {
-            tasks.push(self.operation(Operation::Delete { paths: trash_paths }));
+            let metadata = self.operation_metadata();
+            tasks.push(self.operation(Operation::Delete {
+                paths: trash_paths,
+                metadata,
+            }));
         }
         Task::batch(tasks)
     }
@@ -1276,6 +1280,32 @@ impl App {
             },
         ))
         .map(cosmic::Action::App)
+    }
+
+    /// [`OperationMetadata`] for currently focused [`Tab`].
+    fn operation_metadata(&self) -> OperationMetadata {
+        let tab_entity = self.tab_model.active();
+        let tab: Option<&Tab> = self.tab_model.data(tab_entity);
+        let selected = tab.and_then(|tab| {
+            let index = tab.select_focus?;
+            let position = tab.items_opt()?.get(index)?.pos_opt.get()?;
+
+            Some(operation::SelectedMetadata { index, position })
+        });
+        let selected_range = tab.and_then(|tab| {
+            let index_range = tab.select_range?;
+            let start_pos = tab.items_opt()?.get(index_range.0)?.pos_opt.get()?;
+
+            Some(operation::SelectedRange {
+                index_range,
+                start_pos,
+            })
+        });
+        OperationMetadata {
+            tab_entity,
+            selected,
+            selected_range,
+        }
     }
 
     fn remove_window(&mut self, id: &window::Id) {
@@ -1513,6 +1543,43 @@ impl App {
         if let Some(tab) = self.tab_model.data_mut::<Tab>(entity) {
             tab.cut_selected();
         }
+    }
+
+    /// Focus next item after destructive mutative operation.
+    ///
+    /// Some operations mutate the [`Tab`] in a destructive manner, such as deleting or cutting
+    /// items. It's ergonomic to automatically select the next item.
+    fn focus_next_after_op(&mut self, metadata: OperationMetadata) -> Option<PathBuf> {
+        // This function needs to take care to only select the next item if the tab state did
+        // not change during the operation. In other words, the next item should only be selected
+        // if the user is on the same tab with the same selected (and now deleted/cutted)
+        // items.
+        if self.tab_model.is_active(metadata.tab_entity)
+            && let Some(tab) = self.tab_model.active_data_mut::<Tab>()
+        {
+            let index = if let Some(operation::SelectedMetadata { index, .. }) = metadata.selected
+                && Some(index) == tab.select_focus
+            {
+                index + 1
+            } else if let Some(operation::SelectedRange { index_range, .. }) =
+                metadata.selected_range
+                && Some(index_range) == tab.select_range
+            {
+                index_range.0 + 1
+            } else {
+                return None;
+            };
+
+            if let Some(item) = tab.items_opt().and_then(|items| items.get(index))
+                && let Some(position) = item.pos_opt.get()
+                && let Some(path) = item.path_opt().cloned()
+            {
+                tab.select_position(position.0, position.1, false);
+                return Some(path);
+            }
+        }
+
+        None
     }
 
     fn update_config(&mut self) -> Task<Message> {
@@ -3875,12 +3942,12 @@ impl Application for App {
                     self.progress_operations.remove(id);
                 }
             }
-            Message::PendingComplete(id, op_sel) => {
+            Message::PendingComplete(id, mut op_sel) => {
                 let mut commands = Vec::with_capacity(4);
                 if let Some((op, _)) = self.pending_operations.remove(&id) {
                     // Show toast for some operations
                     if let Some(description) = op.toast() {
-                        if let Operation::Delete { ref paths } = op {
+                        if let Operation::Delete { ref paths, .. } = op {
                             let paths: Arc<[PathBuf]> = Arc::from(paths.as_slice());
                             commands.push(
                                 self.toasts
@@ -3917,6 +3984,18 @@ impl Application for App {
                         if self.update_favorites(&path_changes) {
                             commands.push(self.update_config());
                         }
+                    }
+
+                    // Select next item if necessary
+                    match op {
+                        Operation::Delete { metadata, .. } => {
+                            if let Some(path) = self.focus_next_after_op(metadata) {
+                                op_sel.selected.reserve_exact(1);
+                                op_sel.selected.push(path);
+                            }
+                        }
+                        // XXX: Repeat for all ops that change the tab
+                        _ => (),
                     }
 
                     if matches!(op, Operation::RemoveFromRecents { .. }) {

--- a/src/app.rs
+++ b/src/app.rs
@@ -90,7 +90,7 @@ use crate::{
     mounter::{MOUNTERS, MounterAuth, MounterItem, MounterItems, MounterKey, MounterMessage},
     operation::{
         self, Controller, Operation, OperationError, OperationErrorType, OperationMetadata,
-        OperationSelection, ReplaceResult, copy_unique_path,
+        OperationSelection, ReplaceResult, SelectedItems, copy_unique_path,
     },
     spawn_detached::spawn_detached,
     tab::{
@@ -564,6 +564,7 @@ pub enum DialogPage {
     },
     PermanentlyDelete {
         paths: Box<[PathBuf]>,
+        metadata: OperationMetadata,
     },
     DeleteTrash {
         items: Vec<TrashItem>,
@@ -1224,9 +1225,11 @@ impl App {
 
         let mut tasks = Vec::new();
         if !dialog_paths.is_empty() {
+            let metadata = self.operation_metadata();
             tasks.push(self.update(Message::DialogPush(
                 DialogPage::PermanentlyDelete {
                     paths: dialog_paths.into_boxed_slice(),
+                    metadata,
                 },
                 Some(PERMANENT_DELETE_BUTTON_ID.clone()),
             )));
@@ -1287,24 +1290,23 @@ impl App {
         let tab_entity = self.tab_model.active();
         let tab: Option<&Tab> = self.tab_model.data(tab_entity);
         let selected = tab.and_then(|tab| {
-            let index = tab.select_focus?;
-            let position = tab.items_opt()?.get(index)?.pos_opt.get()?;
-
-            Some(operation::SelectedMetadata { index, position })
-        });
-        let selected_range = tab.and_then(|tab| {
-            let index_range = tab.select_range?;
-            let start_pos = tab.items_opt()?.get(index_range.0)?.pos_opt.get()?;
-
-            Some(operation::SelectedRange {
-                index_range,
-                start_pos,
-            })
+            if let Some(index) = tab.select_focus {
+                let position = tab.items_opt()?.get(index)?.pos_opt.get()?;
+                Some(SelectedItems::Single { index, position })
+            } else if let Some((first, last)) = tab.select_range {
+                let first_pos = tab.items_opt()?.get(first)?.pos_opt.get()?;
+                Some(SelectedItems::Range {
+                    first,
+                    last,
+                    first_pos,
+                })
+            } else {
+                None
+            }
         });
         OperationMetadata {
             tab_entity,
             selected,
-            selected_range,
         }
     }
 
@@ -1548,29 +1550,26 @@ impl App {
     /// Focus next item after destructive mutative operation.
     ///
     /// Some operations mutate the [`Tab`] in a destructive manner, such as deleting or cutting
-    /// items. It's ergonomic to automatically select the next item.
+    /// items. It's ergonomic to automatically select the next item in some cases.
     fn focus_next_after_op(&mut self, metadata: OperationMetadata) -> Option<PathBuf> {
         // This function needs to take care to only select the next item if the tab state did
         // not change during the operation. In other words, the next item should only be selected
-        // if the user is on the same tab with the same selected (and now deleted/cutted)
-        // items.
+        // if the user is on the same tab with the same selected (and now removed) items.
         if self.tab_model.is_active(metadata.tab_entity)
             && let Some(tab) = self.tab_model.active_data_mut::<Tab>()
+            && let Some(selected) = metadata.selected
         {
-            let index = if let Some(operation::SelectedMetadata { index, .. }) = metadata.selected
-                && Some(index) == tab.select_focus
-            {
-                index + 1
-            } else if let Some(operation::SelectedRange { index_range, .. }) =
-                metadata.selected_range
-                && Some(index_range) == tab.select_range
-            {
-                index_range.0 + 1
-            } else {
-                return None;
+            let index = match selected {
+                SelectedItems::Single { index, .. } if Some(index) == tab.select_focus => index + 1,
+                SelectedItems::Range { first, last, .. }
+                    if Some((first, last)) == tab.select_range =>
+                {
+                    first + 1
+                }
+                _ => return None,
             };
 
-            if let Some(item) = tab.items_opt().and_then(|items| items.get(index))
+            if let Some(item) = tab.items_opt()?.get(index)
                 && let Some(position) = item.pos_opt.get()
                 && let Some(path) = item.path_opt().cloned()
             {
@@ -3124,8 +3123,10 @@ impl Application for App {
                                 }
                             }
                         }
-                        DialogPage::PermanentlyDelete { paths } => {
-                            tasks.push(self.operation(Operation::PermanentlyDelete { paths }));
+                        DialogPage::PermanentlyDelete { paths, metadata } => {
+                            tasks.push(
+                                self.operation(Operation::PermanentlyDelete { paths, metadata }),
+                            );
                         }
                         DialogPage::DeleteTrash { items } => {
                             tasks.push(self.operation(Operation::DeleteTrash { items }));
@@ -3987,15 +3988,12 @@ impl Application for App {
                     }
 
                     // Select next item if necessary
-                    match op {
-                        Operation::Delete { metadata, .. } => {
-                            if let Some(path) = self.focus_next_after_op(metadata) {
-                                op_sel.selected.reserve_exact(1);
-                                op_sel.selected.push(path);
-                            }
-                        }
-                        // XXX: Repeat for all ops that change the tab
-                        _ => (),
+                    if let Operation::Delete { metadata, .. }
+                    | Operation::PermanentlyDelete { metadata, .. } = op
+                        && let Some(path) = self.focus_next_after_op(metadata)
+                    {
+                        op_sel.selected.reserve_exact(1);
+                        op_sel.selected.push(path);
                     }
 
                     if matches!(op, Operation::RemoveFromRecents { .. }) {
@@ -4077,8 +4075,9 @@ impl Application for App {
             Message::PermanentlyDelete(entity_opt) => {
                 let paths: Box<[_]> = self.selected_paths(entity_opt).collect();
                 if !paths.is_empty() {
+                    let metadata = self.operation_metadata();
                     return self.push_dialog(
-                        DialogPage::PermanentlyDelete { paths },
+                        DialogPage::PermanentlyDelete { paths, metadata },
                         Some(PERMANENT_DELETE_BUTTON_ID.clone()),
                     );
                 }
@@ -5843,7 +5842,7 @@ impl Application for App {
 
                 dialog
             }
-            DialogPage::PermanentlyDelete { paths } => {
+            DialogPage::PermanentlyDelete { paths, .. } => {
                 let target = if paths.len() == 1 {
                     format!(
                         "\"{}\"",

--- a/src/operation/mod.rs
+++ b/src/operation/mod.rs
@@ -386,6 +386,7 @@ pub enum Operation {
     /// Permanently delete items, skipping the trash
     PermanentlyDelete {
         paths: Box<[PathBuf]>,
+        metadata: OperationMetadata,
     },
     RemoveFromRecents {
         paths: Box<[PathBuf]>,
@@ -528,7 +529,9 @@ impl Operation {
                 name = file_name(path),
                 parent = parent_name(path)
             ),
-            Self::PermanentlyDelete { paths } => fl!("permanently-deleting", items = paths.len()),
+            Self::PermanentlyDelete { paths, .. } => {
+                fl!("permanently-deleting", items = paths.len())
+            }
             Self::Rename { from, to } => {
                 fl!("renaming", from = file_name(from), to = file_name(to))
             }
@@ -595,7 +598,9 @@ impl Operation {
                 name = file_name(path),
                 parent = parent_name(path)
             ),
-            Self::PermanentlyDelete { paths } => fl!("permanently-deleted", items = paths.len()),
+            Self::PermanentlyDelete { paths, .. } => {
+                fl!("permanently-deleted", items = paths.len())
+            }
             Self::RemoveFromRecents { paths } => fl!("removed-from-recents", items = paths.len()),
             Self::Rename { from, to } => fl!("renamed", from = file_name(from), to = file_name(to)),
             Self::Restore { items } => fl!("restored", items = items.len()),
@@ -1042,7 +1047,7 @@ impl Operation {
             }
             .await
             .map_err(wrap_compio_spawn_error)?,
-            Self::PermanentlyDelete { paths } => {
+            Self::PermanentlyDelete { paths, .. } => {
                 let total = paths.len();
                 for (idx, path) in paths.into_iter().enumerate() {
                     controller
@@ -1203,22 +1208,21 @@ impl Operation {
 pub struct OperationMetadata {
     /// ID of tab that launched this operation
     pub tab_entity: Entity,
-    /// Selected item position at operation launch
-    pub selected: Option<SelectedMetadata>,
     /// Selected items positions at operation launch
-    pub selected_range: Option<SelectedRange>,
+    pub selected: Option<SelectedItems>,
 }
 
-#[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
-pub struct SelectedMetadata {
-    pub index: usize,
-    pub position: (usize, usize),
-}
-
-#[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
-pub struct SelectedRange {
-    pub index_range: (usize, usize),
-    pub start_pos: (usize, usize),
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub enum SelectedItems {
+    Single {
+        index: usize,
+        position: (usize, usize),
+    },
+    Range {
+        first: usize,
+        last: usize,
+        first_pos: (usize, usize),
+    },
 }
 
 #[track_caller]

--- a/src/operation/mod.rs
+++ b/src/operation/mod.rs
@@ -5,7 +5,10 @@ use crate::{
     spawn_detached::spawn_detached,
     tab,
 };
-use cosmic::iced::futures::{self, SinkExt, StreamExt, channel::mpsc::Sender, stream};
+use cosmic::{
+    iced::futures::{self, SinkExt, StreamExt, channel::mpsc::Sender, stream},
+    widget::segmented_button::Entity,
+};
 use std::{
     borrow::Cow,
     fmt::Formatter,
@@ -184,7 +187,13 @@ async fn copy_or_move(
             let msg_tx = msg_tx.clone();
             context = context.on_replace(move |op, conflict_count| {
                 let msg_tx = msg_tx.clone();
-                Box::pin(handle_replace(msg_tx, op.from.clone(), op.to.clone(), true, conflict_count))
+                Box::pin(handle_replace(
+                    msg_tx,
+                    op.from.clone(),
+                    op.to.clone(),
+                    true,
+                    conflict_count,
+                ))
             });
         }
 
@@ -348,6 +357,7 @@ pub enum Operation {
     /// Move items to the trash
     Delete {
         paths: Vec<PathBuf>,
+        metadata: OperationMetadata,
     },
     /// Delete a path from the trash
     DeleteTrash {
@@ -479,7 +489,7 @@ impl Operation {
                 to = file_name(to),
                 progress = progress()
             ),
-            Self::Delete { paths } => fl!(
+            Self::Delete { paths, .. } => fl!(
                 "moving",
                 items = paths.len(),
                 from = paths_parent_name(paths),
@@ -551,7 +561,7 @@ impl Operation {
                 from = paths_parent_name(paths),
                 to = file_name(to)
             ),
-            Self::Delete { paths } => fl!(
+            Self::Delete { paths, .. } => fl!(
                 "moved",
                 items = paths.len(),
                 from = paths_parent_name(paths),
@@ -821,7 +831,7 @@ impl Operation {
             Self::Copy { paths, to } => {
                 copy_or_move(paths, to, Method::Copy, msg_tx, controller).await
             }
-            Self::Delete { paths } => {
+            Self::Delete { paths, .. } => {
                 let total = paths.len();
                 for (i, path) in paths.into_iter().enumerate() {
                     futures::executor::block_on(async {
@@ -1187,6 +1197,28 @@ impl Operation {
 
         paths
     }
+}
+
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
+pub struct OperationMetadata {
+    /// ID of tab that launched this operation
+    pub tab_entity: Entity,
+    /// Selected item position at operation launch
+    pub selected: Option<SelectedMetadata>,
+    /// Selected items positions at operation launch
+    pub selected_range: Option<SelectedRange>,
+}
+
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
+pub struct SelectedMetadata {
+    pub index: usize,
+    pub position: (usize, usize),
+}
+
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
+pub struct SelectedRange {
+    pub index_range: (usize, usize),
+    pub start_pos: (usize, usize),
 }
 
 #[track_caller]

--- a/src/tab.rs
+++ b/src/tab.rs
@@ -2819,8 +2819,8 @@ pub struct Tab {
     pub(crate) items_opt: Option<Vec<Item>>,
     pub dnd_hovered: Option<(Location, Instant)>,
     pub(crate) scrollable_id: widget::Id,
-    select_focus: Option<usize>,
-    select_range: Option<(usize, usize)>,
+    pub(crate) select_focus: Option<usize>,
+    pub(crate) select_range: Option<(usize, usize)>,
     clicked: Option<usize>,
     selected_clicked: bool,
     last_right_click: Option<usize>,
@@ -3095,7 +3095,7 @@ impl Tab {
         }
     }
 
-    fn select_position(&mut self, row: usize, col: usize, mod_shift: bool) -> bool {
+    pub(crate) fn select_position(&mut self, row: usize, col: usize, mod_shift: bool) -> bool {
         let mut start = (row, col);
         let mut end = (row, col);
         if mod_shift {


### PR DESCRIPTION
Closes: #1608

The original issue is for the gallery, but after cross-checking with Thunar I implemented this as a general feature. Deleting an item now auto selects and focuses the next item, if any.

---
Draft until I clean up the code a little and add support for `PermanentlyDelete` ~~and cut~~. **I did not implement this for cut because it doesn't seem to make sense to do so.**

To test, create a folder with a few files. Delete one and notice that the next item is automatically highlighted. Repeat a few times to verify that it works with consecutive deletes. Try highlighting a few files with `shift` or your mouse and then deleting them. The next item after the deleted files should still select.

I also tested it with the preview pane/gallery which is what the original issue covers.

- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.