### PR TITLE
feat: select file name until the extension in rename and save dialog

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1317,7 +1317,7 @@ dependencies = [
 [[package]]
 name = "cosmic-config"
 version = "1.0.0"
-source = "git+https://github.com/pop-os/libcosmic.git#a44cff8011d81209e18de86f24da248c88b5a28d"
+source = "git+https://github.com/pop-os/libcosmic.git#6caccaba337ed9bab21c5fe3c2aa7392e322e89c"
 dependencies = [
  "atomicwrites",
  "cosmic-config-derive",
@@ -1338,7 +1338,7 @@ dependencies = [
 [[package]]
 name = "cosmic-config-derive"
 version = "1.0.0"
-source = "git+https://github.com/pop-os/libcosmic.git#a44cff8011d81209e18de86f24da248c88b5a28d"
+source = "git+https://github.com/pop-os/libcosmic.git#6caccaba337ed9bab21c5fe3c2aa7392e322e89c"
 dependencies = [
  "quote",
  "syn",
@@ -1479,7 +1479,7 @@ dependencies = [
 [[package]]
 name = "cosmic-text"
 version = "0.18.2"
-source = "git+https://github.com/pop-os/cosmic-text.git#9a2ab09f06905e91f41d64ac6eee887726e7fd76"
+source = "git+https://github.com/pop-os/cosmic-text.git#4d74f795cc771fdcc7ea0f9cacba63fcf036fad6"
 dependencies = [
  "bitflags 2.11.0",
  "fontdb",
@@ -1502,7 +1502,7 @@ dependencies = [
 [[package]]
 name = "cosmic-theme"
 version = "1.0.0"
-source = "git+https://github.com/pop-os/libcosmic.git#a44cff8011d81209e18de86f24da248c88b5a28d"
+source = "git+https://github.com/pop-os/libcosmic.git#6caccaba337ed9bab21c5fe3c2aa7392e322e89c"
 dependencies = [
  "almost",
  "configparser",
@@ -2365,7 +2365,7 @@ version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc6d3a3635983a889f065aa9ce760384713f23a9b4a04f696f86c39a5d7a6a5a"
 dependencies = [
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
  "nom 8.0.0",
 ]
 
@@ -2584,9 +2584,9 @@ dependencies = [
 
 [[package]]
 name = "gif"
-version = "0.14.1"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5df2ba84018d80c213569363bdcd0c64e6933c67fe4c1d60ecf822971a3c35e"
+checksum = "ee8cfcc411d9adbbaba82fb72661cc1bcca13e8bba98b364e62b2dba8f960159"
 dependencies = [
  "color_quant",
  "weezl",
@@ -2851,6 +2851,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+
+[[package]]
 name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2983,7 +2989,7 @@ dependencies = [
 [[package]]
 name = "iced"
 version = "0.14.0"
-source = "git+https://github.com/pop-os/libcosmic.git#a44cff8011d81209e18de86f24da248c88b5a28d"
+source = "git+https://github.com/pop-os/libcosmic.git#6caccaba337ed9bab21c5fe3c2aa7392e322e89c"
 dependencies = [
  "dnd",
  "iced_accessibility",
@@ -3004,7 +3010,7 @@ dependencies = [
 [[package]]
 name = "iced_accessibility"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/libcosmic.git#a44cff8011d81209e18de86f24da248c88b5a28d"
+source = "git+https://github.com/pop-os/libcosmic.git#6caccaba337ed9bab21c5fe3c2aa7392e322e89c"
 dependencies = [
  "accesskit",
  "accesskit_winit",
@@ -3013,7 +3019,7 @@ dependencies = [
 [[package]]
 name = "iced_core"
 version = "0.14.0"
-source = "git+https://github.com/pop-os/libcosmic.git#a44cff8011d81209e18de86f24da248c88b5a28d"
+source = "git+https://github.com/pop-os/libcosmic.git#6caccaba337ed9bab21c5fe3c2aa7392e322e89c"
 dependencies = [
  "bitflags 2.11.0",
  "bytes",
@@ -3037,7 +3043,7 @@ dependencies = [
 [[package]]
 name = "iced_debug"
 version = "0.14.0"
-source = "git+https://github.com/pop-os/libcosmic.git#a44cff8011d81209e18de86f24da248c88b5a28d"
+source = "git+https://github.com/pop-os/libcosmic.git#6caccaba337ed9bab21c5fe3c2aa7392e322e89c"
 dependencies = [
  "iced_core",
  "iced_futures",
@@ -3047,7 +3053,7 @@ dependencies = [
 [[package]]
 name = "iced_futures"
 version = "0.14.0"
-source = "git+https://github.com/pop-os/libcosmic.git#a44cff8011d81209e18de86f24da248c88b5a28d"
+source = "git+https://github.com/pop-os/libcosmic.git#6caccaba337ed9bab21c5fe3c2aa7392e322e89c"
 dependencies = [
  "futures",
  "iced_core",
@@ -3061,7 +3067,7 @@ dependencies = [
 [[package]]
 name = "iced_graphics"
 version = "0.14.0"
-source = "git+https://github.com/pop-os/libcosmic.git#a44cff8011d81209e18de86f24da248c88b5a28d"
+source = "git+https://github.com/pop-os/libcosmic.git#6caccaba337ed9bab21c5fe3c2aa7392e322e89c"
 dependencies = [
  "bitflags 2.11.0",
  "bytemuck",
@@ -3082,7 +3088,7 @@ dependencies = [
 [[package]]
 name = "iced_program"
 version = "0.14.0"
-source = "git+https://github.com/pop-os/libcosmic.git#a44cff8011d81209e18de86f24da248c88b5a28d"
+source = "git+https://github.com/pop-os/libcosmic.git#6caccaba337ed9bab21c5fe3c2aa7392e322e89c"
 dependencies = [
  "iced_graphics",
  "iced_runtime",
@@ -3091,7 +3097,7 @@ dependencies = [
 [[package]]
 name = "iced_renderer"
 version = "0.14.0"
-source = "git+https://github.com/pop-os/libcosmic.git#a44cff8011d81209e18de86f24da248c88b5a28d"
+source = "git+https://github.com/pop-os/libcosmic.git#6caccaba337ed9bab21c5fe3c2aa7392e322e89c"
 dependencies = [
  "iced_graphics",
  "iced_tiny_skia",
@@ -3103,7 +3109,7 @@ dependencies = [
 [[package]]
 name = "iced_runtime"
 version = "0.14.0"
-source = "git+https://github.com/pop-os/libcosmic.git#a44cff8011d81209e18de86f24da248c88b5a28d"
+source = "git+https://github.com/pop-os/libcosmic.git#6caccaba337ed9bab21c5fe3c2aa7392e322e89c"
 dependencies = [
  "bytes",
  "cosmic-client-toolkit",
@@ -3118,7 +3124,7 @@ dependencies = [
 [[package]]
 name = "iced_tiny_skia"
 version = "0.14.0"
-source = "git+https://github.com/pop-os/libcosmic.git#a44cff8011d81209e18de86f24da248c88b5a28d"
+source = "git+https://github.com/pop-os/libcosmic.git#6caccaba337ed9bab21c5fe3c2aa7392e322e89c"
 dependencies = [
  "bytemuck",
  "cosmic-text",
@@ -3135,7 +3141,7 @@ dependencies = [
 [[package]]
 name = "iced_wgpu"
 version = "0.14.0"
-source = "git+https://github.com/pop-os/libcosmic.git#a44cff8011d81209e18de86f24da248c88b5a28d"
+source = "git+https://github.com/pop-os/libcosmic.git#6caccaba337ed9bab21c5fe3c2aa7392e322e89c"
 dependencies = [
  "as-raw-xcb-connection",
  "bitflags 2.11.0",
@@ -3166,7 +3172,7 @@ dependencies = [
 [[package]]
 name = "iced_widget"
 version = "0.14.2"
-source = "git+https://github.com/pop-os/libcosmic.git#a44cff8011d81209e18de86f24da248c88b5a28d"
+source = "git+https://github.com/pop-os/libcosmic.git#6caccaba337ed9bab21c5fe3c2aa7392e322e89c"
 dependencies = [
  "cosmic-client-toolkit",
  "dnd",
@@ -3184,7 +3190,7 @@ dependencies = [
 [[package]]
 name = "iced_winit"
 version = "0.14.0"
-source = "git+https://github.com/pop-os/libcosmic.git#a44cff8011d81209e18de86f24da248c88b5a28d"
+source = "git+https://github.com/pop-os/libcosmic.git#6caccaba337ed9bab21c5fe3c2aa7392e322e89c"
 dependencies = [
  "cosmic-client-toolkit",
  "cursor-icon",
@@ -3671,7 +3677,7 @@ dependencies = [
  "byteorder-lite",
  "color_quant",
  "exr",
- "gif 0.14.1",
+ "gif 0.14.2",
  "image-webp",
  "moxcms",
  "num-traits",
@@ -3720,12 +3726,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.13.1"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45a8a2b9cb3e0b0c1803dbb0758ffac5de2f425b23c28f518faabd9d805342ff"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
  "serde",
  "serde_core",
 ]
@@ -4297,7 +4303,7 @@ checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
 [[package]]
 name = "libcosmic"
 version = "1.0.0"
-source = "git+https://github.com/pop-os/libcosmic.git#a44cff8011d81209e18de86f24da248c88b5a28d"
+source = "git+https://github.com/pop-os/libcosmic.git#6caccaba337ed9bab21c5fe3c2aa7392e322e89c"
 dependencies = [
  "apply",
  "ashpd 0.12.3",
@@ -4374,14 +4380,14 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
-version = "0.1.15"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ddbf48fd451246b1f8c2610bd3b4ac0cc6e149d89832867093ab69a17194f08"
+checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
 dependencies = [
  "bitflags 2.11.0",
  "libc",
  "plain",
- "redox_syscall 0.7.3",
+ "redox_syscall 0.7.4",
 ]
 
 [[package]]
@@ -4728,7 +4734,7 @@ dependencies = [
  "half",
  "hashbrown 0.16.1",
  "hexf-parse",
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
  "libm",
  "log",
  "num-traits",
@@ -5234,11 +5240,11 @@ dependencies = [
 
 [[package]]
 name = "ordermap"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfa78c92071bbd3628c22b1a964f7e0eb201dc1456555db072beb1662ecd6715"
+checksum = "7f7476a5b122ff1fce7208e7ee9dccd0a516e835f5b8b19b8f3c98a34cf757c1"
 dependencies = [
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
  "serde",
  "serde_core",
 ]
@@ -5992,9 +5998,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce70a74e890531977d37e532c34d45e9055d2409ed08ddba14529471ed0be16"
+checksum = "f450ad9c3b1da563fb6948a8e0fb0fb9269711c9c73d9ea1de5058c79c8d643a"
 dependencies = [
  "bitflags 2.11.0",
 ]
@@ -6370,7 +6376,7 @@ version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
  "itoa",
  "memchr",
  "serde",
@@ -6408,7 +6414,7 @@ dependencies = [
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
  "schemars 0.9.0",
  "schemars 1.2.1",
  "serde_core",
@@ -7107,7 +7113,7 @@ version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
 dependencies = [
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
  "serde_core",
  "serde_spanned",
  "toml_datetime",
@@ -7131,7 +7137,7 @@ version = "0.25.11+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
 dependencies = [
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
  "toml_datetime",
  "toml_parser",
  "winnow 1.0.1",
@@ -7598,7 +7604,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
 dependencies = [
  "anyhow",
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
  "wasm-encoder",
  "wasmparser",
 ]
@@ -7611,7 +7617,7 @@ checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
  "bitflags 2.11.0",
  "hashbrown 0.15.5",
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
  "semver",
 ]
 
@@ -7848,7 +7854,7 @@ dependencies = [
  "cfg_aliases",
  "document-features",
  "hashbrown 0.16.1",
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
  "log",
  "naga",
  "once_cell",
@@ -8615,7 +8621,7 @@ dependencies = [
  "libredox",
  "orbclient",
  "raw-window-handle",
- "redox_syscall 0.7.3",
+ "redox_syscall 0.7.4",
  "smol_str",
  "tracing",
  "winit-core",
@@ -8774,7 +8780,7 @@ checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
 dependencies = [
  "anyhow",
  "heck 0.5.0",
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
  "prettyplease",
  "syn",
  "wasm-metadata",
@@ -8805,7 +8811,7 @@ checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
  "bitflags 2.11.0",
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
  "log",
  "serde",
  "serde_derive",
@@ -8824,7 +8830,7 @@ checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
 dependencies = [
  "anyhow",
  "id-arena",
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
  "log",
  "semver",
  "serde",
@@ -9323,7 +9329,7 @@ dependencies = [
  "flate2",
  "getrandom 0.4.2",
  "hmac",
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
  "lzma-rust2",
  "memchr",
  "pbkdf2",

--- a/src/app.rs
+++ b/src/app.rs
@@ -4218,12 +4218,14 @@ impl Application for App {
                         .collect();
                     if !selected.is_empty() {
                         //TODO: batch rename
-                        let tasks = selected
+                        let mut last_name = String::new();
+                        let tasks: Vec<_> = selected
                             .into_iter()
                             .filter_map(|path| {
                                 let parent = path.parent()?.to_path_buf();
                                 let name = path.file_name()?.to_str()?.to_string();
                                 let dir = path.is_dir();
+                                last_name = name.clone();
                                 Some(self.dialog_pages.push_back(DialogPage::RenameItem {
                                     from: path,
                                     parent,
@@ -4231,9 +4233,15 @@ impl Application for App {
                                     dir,
                                 }))
                             })
-                            .chain(std::iter::once(widget::text_input::focus(
+                            .collect();
+                        let tasks = tasks.into_iter().chain([
+                            widget::text_input::focus(self.dialog_text_input.clone()),
+                            widget::text_input::select_until_last(
                                 self.dialog_text_input.clone(),
-                            )));
+                                &last_name,
+                                '.',
+                            ),
+                        ]);
                         return Task::batch(tasks);
                     }
                 }
@@ -6102,6 +6110,7 @@ impl Application for App {
                             .into(),
                             widget::text_input("", name.as_str())
                                 .id(self.dialog_text_input.clone())
+                                .double_click_select_delimiter('.')
                                 .on_input(move |name| {
                                     Message::DialogUpdate(DialogPage::RenameItem {
                                         from: from.clone(),

--- a/src/dialog.rs
+++ b/src/dialog.rs
@@ -600,6 +600,7 @@ impl App {
             col = col.push(
                 widget::text_input("", filename)
                     .id(self.filename_id.clone())
+                    .double_click_select_delimiter('.')
                     .on_input(Message::Filename)
                     .on_submit(|_| Message::Save(false)),
             );
@@ -1961,6 +1962,16 @@ impl Application for App {
                     // Reset focus on location change
                     if self.search_get().is_some() {
                         return widget::text_input::focus(self.search_id.clone());
+                    }
+                    if let DialogKind::SaveFile { filename } = &self.flags.kind {
+                        return Task::batch([
+                            widget::text_input::focus(self.filename_id.clone()),
+                            widget::text_input::select_until_last(
+                                self.filename_id.clone(),
+                                filename,
+                                '.',
+                            ),
+                        ]);
                     }
                     return widget::text_input::focus(self.filename_id.clone());
                 }


### PR DESCRIPTION
~~Draft until https://github.com/pop-os/libcosmic/pull/1227 is merged.~~ Ready.

The file name before the last `.` is selected when rename dialog or saved dialog is opened.
Pressing double-click on the filename in the rename or save dialog will select until the last `.`

https://github.com/user-attachments/assets/c759146b-4ac4-482f-835a-0fb659db66ac

This also pulls in the fixes from https://github.com/pop-os/libcosmic/pull/1228.

___
- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

