### PR TITLE
fix: apply EXIF orientation for image previews

### DIFF
--- a/src/large_image.rs
+++ b/src/large_image.rs
@@ -262,9 +262,7 @@ pub fn decode_with_orientation<R: std::io::BufRead + std::io::Seek>(
     reader: ImageReader<R>,
 ) -> ImageResult<DynamicImage> {
     reader.into_decoder().and_then(|mut decoder| {
-        let orientation = decoder
-            .orientation()
-            .unwrap_or(Orientation::NoTransforms);
+        let orientation = decoder.orientation().unwrap_or(Orientation::NoTransforms);
         let mut img = DynamicImage::from_decoder(decoder)?;
         img.apply_orientation(orientation);
         Ok(img)
@@ -610,5 +608,143 @@ impl LargeImageManager {
             );
         }
         false
+    }
+}
+
+// Tests for EXIF orientation handling in thumbnail generation.
+// Regression tests for https://github.com/pop-os/cosmic-files/issues/883
+#[cfg(test)]
+mod tests {
+    mod exif_orientation {
+        use std::io;
+
+        use image::{ImageEncoder as _, ImageReader, metadata::Orientation};
+
+        use crate::large_image::decode_with_orientation;
+
+        /// Build a minimal raw TIFF chunk (the payload of an Exif/eXIf block)
+        /// containing only the Orientation tag. All values use little-endian.
+        ///
+        /// See [https://web.archive.org/web/20200412005226/https://www.impulseadventure.com/photo/exif-orientation.html]
+        /// for more information about EXIF orientation values.
+        #[rustfmt::skip]
+        fn make_exif_chunk(orientation: Orientation) -> Vec<u8> {
+            vec![
+                b'I', b'I',                              // marker
+                0x2A, 0x00,                              // TIFF magic = 42
+                0x08, 0x00, 0x00, 0x00,                  // offset to IFD
+                0x01, 0x00,                              // 1 IFD entry
+                0x12, 0x01,                              // tag = 0x0112 (Orientation)
+                0x03, 0x00,                              // type = SHORT
+                0x01, 0x00, 0x00, 0x00,                  // count = 1
+                orientation.to_exif(), 0x00, 0x00, 0x00, // value (padded to 4 bytes)
+                0x00, 0x00, 0x00, 0x00,                  // no next IFD
+            ]
+        }
+
+        /// Write a PNG with EXIF orientation metadata embedded and return a temp file.
+        fn make_png_with_orientation(img: &image::RgbaImage, orientation: Orientation) -> Vec<u8> {
+            let exif_chunk = make_exif_chunk(orientation);
+            let mut data = vec![];
+            let mut encoder = image::codecs::png::PngEncoder::new(&mut data);
+            encoder
+                .set_exif_metadata(exif_chunk)
+                .expect("failed to set exif metadata");
+            encoder
+                .write_image(
+                    img.as_raw(),
+                    img.width(),
+                    img.height(),
+                    image::ExtendedColorType::Rgba8,
+                )
+                .expect("failed to encode PNG");
+            data
+        }
+
+        /// Create a 2×1 RGBA test image: left pixel RED, right pixel GREEN.
+        fn make_2x1_red_green() -> image::RgbaImage {
+            let mut img = image::RgbaImage::new(2, 1);
+            img.put_pixel(0, 0, image::Rgba([255, 0, 0, 255])); // red
+            img.put_pixel(1, 0, image::Rgba([0, 255, 0, 255])); // green
+            img
+        }
+
+        fn png_reader(png_data: &[u8]) -> ImageReader<io::Cursor<&[u8]>> {
+            image::ImageReader::new(io::Cursor::new(png_data))
+                .with_guessed_format()
+                .unwrap()
+        }
+
+        #[test]
+        fn no_orientation_tag_leaves_image_unchanged() {
+            let src = make_2x1_red_green();
+            let png_data = make_png_with_orientation(&src, Orientation::NoTransforms);
+            let decoded = decode_with_orientation(png_reader(&png_data)).unwrap();
+            let rgba = decoded.to_rgba8();
+            assert_eq!(rgba.get_pixel(0, 0), &image::Rgba([255, 0, 0, 255]));
+            assert_eq!(rgba.get_pixel(1, 0), &image::Rgba([0, 255, 0, 255]));
+        }
+
+        #[test]
+        fn exif_orientation_rotate180_is_applied() {
+            let src = make_2x1_red_green();
+            let png_data = make_png_with_orientation(&src, Orientation::Rotate180);
+            let decoded = decode_with_orientation(png_reader(&png_data)).unwrap();
+            let rgba = decoded.to_rgba8();
+            // After 180° rotation of a 2×1 image the pixels swap positions.
+            assert_eq!(
+                rgba.get_pixel(0, 0),
+                &image::Rgba([0, 255, 0, 255]),
+                "left pixel should be green after 180° rotation"
+            );
+            assert_eq!(
+                rgba.get_pixel(1, 0),
+                &image::Rgba([255, 0, 0, 255]),
+                "right pixel should be red after 180° rotation"
+            );
+        }
+
+        #[test]
+        fn exif_orientation_rotate90_cw_is_applied() {
+            let src = make_2x1_red_green();
+            let png_data = make_png_with_orientation(&src, Orientation::Rotate90);
+            let decoded = decode_with_orientation(png_reader(&png_data)).unwrap();
+            let rgba = decoded.to_rgba8();
+            // 2×1 image rotated 90° CW becomes a 1×2 image.
+            // Rotation maps (x,y) → (H-1-y, x) where H=1:
+            //   (0,0) red  → (0, 0)
+            //   (1,0) green → (0, 1)
+            assert_eq!(decoded.width(), 1);
+            assert_eq!(decoded.height(), 2);
+            assert_eq!(
+                rgba.get_pixel(0, 0),
+                &image::Rgba([255, 0, 0, 255]),
+                "top pixel should be red after 90° CW rotation"
+            );
+            assert_eq!(
+                rgba.get_pixel(0, 1),
+                &image::Rgba([0, 255, 0, 255]),
+                "bottom pixel should be green after 90° CW rotation"
+            );
+        }
+
+        #[test]
+        fn exif_orientation_flip_horizontal_is_applied() {
+            let src = make_2x1_red_green();
+            let png_data = make_png_with_orientation(&src, Orientation::FlipHorizontal);
+            let decoded = decode_with_orientation(png_reader(&png_data)).unwrap();
+            let rgba = decoded.to_rgba8();
+            // Horizontal flip swaps left↔right.
+            assert_eq!(
+                rgba.get_pixel(0, 0),
+                &image::Rgba([0, 255, 0, 255]),
+                "left pixel should be green after horizontal flip"
+            );
+            assert_eq!(
+                rgba.get_pixel(1, 0),
+                &image::Rgba([255, 0, 0, 255]),
+                "right pixel should be red after horizontal flip"
+            );
+        }
     }
 }

--- a/src/large_image.rs
+++ b/src/large_image.rs
@@ -1,5 +1,5 @@
 use cosmic::widget;
-use image::ImageReader;
+use image::{DynamicImage, ImageDecoder, ImageReader, ImageResult, metadata::Orientation};
 use std::{
     collections::{HashMap, HashSet},
     path::{Path, PathBuf},
@@ -256,6 +256,21 @@ pub fn check_memory_available(width: u32, height: u32) -> (bool, Option<String>)
     check_ram_available(width, height)
 }
 
+/// Decode an image from a reader, applying any EXIF orientation metadata so that
+/// the returned image is correctly oriented regardless of how the pixels are stored.
+pub fn decode_with_orientation<R: std::io::BufRead + std::io::Seek>(
+    reader: ImageReader<R>,
+) -> ImageResult<DynamicImage> {
+    reader.into_decoder().and_then(|mut decoder| {
+        let orientation = decoder
+            .orientation()
+            .unwrap_or(Orientation::NoTransforms);
+        let mut img = DynamicImage::from_decoder(decoder)?;
+        img.apply_orientation(orientation);
+        Ok(img)
+    })
+}
+
 /// Decode a large image asynchronously in a blocking thread pool.
 ///
 /// This function is used for gallery mode where full-resolution images need to be loaded.
@@ -280,7 +295,7 @@ pub async fn decode_large_image(
                         limits.max_alloc = Some(GALLERY_MEMORY_LIMIT_MB * DECIMAL_MB_TO_BYTES);
                         reader.limits(limits);
 
-                        match reader.decode() {
+                        match decode_with_orientation(reader) {
                             Ok(img) => {
                                 let rgba = img.into_rgba8();
                                 let orig_width = rgba.width();

--- a/src/tab.rs
+++ b/src/tab.rs
@@ -39,7 +39,7 @@ use icu::{
     },
     locale::preferences::extensions::unicode::keywords::HourCycle,
 };
-use image::{DynamicImage, ImageDecoder, ImageReader, metadata::Orientation};
+use image::{DynamicImage, ImageDecoder, ImageReader};
 use jxl_oxide::integration::JxlDecoder;
 use mime_guess::{Mime, mime};
 use regex::Regex;
@@ -73,7 +73,7 @@ use crate::{
     dialog::DialogKind,
     fl,
     large_image::{
-        LargeImageManager, decode_large_image, exceeds_memory_limit, should_use_dedicated_worker,
+        LargeImageManager, decode_large_image, decode_with_orientation, exceeds_memory_limit, should_use_dedicated_worker,
         should_use_tiling,
     },
     localize::{LANGUAGE_SORTER, LOCALE},
@@ -2148,13 +2148,7 @@ impl ItemThumbnail {
                             let max_ram = max_mem * 1000 * 1000 / jobs as u64;
                             limits.max_alloc = Some(max_ram);
                             reader.limits(limits);
-                            match reader.into_decoder().and_then(|mut decoder| {
-                                let orientation =
-                                    decoder.orientation().unwrap_or(Orientation::NoTransforms);
-                                let mut img = DynamicImage::from_decoder(decoder)?;
-                                img.apply_orientation(orientation);
-                                Ok(img)
-                            }) {
+                            match decode_with_orientation(reader) {
                                 Ok(img) => Some(img),
                                 Err(err) => {
                                     log::warn!("failed to decode {}: {}", path.display(), err);

--- a/src/tab.rs
+++ b/src/tab.rs
@@ -73,8 +73,8 @@ use crate::{
     dialog::DialogKind,
     fl,
     large_image::{
-        LargeImageManager, decode_large_image, decode_with_orientation, exceeds_memory_limit, should_use_dedicated_worker,
-        should_use_tiling,
+        LargeImageManager, decode_large_image, decode_with_orientation, exceeds_memory_limit,
+        should_use_dedicated_worker, should_use_tiling,
     },
     localize::{LANGUAGE_SORTER, LOCALE},
     menu, mime_app,
@@ -7348,148 +7348,6 @@ mod tests {
                     assert_eq!(set_mode_part(mode_no_other, MODE_SHIFT_OTHER, other), mode);
                 }
             }
-        }
-    }
-
-    // Tests for EXIF orientation handling in thumbnail generation.
-    // Regression tests for https://github.com/pop-os/cosmic-files/issues/883
-    mod exif_orientation {
-        use image::{ImageDecoder as _, ImageEncoder as _, metadata::Orientation};
-        use tempfile::NamedTempFile;
-
-        /// Build a minimal raw TIFF chunk (the payload of an Exif/eXIf block)
-        /// containing only the Orientation tag. All values use little-endian.
-        #[rustfmt::skip]
-        fn make_exif_chunk(orientation: Orientation) -> Vec<u8> {
-            vec![
-                b'I', b'I',                              // marker
-                0x2A, 0x00,                              // TIFF magic = 42
-                0x08, 0x00, 0x00, 0x00,                  // offset to IFD
-                0x01, 0x00,                              // 1 IFD entry
-                0x12, 0x01,                              // tag = 0x0112 (Orientation)
-                0x03, 0x00,                              // type = SHORT
-                0x01, 0x00, 0x00, 0x00,                  // count = 1
-                orientation.to_exif(), 0x00, 0x00, 0x00, // value (padded to 4 bytes)
-                0x00, 0x00, 0x00, 0x00,                  // no next IFD
-            ]
-        }
-
-        /// Write a PNG with EXIF orientation metadata embedded and return a temp file.
-        fn write_png_with_orientation(
-            img: &image::RgbaImage,
-            orientation: Orientation,
-        ) -> NamedTempFile {
-            let exif_chunk = make_exif_chunk(orientation);
-            let temp = NamedTempFile::new().expect("failed to create temp file");
-            let file = std::fs::File::create(temp.path()).expect("failed to create file");
-            let mut encoder = image::codecs::png::PngEncoder::new(file);
-            encoder
-                .set_exif_metadata(exif_chunk)
-                .expect("failed to set exif metadata");
-            encoder
-                .write_image(
-                    img.as_raw(),
-                    img.width(),
-                    img.height(),
-                    image::ExtendedColorType::Rgba8,
-                )
-                .expect("failed to encode PNG");
-            temp
-        }
-
-        /// Decode a PNG file using the same approach as the thumbnail generator:
-        /// into_decoder() → orientation() → from_decoder() → apply_orientation()
-        fn decode_with_orientation(path: &std::path::Path) -> image::DynamicImage {
-            let reader = image::ImageReader::open(path)
-                .expect("failed to open")
-                .with_guessed_format()
-                .expect("failed to guess format");
-            let mut decoder = reader.into_decoder().expect("failed to create decoder");
-            let orientation = decoder.orientation().unwrap_or(Orientation::NoTransforms);
-            let mut img =
-                image::DynamicImage::from_decoder(decoder).expect("failed to decode image");
-            img.apply_orientation(orientation);
-            img
-        }
-
-        /// Create a 2×1 RGBA test image: left pixel RED, right pixel GREEN.
-        fn make_2x1_red_green() -> image::RgbaImage {
-            let mut img = image::RgbaImage::new(2, 1);
-            img.put_pixel(0, 0, image::Rgba([255, 0, 0, 255])); // red
-            img.put_pixel(1, 0, image::Rgba([0, 255, 0, 255])); // green
-            img
-        }
-
-        #[test]
-        fn no_orientation_tag_leaves_image_unchanged() {
-            let src = make_2x1_red_green();
-            let tmp = write_png_with_orientation(&src, Orientation::NoTransforms);
-            let decoded = decode_with_orientation(tmp.path());
-            let rgba = decoded.to_rgba8();
-            assert_eq!(rgba.get_pixel(0, 0), &image::Rgba([255, 0, 0, 255]));
-            assert_eq!(rgba.get_pixel(1, 0), &image::Rgba([0, 255, 0, 255]));
-        }
-
-        #[test]
-        fn exif_orientation_rotate180_is_applied() {
-            let src = make_2x1_red_green();
-            let tmp = write_png_with_orientation(&src, Orientation::Rotate180);
-            let decoded = decode_with_orientation(tmp.path());
-            let rgba = decoded.to_rgba8();
-            // After 180° rotation of a 2×1 image the pixels swap positions.
-            assert_eq!(
-                rgba.get_pixel(0, 0),
-                &image::Rgba([0, 255, 0, 255]),
-                "left pixel should be green after 180° rotation"
-            );
-            assert_eq!(
-                rgba.get_pixel(1, 0),
-                &image::Rgba([255, 0, 0, 255]),
-                "right pixel should be red after 180° rotation"
-            );
-        }
-
-        #[test]
-        fn exif_orientation_rotate90_cw_is_applied() {
-            let src = make_2x1_red_green();
-            let tmp = write_png_with_orientation(&src, Orientation::Rotate90);
-            let decoded = decode_with_orientation(tmp.path());
-            let rgba = decoded.to_rgba8();
-            // 2×1 image rotated 90° CW becomes a 1×2 image.
-            // Rotation maps (x,y) → (H-1-y, x) where H=1:
-            //   (0,0) red  → (0, 0)
-            //   (1,0) green → (0, 1)
-            assert_eq!(decoded.width(), 1);
-            assert_eq!(decoded.height(), 2);
-            assert_eq!(
-                rgba.get_pixel(0, 0),
-                &image::Rgba([255, 0, 0, 255]),
-                "top pixel should be red after 90° CW rotation"
-            );
-            assert_eq!(
-                rgba.get_pixel(0, 1),
-                &image::Rgba([0, 255, 0, 255]),
-                "bottom pixel should be green after 90° CW rotation"
-            );
-        }
-
-        #[test]
-        fn exif_orientation_flip_horizontal_is_applied() {
-            let src = make_2x1_red_green();
-            let tmp = write_png_with_orientation(&src, Orientation::FlipHorizontal);
-            let decoded = decode_with_orientation(tmp.path());
-            let rgba = decoded.to_rgba8();
-            // Horizontal flip swaps left↔right.
-            assert_eq!(
-                rgba.get_pixel(0, 0),
-                &image::Rgba([0, 255, 0, 255]),
-                "left pixel should be green after horizontal flip"
-            );
-            assert_eq!(
-                rgba.get_pixel(1, 0),
-                &image::Rgba([255, 0, 0, 255]),
-                "right pixel should be red after horizontal flip"
-            );
         }
     }
 }

--- a/src/tab.rs
+++ b/src/tab.rs
@@ -39,7 +39,7 @@ use icu::{
     },
     locale::preferences::extensions::unicode::keywords::HourCycle,
 };
-use image::{DynamicImage, ImageDecoder, ImageReader};
+use image::{DynamicImage, ImageDecoder, ImageReader, metadata::Orientation};
 use jxl_oxide::integration::JxlDecoder;
 use mime_guess::{Mime, mime};
 use regex::Regex;
@@ -2148,8 +2148,14 @@ impl ItemThumbnail {
                             let max_ram = max_mem * 1000 * 1000 / jobs as u64;
                             limits.max_alloc = Some(max_ram);
                             reader.limits(limits);
-                            match reader.decode() {
-                                Ok(reader) => Some(reader),
+                            match reader.into_decoder().and_then(|mut decoder| {
+                                let orientation =
+                                    decoder.orientation().unwrap_or(Orientation::NoTransforms);
+                                let mut img = DynamicImage::from_decoder(decoder)?;
+                                img.apply_orientation(orientation);
+                                Ok(img)
+                            }) {
+                                Ok(img) => Some(img),
                                 Err(err) => {
                                     log::warn!("failed to decode {}: {}", path.display(), err);
                                     None
@@ -7348,6 +7354,148 @@ mod tests {
                     assert_eq!(set_mode_part(mode_no_other, MODE_SHIFT_OTHER, other), mode);
                 }
             }
+        }
+    }
+
+    // Tests for EXIF orientation handling in thumbnail generation.
+    // Regression tests for https://github.com/pop-os/cosmic-files/issues/883
+    mod exif_orientation {
+        use image::{ImageDecoder as _, ImageEncoder as _, metadata::Orientation};
+        use tempfile::NamedTempFile;
+
+        /// Build a minimal raw TIFF chunk (the payload of an Exif/eXIf block)
+        /// containing only the Orientation tag. All values use little-endian.
+        #[rustfmt::skip]
+        fn make_exif_chunk(orientation: Orientation) -> Vec<u8> {
+            vec![
+                b'I', b'I',                              // marker
+                0x2A, 0x00,                              // TIFF magic = 42
+                0x08, 0x00, 0x00, 0x00,                  // offset to IFD
+                0x01, 0x00,                              // 1 IFD entry
+                0x12, 0x01,                              // tag = 0x0112 (Orientation)
+                0x03, 0x00,                              // type = SHORT
+                0x01, 0x00, 0x00, 0x00,                  // count = 1
+                orientation.to_exif(), 0x00, 0x00, 0x00, // value (padded to 4 bytes)
+                0x00, 0x00, 0x00, 0x00,                  // no next IFD
+            ]
+        }
+
+        /// Write a PNG with EXIF orientation metadata embedded and return a temp file.
+        fn write_png_with_orientation(
+            img: &image::RgbaImage,
+            orientation: Orientation,
+        ) -> NamedTempFile {
+            let exif_chunk = make_exif_chunk(orientation);
+            let temp = NamedTempFile::new().expect("failed to create temp file");
+            let file = std::fs::File::create(temp.path()).expect("failed to create file");
+            let mut encoder = image::codecs::png::PngEncoder::new(file);
+            encoder
+                .set_exif_metadata(exif_chunk)
+                .expect("failed to set exif metadata");
+            encoder
+                .write_image(
+                    img.as_raw(),
+                    img.width(),
+                    img.height(),
+                    image::ExtendedColorType::Rgba8,
+                )
+                .expect("failed to encode PNG");
+            temp
+        }
+
+        /// Decode a PNG file using the same approach as the thumbnail generator:
+        /// into_decoder() → orientation() → from_decoder() → apply_orientation()
+        fn decode_with_orientation(path: &std::path::Path) -> image::DynamicImage {
+            let reader = image::ImageReader::open(path)
+                .expect("failed to open")
+                .with_guessed_format()
+                .expect("failed to guess format");
+            let mut decoder = reader.into_decoder().expect("failed to create decoder");
+            let orientation = decoder.orientation().unwrap_or(Orientation::NoTransforms);
+            let mut img =
+                image::DynamicImage::from_decoder(decoder).expect("failed to decode image");
+            img.apply_orientation(orientation);
+            img
+        }
+
+        /// Create a 2×1 RGBA test image: left pixel RED, right pixel GREEN.
+        fn make_2x1_red_green() -> image::RgbaImage {
+            let mut img = image::RgbaImage::new(2, 1);
+            img.put_pixel(0, 0, image::Rgba([255, 0, 0, 255])); // red
+            img.put_pixel(1, 0, image::Rgba([0, 255, 0, 255])); // green
+            img
+        }
+
+        #[test]
+        fn no_orientation_tag_leaves_image_unchanged() {
+            let src = make_2x1_red_green();
+            let tmp = write_png_with_orientation(&src, Orientation::NoTransforms);
+            let decoded = decode_with_orientation(tmp.path());
+            let rgba = decoded.to_rgba8();
+            assert_eq!(rgba.get_pixel(0, 0), &image::Rgba([255, 0, 0, 255]));
+            assert_eq!(rgba.get_pixel(1, 0), &image::Rgba([0, 255, 0, 255]));
+        }
+
+        #[test]
+        fn exif_orientation_rotate180_is_applied() {
+            let src = make_2x1_red_green();
+            let tmp = write_png_with_orientation(&src, Orientation::Rotate180);
+            let decoded = decode_with_orientation(tmp.path());
+            let rgba = decoded.to_rgba8();
+            // After 180° rotation of a 2×1 image the pixels swap positions.
+            assert_eq!(
+                rgba.get_pixel(0, 0),
+                &image::Rgba([0, 255, 0, 255]),
+                "left pixel should be green after 180° rotation"
+            );
+            assert_eq!(
+                rgba.get_pixel(1, 0),
+                &image::Rgba([255, 0, 0, 255]),
+                "right pixel should be red after 180° rotation"
+            );
+        }
+
+        #[test]
+        fn exif_orientation_rotate90_cw_is_applied() {
+            let src = make_2x1_red_green();
+            let tmp = write_png_with_orientation(&src, Orientation::Rotate90);
+            let decoded = decode_with_orientation(tmp.path());
+            let rgba = decoded.to_rgba8();
+            // 2×1 image rotated 90° CW becomes a 1×2 image.
+            // Rotation maps (x,y) → (H-1-y, x) where H=1:
+            //   (0,0) red  → (0, 0)
+            //   (1,0) green → (0, 1)
+            assert_eq!(decoded.width(), 1);
+            assert_eq!(decoded.height(), 2);
+            assert_eq!(
+                rgba.get_pixel(0, 0),
+                &image::Rgba([255, 0, 0, 255]),
+                "top pixel should be red after 90° CW rotation"
+            );
+            assert_eq!(
+                rgba.get_pixel(0, 1),
+                &image::Rgba([0, 255, 0, 255]),
+                "bottom pixel should be green after 90° CW rotation"
+            );
+        }
+
+        #[test]
+        fn exif_orientation_flip_horizontal_is_applied() {
+            let src = make_2x1_red_green();
+            let tmp = write_png_with_orientation(&src, Orientation::FlipHorizontal);
+            let decoded = decode_with_orientation(tmp.path());
+            let rgba = decoded.to_rgba8();
+            // Horizontal flip swaps left↔right.
+            assert_eq!(
+                rgba.get_pixel(0, 0),
+                &image::Rgba([0, 255, 0, 255]),
+                "left pixel should be green after horizontal flip"
+            );
+            assert_eq!(
+                rgba.get_pixel(1, 0),
+                &image::Rgba([255, 0, 0, 255]),
+                "right pixel should be red after horizontal flip"
+            );
         }
     }
 }


### PR DESCRIPTION
Images with EXIF orientation metadata (e.g. photos taken rotated) were displayed with incorrect rotation/flip in thumbnails and gallery previews because `reader.decode()` ignores orientation metadata.

Switch to `reader.into_decoder()` so the EXIF orientation can be read before decoding, then apply it via `DynamicImage::apply_orientation()`. This fixes rotation and flip for JPEG, PNG, WebP, TIFF and any other format whose image 0.25 decoder implements `orientation()`.

Fixes #883.

I built and ran it locally and tested it with a photo I took on my iPhone 15 Pro. Here's `cosmic-files` before and after:

| Before | After |
|-|-|
| <img width="760" height="412" alt="Screenshot_2026-03-10_10-48-57" src="https://github.com/user-attachments/assets/e9da5811-b66f-4bc5-862b-01fd8d906b6b" /> | <img width="760" height="412" alt="Screenshot_2026-03-10_10-48-31" src="https://github.com/user-attachments/assets/e3c91f50-f95e-4e1f-926a-ab4791fd104c" /> |

I cleared the thumbnail cache with `rm -rf ~/.cache/thumbnails/`. I checked that pressing spacebar to show the image preview is also correct.

- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

