### PR TITLE
Add 'Install Package' context menu for .deb files with install feedback

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -14,6 +14,7 @@ use cosmic::iced::{
 };
 #[cfg(all(feature = "wayland", feature = "desktop-applet"))]
 use cosmic::iced_winit::commands::overlap_notify::overlap_notify;
+use cosmic::widget::Toast;
 use cosmic::{
     Application, ApplicationExt, Element,
     app::{self, Core, Task, context_drawer},
@@ -166,6 +167,7 @@ pub enum Action {
     Gallery,
     HistoryNext,
     HistoryPrevious,
+    InstallDeb,
     ItemDown,
     ItemLeft,
     ItemRight,
@@ -238,6 +240,7 @@ impl Action {
             Self::Gallery => Message::TabMessage(entity_opt, tab::Message::GalleryToggle),
             Self::HistoryNext => Message::TabMessage(entity_opt, tab::Message::GoNext),
             Self::HistoryPrevious => Message::TabMessage(entity_opt, tab::Message::GoPrevious),
+            Self::InstallDeb => Message::InstallDeb(entity_opt),
             Self::ItemDown => Message::TabMessage(entity_opt, tab::Message::ItemDown),
             Self::ItemLeft => Message::TabMessage(entity_opt, tab::Message::ItemLeft),
             Self::ItemRight => Message::TabMessage(entity_opt, tab::Message::ItemRight),
@@ -364,6 +367,8 @@ pub enum Message {
     ExtractToResult(DialogResult),
     #[cfg(all(feature = "wayland", feature = "desktop-applet"))]
     Focused(window::Id),
+    InstallDeb(Option<Entity>),
+    DebInstallResult(Result<(), String>),
     Key(window::Id, Modifiers, Key, Option<SmolStr>),
     LaunchUrl(String),
     MaybeExit,
@@ -3101,6 +3106,20 @@ impl Application for App {
                     self.update(Message::DialogComplete),
                 ]);
             }
+            Message::DebInstallResult(result) => match result {
+                Ok(_) => {
+                    self.toasts
+                        .push(Toast::new("Package installed successfully"));
+                }
+                Err(err) => {
+                    if err == "Package already installed" {
+                        self.toasts.push(Toast::new("Package is already installed"));
+                    } else {
+                        self.toasts
+                            .push(Toast::new(format!("Install failed: {}", err)));
+                    }
+                }
+            },
             Message::ExtractHere(entity_opt) => {
                 let paths: Box<[_]> = self.selected_paths(entity_opt).collect();
                 if let Some(destination) = paths
@@ -3147,6 +3166,43 @@ impl Application for App {
             Message::FileDialogMessage(dialog_message) => {
                 if let Some(dialog) = &mut self.file_dialog_opt {
                     return dialog.update(dialog_message);
+                }
+            }
+            Message::InstallDeb(entity_opt) => {
+                let paths: Vec<_> = self.selected_paths(entity_opt).collect();
+                if let Some(path) = paths.first().cloned() {
+                    return Task::future(async move {
+                        let output = tokio::process::Command::new("pkexec")
+                            .arg("apt")
+                            .arg("install")
+                            .arg("-y")
+                            .arg(&path)
+                            .output()
+                            .await;
+
+                        match output {
+                            Ok(out) => {
+                                let stdout = String::from_utf8_lossy(&out.stdout).to_string();
+                                let stderr = String::from_utf8_lossy(&out.stderr).to_string();
+
+                                if stdout.contains("already") || stderr.contains("already") {
+                                    cosmic::Action::App(Message::DebInstallResult(Err(
+                                        "Package already installed".to_string(),
+                                    )))
+                                } else if out.status.success() {
+                                    cosmic::Action::App(Message::DebInstallResult(Ok(())))
+                                } else {
+                                    cosmic::Action::App(Message::DebInstallResult(Err(stderr)))
+                                }
+                            }
+                            Ok(out) => cosmic::Action::App(Message::DebInstallResult(Err(
+                                String::from_utf8_lossy(&out.stderr).to_string(),
+                            ))),
+                            Err(e) => {
+                                cosmic::Action::App(Message::DebInstallResult(Err(e.to_string())))
+                            }
+                        }
+                    });
                 }
             }
             Message::Key(window_id, modifiers, key, text) => {

--- a/src/menu.rs
+++ b/src/menu.rs
@@ -210,6 +210,15 @@ pub fn context_menu<'a>(
                 }
                 if selected == 1 {
                     children.push(menu_item(fl!("menu-open-with"), Action::OpenWith).into());
+
+                    if selected_types
+                        .iter()
+                        .any(|t| t.essence_str() == "application/vnd.debian.binary-package")
+                    {
+                        children.push(
+                            menu_item("Install Package".to_string(), Action::InstallDeb).into(),
+                        );
+                    }
                     if selected_dir == 1 {
                         children
                             .push(menu_item(fl!("open-in-terminal"), Action::OpenTerminal).into());


### PR DESCRIPTION
- [X] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [X] I understand these changes in full and will be able to respond to review comments.
- [X] My change is accurately described in the commit message.
- [X] My contribution is tested and working as described.
- [X] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.


adds an install package option for the user for .deb files, when right clicked on .deb file
it also shows feedback such as successfully installed or already installed or failed if installed failed
<img width="402" height="523" alt="Screenshot_2026-03-12_23-35-39" src="https://github.com/user-attachments/assets/cdb8a898-6068-47aa-924e-1d76ed29ca84" />


