### PR TITLE
Add user-defined context actions

### DIFF
--- a/i18n/en/cosmic_files.ftl
+++ b/i18n/en/cosmic_files.ftl
@@ -99,6 +99,13 @@ open-with-title = How do you want to open "{$name}"?
 browse-store = Browse {$store}
 other-apps = Other applications
 related-apps = Related applications
+context-action = Context action
+context-action-confirm-title = Run "{$name}"?
+context-action-confirm-warning = This will run on {$items} {$items ->
+    [one] item
+    *[other] items
+  }.
+run = Run
 
 ## Permanently delete Dialog
 selected-items = The {$items} selected items

--- a/src/app.rs
+++ b/src/app.rs
@@ -80,6 +80,7 @@ use crate::{
         AppTheme, Config, DesktopConfig, Favorite, IconSizes, State, TIME_CONFIG_ID, TabConfig,
         TimeConfig, TypeToSearch,
     },
+    context_action,
     dialog::{Dialog, DialogKind, DialogMessage, DialogResult, DialogSettings},
     fl, home_dir,
     key_bind::key_binds,
@@ -108,6 +109,9 @@ static DELETE_TRASH_BUTTON_ID: LazyLock<widget::Id> =
 
 static CONFIRM_OPEN_WITH_BUTTON_ID: LazyLock<widget::Id> =
     LazyLock::new(|| widget::Id::new("confirm-open-with-button"));
+
+static CONFIRM_CONTEXT_ACTION_BUTTON_ID: LazyLock<widget::Id> =
+    LazyLock::new(|| widget::Id::new("confirm-context-action-button"));
 
 static EMPTY_TRASH_BUTTON_ID: LazyLock<widget::Id> =
     LazyLock::new(|| widget::Id::new("empty-trash-button"));
@@ -180,6 +184,7 @@ pub enum Action {
     OpenItemLocation,
     OpenTerminal,
     OpenWith,
+    RunContextAction(usize),
     Paste,
     PermanentlyDelete,
     Preview,
@@ -252,6 +257,9 @@ impl Action {
             Self::OpenItemLocation => Message::OpenItemLocation(entity_opt),
             Self::OpenTerminal => Message::OpenTerminal(entity_opt),
             Self::OpenWith => Message::OpenWithDialog(entity_opt),
+            Self::RunContextAction(action) => {
+                Message::TabMessage(entity_opt, tab::Message::RunContextAction(*action))
+            }
             Self::Paste => Message::Paste(entity_opt),
             Self::PermanentlyDelete => Message::PermanentlyDelete(entity_opt),
             Self::Preview => Message::Preview(entity_opt),
@@ -323,6 +331,7 @@ pub enum NavMenuAction {
     OpenInNewTab(segmented_button::Entity),
     OpenInNewWindow(segmented_button::Entity),
     Preview(segmented_button::Entity),
+    RunContextAction(segmented_button::Entity, usize),
     RemoveFromSidebar(segmented_button::Entity),
 }
 
@@ -557,6 +566,10 @@ pub enum DialogPage {
         parent: PathBuf,
         name: String,
         dir: bool,
+    },
+    RunContextAction {
+        action: usize,
+        paths: Box<[PathBuf]>,
     },
     OpenWith {
         path: PathBuf,
@@ -2593,6 +2606,28 @@ impl Application for App {
                 NavMenuAction::OpenInNewWindow(entity),
             ));
         }
+        if let Some(path) = location_opt.and_then(Location::path_opt) {
+            let selected_dir = usize::from(path.is_dir());
+            let action_items: Vec<_> = self
+                .config
+                .context_actions
+                .iter()
+                .enumerate()
+                .filter(|(_, action)| action.matches_selection(1, selected_dir))
+                .map(|(i, action)| {
+                    cosmic::widget::menu::Item::Button(
+                        action.name.clone(),
+                        None,
+                        NavMenuAction::RunContextAction(entity, i),
+                    )
+                })
+                .collect();
+
+            if !action_items.is_empty() {
+                items.push(cosmic::widget::menu::Item::Divider);
+                items.extend(action_items);
+            }
+        }
         items.push(cosmic::widget::menu::Item::Divider);
         if matches!(location_opt, Some(Location::Path(..))) {
             items.push(cosmic::widget::menu::Item::Button(
@@ -3184,6 +3219,9 @@ impl Application for App {
                             } else {
                                 Operation::NewFile { path }
                             }));
+                        }
+                        DialogPage::RunContextAction { action, paths } => {
+                            context_action::run(&self.config.context_actions, action, &paths);
                         }
                         DialogPage::OpenWith {
                             path,
@@ -4505,6 +4543,25 @@ impl Application for App {
                         tab::Command::ExecEntryAction(entry, action) => {
                             Self::exec_entry_action(&entry, action);
                         }
+                        tab::Command::RunContextAction(action) => {
+                            let paths: Box<[_]> = self.selected_paths(Some(entity)).collect();
+                            if let Some(preset) = self.config.context_actions.get(action) {
+                                if preset.confirm {
+                                    commands.push(self.push_dialog(
+                                        DialogPage::RunContextAction { action, paths },
+                                        Some(CONFIRM_CONTEXT_ACTION_BUTTON_ID.clone()),
+                                    ));
+                                } else {
+                                    context_action::run(
+                                        &self.config.context_actions,
+                                        action,
+                                        &paths,
+                                    );
+                                }
+                            } else {
+                                log::warn!("invalid context action index `{action}`");
+                            }
+                        }
                         tab::Command::Iced(iced_command) => {
                             commands.push(iced_command.0.map(move |x| {
                                 cosmic::action::app(Message::TabMessage(Some(entity), x))
@@ -5009,6 +5066,30 @@ impl Application for App {
                                     err
                                 );
                             }
+                        }
+                    }
+                }
+                NavMenuAction::RunContextAction(entity, action) => {
+                    if let Some(path) = self
+                        .nav_model
+                        .data::<Location>(entity)
+                        .and_then(Location::path_opt)
+                        .cloned()
+                    {
+                        let paths = vec![path];
+                        if let Some(preset) = self.config.context_actions.get(action) {
+                            if preset.confirm {
+                                return self.push_dialog(
+                                    DialogPage::RunContextAction {
+                                        action,
+                                        paths: paths.into_boxed_slice(),
+                                    },
+                                    Some(CONFIRM_CONTEXT_ACTION_BUTTON_ID.clone()),
+                                );
+                            }
+                            context_action::run(&self.config.context_actions, action, &paths);
+                        } else {
+                            log::warn!("invalid context action index `{action}`");
                         }
                     }
                 }
@@ -5788,6 +5869,26 @@ impl Application for App {
                         .spacing(space_xxs),
                     )
             }
+            DialogPage::RunContextAction { action, paths } => {
+                let name = self
+                    .config
+                    .context_actions
+                    .get(*action)
+                    .map_or_else(|| fl!("context-action"), |preset| preset.name.clone());
+
+                widget::dialog()
+                    .title(fl!("context-action-confirm-title", name = name))
+                    .body(fl!("context-action-confirm-warning", items = paths.len()))
+                    .icon(icon::from_name("dialog-error").size(64))
+                    .primary_action(
+                        widget::button::suggested(fl!("run"))
+                            .on_press(Message::DialogComplete)
+                            .id(CONFIRM_CONTEXT_ACTION_BUTTON_ID.clone()),
+                    )
+                    .secondary_action(
+                        widget::button::standard(fl!("cancel")).on_press(Message::DialogCancel),
+                    )
+            }
             DialogPage::OpenWith {
                 path,
                 mime,
@@ -6333,6 +6434,7 @@ impl Application for App {
                     &self.key_binds,
                     &self.modifiers,
                     self.clipboard_has_content(),
+                    &self.config.context_actions,
                 )
                 .map(move |message| Message::TabMessage(Some(entity), message));
             tab_column = tab_column.push(tab_view);
@@ -6361,6 +6463,7 @@ impl Application for App {
                                 &self.key_binds,
                                 &window.modifiers,
                                 self.clipboard_has_content(),
+                                &self.config.context_actions,
                             )
                             .map(|x| Message::TabMessage(Some(*entity), x)),
                             id.clone(),
@@ -6378,6 +6481,7 @@ impl Application for App {
                                 &self.key_binds,
                                 &window.modifiers,
                                 self.clipboard_has_content(),
+                                &self.config.context_actions,
                             )
                             .map(move |message| Message::TabMessage(Some(*entity), message)),
                         None => widget::space::vertical().into(),

--- a/src/config.rs
+++ b/src/config.rs
@@ -16,6 +16,8 @@ use crate::{
     tab::{HeadingOptions, Location, View},
 };
 
+pub use crate::context_action::{ContextActionPreset, ContextActionSelection};
+
 pub const CONFIG_VERSION: u64 = 1;
 
 // Default icon sizes
@@ -164,6 +166,7 @@ pub struct Config {
     pub app_theme: AppTheme,
     pub dialog: DialogConfig,
     pub desktop: DesktopConfig,
+    pub context_actions: Vec<ContextActionPreset>,
     pub thumb_cfg: ThumbCfg,
     pub favorites: Vec<Favorite>,
     pub show_details: bool,
@@ -220,6 +223,7 @@ impl Default for Config {
             app_theme: AppTheme::System,
             desktop: DesktopConfig::default(),
             dialog: DialogConfig::default(),
+            context_actions: Vec::new(),
             thumb_cfg: ThumbCfg::default(),
             favorites: vec![
                 Favorite::Home,

--- a/src/context_action.rs
+++ b/src/context_action.rs
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: GPL-3.0-only
+
+use std::path::PathBuf;
+
+use serde::{Deserialize, Serialize};
+
+use crate::{mime_app, spawn_detached::spawn_detached};
+
+#[derive(Clone, Copy, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+pub enum ContextActionSelection {
+    #[default]
+    #[serde(alias = "any")]
+    Any,
+    #[serde(alias = "files")]
+    Files,
+    #[serde(alias = "folders")]
+    Folders,
+}
+
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(default)]
+pub struct ContextActionPreset {
+    pub name: String,
+    pub confirm: bool,
+    pub selection: ContextActionSelection,
+    pub steps: Vec<String>,
+}
+
+impl ContextActionPreset {
+    pub fn matches_selection(&self, selected: usize, selected_dir: usize) -> bool {
+        if selected == 0 {
+            return false;
+        }
+
+        match self.selection {
+            ContextActionSelection::Any => true,
+            ContextActionSelection::Files => selected_dir == 0,
+            ContextActionSelection::Folders => selected_dir == selected,
+        }
+    }
+
+    pub fn run(&self, paths: &[PathBuf]) {
+        if self.steps.is_empty() {
+            log::warn!("context action {:?} has no steps", self.name);
+            return;
+        }
+
+        for step in &self.steps {
+            let Some(commands) = mime_app::exec_to_command(step, paths) else {
+                log::warn!(
+                    "failed to parse context action {:?}: invalid Exec {:?}",
+                    self.name,
+                    step
+                );
+                return;
+            };
+
+            for mut command in commands {
+                if let Err(err) = spawn_detached(&mut command) {
+                    log::warn!(
+                        "failed to run context action {:?} step {:?}: {}",
+                        self.name,
+                        step,
+                        err
+                    );
+                    return;
+                }
+            }
+        }
+    }
+}
+
+pub fn action_name(actions: &[ContextActionPreset], action: usize) -> Option<String> {
+    actions.get(action).map(|preset| preset.name.clone())
+}
+
+pub fn run(actions: &[ContextActionPreset], action: usize, paths: &[PathBuf]) {
+    if let Some(preset) = actions.get(action) {
+        preset.run(paths);
+    } else {
+        log::warn!("invalid context action index `{action}`");
+    }
+}

--- a/src/context_action.rs
+++ b/src/context_action.rs
@@ -70,10 +70,6 @@ impl ContextActionPreset {
     }
 }
 
-pub fn action_name(actions: &[ContextActionPreset], action: usize) -> Option<String> {
-    actions.get(action).map(|preset| preset.name.clone())
-}
-
 pub fn run(actions: &[ContextActionPreset], action: usize, paths: &[PathBuf]) {
     if let Some(preset) = actions.get(action) {
         preset.run(paths);

--- a/src/dialog.rs
+++ b/src/dialog.rs
@@ -45,7 +45,7 @@ use crate::{
         Action, ContextPage, Message as AppMessage, PreviewItem, PreviewKind, REPLACE_BUTTON_ID,
     },
     config::{Config, DialogConfig, Favorite, TIME_CONFIG_ID, ThumbCfg, TimeConfig, TypeToSearch},
-    context_action, fl, home_dir,
+    fl, home_dir,
     key_bind::key_binds,
     localize::LANGUAGE_SORTER,
     menu,
@@ -444,10 +444,6 @@ enum DialogPage {
     NewFolder {
         parent: PathBuf,
         name: String,
-    },
-    RunContextAction {
-        action: usize,
-        paths: Box<[PathBuf]>,
     },
     Replace {
         filename: String,
@@ -1212,21 +1208,6 @@ impl Application for App {
                         .spacing(space_xxs),
                     )
             }
-            DialogPage::RunContextAction { action, paths } => {
-                let name = context_action::action_name(&self.flags.config.context_actions, *action)
-                    .unwrap_or_else(|| fl!("context-action"));
-
-                widget::dialog()
-                    .title(fl!("context-action-confirm-title", name = name))
-                    .body(fl!("context-action-confirm-warning", items = paths.len()))
-                    .icon(widget::icon::from_name("dialog-error").size(64))
-                    .primary_action(
-                        widget::button::suggested(fl!("run")).on_press(Message::DialogComplete),
-                    )
-                    .secondary_action(
-                        widget::button::standard(fl!("cancel")).on_press(Message::DialogCancel),
-                    )
-            }
             DialogPage::Replace { filename } => widget::dialog()
                 .title(fl!("replace-title", filename = filename.as_str()))
                 .icon(widget::icon::from_name("dialog-question").size(64))
@@ -1448,9 +1429,6 @@ impl Application for App {
                                     log::warn!("failed to create {}: {}", path.display(), err);
                                 }
                             }
-                        }
-                        DialogPage::RunContextAction { action, paths } => {
-                            context_action::run(&self.flags.config.context_actions, action, &paths);
                         }
                         DialogPage::Replace { .. } => {
                             return self.update(Message::Save(true));
@@ -1879,28 +1857,6 @@ impl Application for App {
                                 }
                             }
                         }
-                        tab::Command::RunContextAction(action) => {
-                            let paths: Box<[_]> = self
-                                .tab
-                                .selected_locations()
-                                .into_iter()
-                                .filter_map(Location::into_path_opt)
-                                .collect();
-                            if let Some(preset) = self.flags.config.context_actions.get(action) {
-                                if preset.confirm {
-                                    self.dialog_pages
-                                        .push_back(DialogPage::RunContextAction { action, paths });
-                                } else {
-                                    context_action::run(
-                                        &self.flags.config.context_actions,
-                                        action,
-                                        &paths,
-                                    );
-                                }
-                            } else {
-                                log::warn!("invalid context action index `{action}`");
-                            }
-                        }
                         tab::Command::Iced(iced_command) => {
                             commands.push(iced_command.0.map(|tab_message| {
                                 cosmic::action::app(Message::TabMessage(tab_message))
@@ -2073,13 +2029,8 @@ impl Application for App {
         }
 
         col = col.push(
-            self.tab
-                .view(
-                    &self.key_binds,
-                    &self.modifiers,
-                    false,
-                    &self.flags.config.context_actions,
-                )
+                self.tab
+                .view(&self.key_binds, &self.modifiers, false, &[])
                 .map(Message::TabMessage),
         );
 

--- a/src/dialog.rs
+++ b/src/dialog.rs
@@ -45,7 +45,7 @@ use crate::{
         Action, ContextPage, Message as AppMessage, PreviewItem, PreviewKind, REPLACE_BUTTON_ID,
     },
     config::{Config, DialogConfig, Favorite, TIME_CONFIG_ID, ThumbCfg, TimeConfig, TypeToSearch},
-    fl, home_dir,
+    context_action, fl, home_dir,
     key_bind::key_binds,
     localize::LANGUAGE_SORTER,
     menu,
@@ -441,8 +441,17 @@ impl<M: Send + 'static> Dialog<M> {
 
 #[derive(Clone, Debug)]
 enum DialogPage {
-    NewFolder { parent: PathBuf, name: String },
-    Replace { filename: String },
+    NewFolder {
+        parent: PathBuf,
+        name: String,
+    },
+    RunContextAction {
+        action: usize,
+        paths: Box<[PathBuf]>,
+    },
+    Replace {
+        filename: String,
+    },
 }
 
 #[derive(Clone, Debug)]
@@ -1203,6 +1212,21 @@ impl Application for App {
                         .spacing(space_xxs),
                     )
             }
+            DialogPage::RunContextAction { action, paths } => {
+                let name = context_action::action_name(&self.flags.config.context_actions, *action)
+                    .unwrap_or_else(|| fl!("context-action"));
+
+                widget::dialog()
+                    .title(fl!("context-action-confirm-title", name = name))
+                    .body(fl!("context-action-confirm-warning", items = paths.len()))
+                    .icon(widget::icon::from_name("dialog-error").size(64))
+                    .primary_action(
+                        widget::button::suggested(fl!("run")).on_press(Message::DialogComplete),
+                    )
+                    .secondary_action(
+                        widget::button::standard(fl!("cancel")).on_press(Message::DialogCancel),
+                    )
+            }
             DialogPage::Replace { filename } => widget::dialog()
                 .title(fl!("replace-title", filename = filename.as_str()))
                 .icon(widget::icon::from_name("dialog-question").size(64))
@@ -1424,6 +1448,9 @@ impl Application for App {
                                     log::warn!("failed to create {}: {}", path.display(), err);
                                 }
                             }
+                        }
+                        DialogPage::RunContextAction { action, paths } => {
+                            context_action::run(&self.flags.config.context_actions, action, &paths);
                         }
                         DialogPage::Replace { .. } => {
                             return self.update(Message::Save(true));
@@ -1831,6 +1858,7 @@ impl Application for App {
                                                             &app.key_binds,
                                                             &app.modifiers,
                                                             false, // Paste not used in dialogs
+                                                            &app.flags.config.context_actions,
                                                         )
                                                         .map(Message::TabMessage)
                                                         .map(cosmic::Action::App),
@@ -1849,6 +1877,28 @@ impl Application for App {
                                         )));
                                     }
                                 }
+                            }
+                        }
+                        tab::Command::RunContextAction(action) => {
+                            let paths: Box<[_]> = self
+                                .tab
+                                .selected_locations()
+                                .into_iter()
+                                .filter_map(Location::into_path_opt)
+                                .collect();
+                            if let Some(preset) = self.flags.config.context_actions.get(action) {
+                                if preset.confirm {
+                                    self.dialog_pages
+                                        .push_back(DialogPage::RunContextAction { action, paths });
+                                } else {
+                                    context_action::run(
+                                        &self.flags.config.context_actions,
+                                        action,
+                                        &paths,
+                                    );
+                                }
+                            } else {
+                                log::warn!("invalid context action index `{action}`");
                             }
                         }
                         tab::Command::Iced(iced_command) => {
@@ -2024,7 +2074,12 @@ impl Application for App {
 
         col = col.push(
             self.tab
-                .view(&self.key_binds, &self.modifiers, false)
+                .view(
+                    &self.key_binds,
+                    &self.modifiers,
+                    false,
+                    &self.flags.config.context_actions,
+                )
                 .map(Message::TabMessage),
         );
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@ use app::{App, Flags};
 pub mod app;
 mod archive;
 pub mod clipboard;
+mod context_action;
 use config::Config;
 pub mod config;
 pub mod dialog;

--- a/src/menu.rs
+++ b/src/menu.rs
@@ -20,7 +20,7 @@ use std::{collections::HashMap, sync::LazyLock};
 
 use crate::{
     app::{Action, Message},
-    config::Config,
+    config::{Config, ContextActionPreset},
     fl,
     tab::{self, HeadingOptions, Location, LocationMenuAction, SearchLocation, Tab},
 };
@@ -60,6 +60,7 @@ pub fn context_menu<'a>(
     key_binds: &HashMap<KeyBind, Action>,
     modifiers: &Modifiers,
     clipboard_paste_available: bool,
+    context_actions: &[ContextActionPreset],
 ) -> Element<'a, tab::Message> {
     let find_key = |action: &Action| -> String {
         for (key_bind, key_action) in key_binds {
@@ -157,6 +158,14 @@ pub fn context_menu<'a>(
     selected_types.sort_unstable();
     selected_types.dedup();
     selected_trash_only = selected_trash_only && selected == 1;
+    let context_action_items = |selected: usize, selected_dir: usize| {
+        context_actions
+            .iter()
+            .enumerate()
+            .filter(|(_, action)| action.matches_selection(selected, selected_dir))
+            .map(|(i, action)| menu_item(action.name.clone(), Action::RunContextAction(i)).into())
+            .collect::<Vec<Element<'a, tab::Message>>>()
+    };
     // Parse the desktop entry if it is the only selection
     #[cfg(feature = "desktop")]
     let selected_desktop_entry = selected_desktop_entry.and_then(|path| {
@@ -204,6 +213,11 @@ pub fn context_menu<'a>(
                 }
                 // Should this simply bypass trash and remove the shortcut?
                 children.push(menu_item(fl!("move-to-trash"), Action::Delete).into());
+                let action_items = context_action_items(selected, selected_dir);
+                if !action_items.is_empty() {
+                    children.push(divider::horizontal::light().into());
+                    children.extend(action_items);
+                }
             } else if selected > 0 {
                 if selected_dir == 1 && selected == 1 || selected_dir == 0 {
                     children.push(menu_item(fl!("open"), Action::Open).into());
@@ -225,6 +239,11 @@ pub fn context_menu<'a>(
                     children.push(menu_item(fl!("open-in-new-tab"), Action::OpenInNewTab).into());
                     children
                         .push(menu_item(fl!("open-in-new-window"), Action::OpenInNewWindow).into());
+                }
+                let action_items = context_action_items(selected, selected_dir);
+                if !action_items.is_empty() {
+                    children.push(divider::horizontal::light().into());
+                    children.extend(action_items);
                 }
                 children.push(divider::horizontal::light().into());
                 if selected_mount_point == 0 {

--- a/src/tab.rs
+++ b/src/tab.rs
@@ -66,7 +66,10 @@ use crate::{
     FxOrderMap,
     app::{Action, PreviewItem, PreviewKind},
     clipboard::{ClipboardCopy, ClipboardKind, ClipboardPaste},
-    config::{DesktopConfig, ICON_SCALE_MAX, ICON_SIZE_GRID, IconSizes, TabConfig, ThumbCfg},
+    config::{
+        ContextActionPreset, DesktopConfig, ICON_SCALE_MAX, ICON_SIZE_GRID, IconSizes, TabConfig,
+        ThumbCfg,
+    },
     dialog::DialogKind,
     fl,
     large_image::{
@@ -1794,6 +1797,7 @@ pub enum Command {
     OpenInNewWindow(PathBuf),
     OpenTrash,
     Preview(PreviewKind),
+    RunContextAction(usize),
     SetOpenWith(Mime, String),
     SetPermissions(PathBuf, u32),
     SetMultiplePermissions(Vec<(PathBuf, u32)>),
@@ -1852,6 +1856,7 @@ pub enum Message {
     SelectFirst,
     SelectLast,
     SetOpenWith(Mime, String),
+    RunContextAction(usize),
     SetPermissions(PathBuf, u32),
     ShiftPermissions(Option<(PathBuf, u32)>, u32, u32),
     SetSort(HeadingOptions, bool),
@@ -3565,6 +3570,11 @@ impl Tab {
                 self.context_menu = None;
 
                 commands.push(Command::Action(action));
+            }
+            Message::RunContextAction(action) => {
+                self.context_menu = None;
+
+                commands.push(Command::RunContextAction(action));
             }
             Message::ContextMenu(point_opt, _) => {
                 self.edit_location = None;
@@ -6083,6 +6093,7 @@ impl Tab {
         modifiers: &'a Modifiers,
         size: Size,
         clipboard_paste_available: bool,
+        context_actions: &'a [ContextActionPreset],
     ) -> Element<'a, Message> {
         // Update cached size
         self.size_opt.set(Some(size));
@@ -6170,8 +6181,13 @@ impl Tab {
         if let Some(point) = self.context_menu
             && (!cfg!(feature = "wayland") || !crate::is_wayland())
         {
-            let context_menu =
-                menu::context_menu(self, key_binds, modifiers, clipboard_paste_available);
+            let context_menu = menu::context_menu(
+                self,
+                key_binds,
+                modifiers,
+                clipboard_paste_available,
+                context_actions,
+            );
             popover = popover
                 .popup(context_menu)
                 .position(widget::popover::Position::Point(point));
@@ -6536,10 +6552,17 @@ impl Tab {
         key_binds: &'a HashMap<KeyBind, Action>,
         modifiers: &'a Modifiers,
         clipboard_paste_available: bool,
+        context_actions: &'a [ContextActionPreset],
     ) -> Element<'a, Message> {
         widget::responsive(move |size| {
             widget::id_container(
-                self.view_responsive(key_binds, modifiers, size, clipboard_paste_available),
+                self.view_responsive(
+                    key_binds,
+                    modifiers,
+                    size,
+                    clipboard_paste_available,
+                    context_actions,
+                ),
                 Id::new(format!(
                     "tab-{}-{}",
                     self.scrollable_id, self.location_title


### PR DESCRIPTION
This PR adds support for user-defined context actions in the context menu.

Users can define custom presets that run one or more commands on the selected files or folders. This makes it possible to add actions like `Open with Code`, or other workflow-specific commands.

The configuration is stored under: `~/.config/cosmic/com.system76.CosmicFiles/v1/context_actions`

## Example

```ron
[
    (
        name: "Open with Code",
        confirm: false,
        selection: Any,
        steps: [
            "code %F",
        ],
    ),
    (
        name: "Remove selected",
        confirm: true,
        selection: Any,
        steps: [
            "rm -rf %F",
        ],
    ),
]
```

Selection accepts `Any`, `Files`, or `Folders`. When `confirm` is enabled, a confirmation dialog is shown before the action runs.

## Placeholders

| Placeholder | Description | Example |
|-------------|-------------|---------|
| `%%` | A literal percent sign | `%%` -> `%` |
| `%c` | Application name (entry name) | `%c` -> `"Files"` |
| `%k` | Path to the `.desktop` file | `%k` -> `"/usr/share/applications/org.pop_os.CosmicFiles.desktop"` |
| `%f` | A single selected file. For multiple files, the command runs separately for each | `myedit %f` -> `myedit file1.txt` (then `myedit file2.txt`) |
| `%F` | **All selected files** - each passed as a separate argument **in a single command invocation** | `code %F` -> `code file1.txt file2.txt folder/` (all in one window) |

## Preview

<img width="655" height="477" alt="image" src="https://github.com/user-attachments/assets/34027eaf-6cf1-4f29-ad43-2f38a2a89b94" />

<img width="433" height="426" alt="image" src="https://github.com/user-attachments/assets/5fd5de13-410e-41a0-9954-970658b5a093" />

<img width="862" height="498" alt="image" src="https://github.com/user-attachments/assets/9a127c84-21c8-418c-8fbf-c9326f736769" />

## Agreement

- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

