### PR TITLE
perf: fix slow startup by moving blocking trash checks to async background tasks

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -1780,7 +1780,7 @@ impl App {
 
         nav_model = nav_model.insert(|b| {
             b.text(fl!("trash"))
-                .icon(icon::icon(tab::trash_helpers::trash_icon_symbolic(16)))
+                .icon(icon::icon(crate::trash_helpers::trash_icon_symbolic(16)))
                 .data(Location::Trash)
                 .divider_above()
         });
@@ -4157,7 +4157,7 @@ impl Application for App {
                 if let Some(entity) = maybe_entity {
                     self.nav_model.icon_set(
                         entity,
-                        icon::icon(tab::trash_helpers::trash_icon_symbolic(16)),
+                        icon::icon(crate::trash_helpers::trash_icon_symbolic(16)),
                     );
                 }
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -485,6 +485,7 @@ pub enum Message {
     None,
     Surface(surface::Action),
     CutPaths(Vec<PathBuf>),
+    UpdateTrashState(bool),
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -772,6 +773,7 @@ pub struct App {
     auto_scroll_speed: Option<i16>,
     file_dialog_opt: Option<Dialog<Message>>,
     clipboard_cache: ClipboardCache,
+    trash_is_empty: bool,
 }
 
 impl App {
@@ -1780,7 +1782,7 @@ impl App {
 
         nav_model = nav_model.insert(|b| {
             b.text(fl!("trash"))
-                .icon(icon::icon(crate::trash_helpers::trash_icon_symbolic(16)))
+                .icon(icon::icon(crate::trash_helpers::trash_icon_symbolic(16, self.trash_is_empty)))
                 .data(Location::Trash)
                 .divider_above()
         });
@@ -2484,9 +2486,10 @@ impl Application for App {
             clipboard_cache: ClipboardCache::Empty,
             #[cfg(all(feature = "wayland", feature = "desktop-applet"))]
             layer_sizes: FxHashMap::default(),
+            trash_is_empty: true,
         };
 
-        let mut commands = vec![app.update_config(), app.update(Message::CheckClipboard)];
+        let mut commands = vec![app.update_config(), app.update(Message::CheckClipboard), app.update(Message::RescanTrash)];
 
         for location in flags.locations {
             if let Some(path) = location.path_opt()
@@ -2620,7 +2623,7 @@ impl Application for App {
         }
 
         if matches!(location_opt, Some(Location::Trash))
-            && !trash::os_limited::is_empty().unwrap_or(true)
+            && !self.trash_is_empty
         {
             items.push(cosmic::widget::menu::Item::Button(
                 fl!("empty-trash"),
@@ -4148,7 +4151,19 @@ impl Application for App {
                 return self.rescan_recents();
             }
             Message::RescanTrash => {
-                // Update trash icon if empty/full
+                return Task::batch([
+                    Task::future(async {
+                        let is_empty = tokio::task::spawn_blocking(|| {
+                            crate::trash_helpers::is_empty_blocking()
+                        }).await.unwrap();
+                        cosmic::action::app(Message::UpdateTrashState(is_empty))
+                    }),
+                    self.rescan_trash(),
+                    self.update_desktop()
+                ]);
+            }
+            Message::UpdateTrashState(is_empty) => {
+                self.trash_is_empty = is_empty;
                 let maybe_entity = self.nav_model.iter().find(|&entity| {
                     self.nav_model
                         .data::<Location>(entity)
@@ -4157,11 +4172,9 @@ impl Application for App {
                 if let Some(entity) = maybe_entity {
                     self.nav_model.icon_set(
                         entity,
-                        icon::icon(crate::trash_helpers::trash_icon_symbolic(16)),
+                        widget::icon::icon(crate::trash_helpers::trash_icon_symbolic(16, self.trash_is_empty)),
                     );
                 }
-
-                return Task::batch([self.rescan_trash(), self.update_desktop()]);
             }
             Message::Rename(entity_opt) => {
                 let entity = entity_opt.unwrap_or_else(|| self.tab_model.active());
@@ -6335,6 +6348,7 @@ impl Application for App {
                     &self.key_binds,
                     &self.modifiers,
                     self.clipboard_has_content(),
+                    self.trash_is_empty,
                 )
                 .map(move |message| Message::TabMessage(Some(entity), message));
             tab_column = tab_column.push(tab_view);
@@ -6363,6 +6377,7 @@ impl Application for App {
                                 &self.key_binds,
                                 &window.modifiers,
                                 self.clipboard_has_content(),
+                                self.trash_is_empty,
                             )
                             .map(|x| Message::TabMessage(Some(*entity), x)),
                             id.clone(),
@@ -6380,6 +6395,7 @@ impl Application for App {
                                 &self.key_binds,
                                 &window.modifiers,
                                 self.clipboard_has_content(),
+                                self.trash_is_empty,
                             )
                             .map(move |message| Message::TabMessage(Some(*entity), message)),
                         None => widget::space::vertical().into(),
@@ -6648,33 +6664,36 @@ impl Application for App {
                             not(target_os = "ios"),
                             not(target_os = "android")
                         ))]
-                        match (watcher_res, trash::os_limited::trash_folders()) {
-                            (Ok(mut watcher), Ok(trash_bins)) => {
-                                // Watch the "bins" themselves as well as the files folder where
-                                // trashed items are placed. This allows us to avoid recursively
-                                // watching the trash which is slow but also properly get events.
-                                let trash_paths = trash_bins
-                                    .into_iter()
-                                    .flat_map(|path| [path.join("files"), path]);
-                                for path in trash_paths {
-                                    if let Err(e) =
-                                        watcher.watch(&path, notify::RecursiveMode::NonRecursive)
-                                    {
-                                        log::warn!(
-                                            "failed to add trash bin `{}` to watcher: {e:?}",
-                                            path.display()
-                                        );
-                                    }
-                                }
+                        {
+                            let trash_bins_res = tokio::task::spawn_blocking(|| {
+                                crate::trash_helpers::trash_folders_blocking()
+                            }).await.unwrap();
 
-                                // Don't drop the watcher
-                                std::future::pending().await
-                            }
-                            (Err(e), _) => {
-                                log::warn!("failed to create new watcher for trash bin: {e:?}");
-                            }
-                            (_, Err(e)) => {
-                                log::warn!("could not find any valid trash bins to watch: {e:?}");
+                            match watcher_res {
+                                Ok(mut watcher) => {
+                                    // Watch the "bins" themselves as well as the files folder where
+                                    // trashed items are placed. This allows us to avoid recursively
+                                    // watching the trash which is slow but also properly get events.
+                                    let trash_paths = trash_bins_res
+                                        .into_iter()
+                                        .flat_map(|path| [path.join("files"), path]);
+                                    for path in trash_paths {
+                                        if let Err(e) =
+                                            watcher.watch(&path, notify::RecursiveMode::NonRecursive)
+                                        {
+                                            log::warn!(
+                                                "failed to add trash bin `{}` to watcher: {e:?}",
+                                                path.display()
+                                            );
+                                        }
+                                    }
+
+                                    // Don't drop the watcher
+                                    std::future::pending().await
+                                }
+                                Err(e) => {
+                                    log::warn!("failed to create new watcher for trash bin: {e:?}");
+                                }
                             }
                         }
 

--- a/src/dialog.rs
+++ b/src/dialog.rs
@@ -1833,6 +1833,7 @@ impl Application for App {
                                                             &app.key_binds,
                                                             &app.modifiers,
                                                             false, // Paste not used in dialogs
+                                                            true, // trash_is_empty - default to true for dialogs
                                                         )
                                                         .map(Message::TabMessage)
                                                         .map(cosmic::Action::App),
@@ -2026,7 +2027,7 @@ impl Application for App {
 
         col = col.push(
             self.tab
-                .view(&self.key_binds, &self.modifiers, false)
+                .view(&self.key_binds, &self.modifiers, false, true)
                 .map(Message::TabMessage),
         );
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,6 +27,7 @@ mod zoom;
 
 use crate::config::State;
 pub mod tab;
+pub mod trash_helpers;
 mod thumbnail_cacher;
 mod thumbnailer;
 

--- a/src/menu.rs
+++ b/src/menu.rs
@@ -60,6 +60,7 @@ pub fn context_menu<'a>(
     key_binds: &HashMap<KeyBind, Action>,
     modifiers: &Modifiers,
     clipboard_paste_available: bool,
+    trash_is_empty: bool,
 ) -> Element<'a, tab::Message> {
     let find_key = |action: &Action| -> String {
         for (key_bind, key_action) in key_binds {
@@ -183,7 +184,7 @@ pub fn context_menu<'a>(
         ) => {
             if selected_trash_only {
                 children.push(menu_item(fl!("open"), Action::Open).into());
-                if !trash::os_limited::is_empty().unwrap_or(true) {
+                if !trash_is_empty {
                     children.push(menu_item(fl!("empty-trash"), Action::EmptyTrash).into());
                 }
             } else if let Some(entry) = selected_desktop_entry {

--- a/src/tab.rs
+++ b/src/tab.rs
@@ -39,7 +39,6 @@ use icu::{
 use image::{DynamicImage, ImageReader};
 use jiff_icu::ConvertFrom;
 use mime_guess::{Mime, mime};
-use regex::Regex;
 use rustc_hash::FxHashMap;
 use serde::{Deserialize, Serialize};
 use std::{
@@ -1158,136 +1157,14 @@ pub fn scan_search<F: Fn(SearchItem) -> bool + Sync>(
             }
         }
         SearchLocation::Trash => {
-            trash_helpers::scan_search_trash(callback, &regex);
+            crate::trash_helpers::scan_search_trash(callback, &regex);
         }
     }
 }
 
-// This config statement is from trash::os_limited, inverted
-#[cfg(not(any(
-    target_os = "windows",
-    all(
-        unix,
-        not(target_os = "macos"),
-        not(target_os = "ios"),
-        not(target_os = "android")
-    )
-)))]
-mod trash_helpers {
-    use super::*;
 
-    pub fn trash_entries() -> usize {
-        0
-    }
 
-    pub fn trash_icon(icon_size: u16) -> widget::icon::Handle {
-        widget::icon::from_name("user-trash")
-            .size(icon_size)
-            .handle()
-    }
 
-    pub fn trash_icon_symbolic(icon_size: u16) -> widget::icon::Handle {
-        widget::icon::from_name("user-trash-symbolic")
-            .size(icon_size)
-            .handle()
-    }
-
-    pub fn scan_trash(_sizes: IconSizes) -> Vec<Item> {
-        log::warn!("viewing trash not supported on this platform");
-        Vec::new()
-    }
-
-    pub fn scan_search_trash<F: Fn(SearchItem) -> bool + Sync>(callback: F, regex: &Regex) {}
-}
-
-// This config statement is from trash::os_limited
-#[cfg(any(
-    target_os = "windows",
-    all(
-        unix,
-        not(target_os = "macos"),
-        not(target_os = "ios"),
-        not(target_os = "android")
-    )
-))]
-pub mod trash_helpers {
-    use super::*;
-
-    pub fn trash_entries() -> usize {
-        match trash::os_limited::list() {
-            Ok(entries) => entries.len(),
-            Err(_err) => 0,
-        }
-    }
-
-    pub fn trash_icon(icon_size: u16) -> widget::icon::Handle {
-        widget::icon::from_name(if trash::os_limited::is_empty().unwrap_or(true) {
-            "user-trash"
-        } else {
-            "user-trash-full"
-        })
-        .size(icon_size)
-        .handle()
-    }
-
-    pub fn trash_icon_symbolic(icon_size: u16) -> widget::icon::Handle {
-        widget::icon::from_name(if trash::os_limited::is_empty().unwrap_or(true) {
-            "user-trash-symbolic"
-        } else {
-            "user-trash-full-symbolic"
-        })
-        .size(icon_size)
-        .handle()
-    }
-
-    pub fn scan_trash(sizes: IconSizes) -> Vec<Item> {
-        let entries = match trash::os_limited::list() {
-            Ok(entry) => entry,
-            Err(err) => {
-                log::warn!("failed to read trash items: {err}");
-                return Vec::new();
-            }
-        };
-        let mut items: Vec<_> = entries
-            .into_iter()
-            .filter_map(|entry| {
-                let metadata = trash::os_limited::metadata(&entry)
-                    .inspect_err(|err| {
-                        log::warn!("failed to get metadata for trash item {entry:?}: {err}")
-                    })
-                    .ok()?;
-                Some(item_from_trash_entry(entry, metadata, sizes))
-            })
-            .collect();
-        items.sort_by(|a, b| match (a.metadata.is_dir(), b.metadata.is_dir()) {
-            (true, false) => Ordering::Less,
-            (false, true) => Ordering::Greater,
-            _ => LANGUAGE_SORTER.compare(&a.display_name, &b.display_name),
-        });
-        items
-    }
-
-    pub fn scan_search_trash<F: Fn(SearchItem) -> bool + Sync>(callback: F, regex: &Regex) {
-        let entries = match trash::os_limited::list() {
-            Ok(entries) => entries,
-            Err(err) => {
-                log::warn!("failed to read trash items: {err}");
-                return;
-            }
-        };
-
-        for entry in entries {
-            if let Ok(metadata) = trash::os_limited::metadata(&entry).inspect_err(|err| {
-                log::warn!("failed to get metadata for trash item {entry:?}: {err}")
-            }) {
-                let name = entry.name.to_string_lossy();
-                if regex.is_match(&name) && !callback(SearchItem::Trash(entry, metadata)) {
-                    break;
-                }
-            }
-        }
-    }
-}
 
 fn uri_to_path(uri: String) -> Option<PathBuf> {
     uri.parse::<url::Url>().ok().and_then(|url| {
@@ -1422,15 +1299,15 @@ pub fn scan_desktop(
         let display_name = Item::display_name(&name);
 
         let metadata = ItemMetadata::SimpleDir {
-            entries: trash_helpers::trash_entries() as u64,
+            entries: crate::trash_helpers::trash_entries() as u64,
         };
 
         let (mime, icon_handle_grid, icon_handle_list, icon_handle_list_condensed) = {
             (
                 "inode/directory".parse().unwrap(),
-                trash_helpers::trash_icon(sizes.grid()),
-                trash_helpers::trash_icon(sizes.list()),
-                trash_helpers::trash_icon(sizes.list_condensed()),
+                crate::trash_helpers::trash_icon(sizes.grid()),
+                crate::trash_helpers::trash_icon(sizes.list()),
+                crate::trash_helpers::trash_icon(sizes.list_condensed()),
             )
         };
 
@@ -1670,7 +1547,7 @@ impl Location {
                 // Search is done incrementally
                 Vec::new()
             }
-            Self::Trash => trash_helpers::scan_trash(sizes),
+            Self::Trash => crate::trash_helpers::scan_trash(sizes),
             Self::Recents => scan_recents(sizes),
             Self::Network(uri, _, _) => scan_network(uri, sizes),
         };

--- a/src/tab.rs
+++ b/src/tab.rs
@@ -1301,13 +1301,14 @@ pub fn scan_desktop(
         let metadata = ItemMetadata::SimpleDir {
             entries: crate::trash_helpers::trash_entries() as u64,
         };
+        let is_empty = crate::trash_helpers::is_empty_blocking();
 
         let (mime, icon_handle_grid, icon_handle_list, icon_handle_list_condensed) = {
             (
                 "inode/directory".parse().unwrap(),
-                crate::trash_helpers::trash_icon(sizes.grid()),
-                crate::trash_helpers::trash_icon(sizes.list()),
-                crate::trash_helpers::trash_icon(sizes.list_condensed()),
+                crate::trash_helpers::trash_icon(sizes.grid(), is_empty),
+                crate::trash_helpers::trash_icon(sizes.list(), is_empty),
+                crate::trash_helpers::trash_icon(sizes.list_condensed(), is_empty),
             )
         };
 
@@ -5960,6 +5961,7 @@ impl Tab {
         modifiers: &'a Modifiers,
         size: Size,
         clipboard_paste_available: bool,
+        trash_is_empty: bool,
     ) -> Element<'a, Message> {
         // Update cached size
         self.size_opt.set(Some(size));
@@ -6048,7 +6050,7 @@ impl Tab {
             && (!cfg!(feature = "wayland") || !crate::is_wayland())
         {
             let context_menu =
-                menu::context_menu(self, key_binds, modifiers, clipboard_paste_available);
+                menu::context_menu(self, key_binds, modifiers, clipboard_paste_available, trash_is_empty);
             popover = popover
                 .popup(context_menu)
                 .position(widget::popover::Position::Point(point));
@@ -6413,10 +6415,11 @@ impl Tab {
         key_binds: &'a HashMap<KeyBind, Action>,
         modifiers: &'a Modifiers,
         clipboard_paste_available: bool,
+        trash_is_empty: bool,
     ) -> Element<'a, Message> {
         widget::responsive(move |size| {
             widget::id_container(
-                self.view_responsive(key_binds, modifiers, size, clipboard_paste_available),
+                self.view_responsive(key_binds, modifiers, size, clipboard_paste_available, trash_is_empty),
                 Id::new(format!(
                     "tab-{}-{}",
                     self.scrollable_id, self.location_title

--- a/src/trash_helpers.rs
+++ b/src/trash_helpers.rs
@@ -1,0 +1,133 @@
+// SPDX-License-Identifier: GPL-3.0-only
+use cosmic::widget;
+use regex::Regex;
+use std::cmp::Ordering as CmpOrdering;
+use crate::config::IconSizes;
+use crate::localize::LANGUAGE_SORTER;
+use crate::tab::{Item, SearchItem, item_from_trash_entry};
+
+#[cfg(not(any(
+    target_os = "windows",
+    all(
+        unix,
+        not(target_os = "macos"),
+        not(target_os = "ios"),
+        not(target_os = "android")
+    )
+)))]
+mod os_limited {
+    use super::*;
+
+    pub fn trash_entries() -> usize {
+        0
+    }
+
+    pub fn trash_icon(icon_size: u16) -> widget::icon::Handle {
+        widget::icon::from_name("user-trash")
+            .size(icon_size)
+            .handle()
+    }
+
+    pub fn trash_icon_symbolic(icon_size: u16) -> widget::icon::Handle {
+        widget::icon::from_name("user-trash-symbolic")
+            .size(icon_size)
+            .handle()
+    }
+
+    pub fn scan_trash(_sizes: IconSizes) -> Vec<Item> {
+        log::warn!("viewing trash not supported on this platform");
+        Vec::new()
+    }
+
+    pub fn scan_search_trash<F: Fn(SearchItem) -> bool + Sync>(_callback: F, _regex: &Regex) {}
+}
+
+#[cfg(any(
+    target_os = "windows",
+    all(
+        unix,
+        not(target_os = "macos"),
+        not(target_os = "ios"),
+        not(target_os = "android")
+    )
+))]
+mod os_limited {
+    use super::*;
+
+    pub fn trash_entries() -> usize {
+        match trash::os_limited::list() {
+            Ok(entries) => entries.len(),
+            Err(_err) => 0,
+        }
+    }
+
+    pub fn trash_icon(icon_size: u16) -> widget::icon::Handle {
+        widget::icon::from_name(if trash::os_limited::is_empty().unwrap_or(true) {
+            "user-trash"
+        } else {
+            "user-trash-full"
+        })
+        .size(icon_size)
+        .handle()
+    }
+
+    pub fn trash_icon_symbolic(icon_size: u16) -> widget::icon::Handle {
+        widget::icon::from_name(if trash::os_limited::is_empty().unwrap_or(true) {
+            "user-trash-symbolic"
+        } else {
+            "user-trash-full-symbolic"
+        })
+        .size(icon_size)
+        .handle()
+    }
+
+    pub fn scan_trash(sizes: IconSizes) -> Vec<Item> {
+        let entries = match trash::os_limited::list() {
+            Ok(entry) => entry,
+            Err(err) => {
+                log::warn!("failed to read trash items: {err}");
+                return Vec::new();
+            }
+        };
+        let mut items: Vec<_> = entries
+            .into_iter()
+            .filter_map(|entry| {
+                let metadata = trash::os_limited::metadata(&entry)
+                    .inspect_err(|err| {
+                        log::warn!("failed to get metadata for trash item {entry:?}: {err}")
+                    })
+                    .ok()?;
+                Some(item_from_trash_entry(entry, metadata, sizes))
+            })
+            .collect();
+        items.sort_by(|a, b| match (a.metadata.is_dir(), b.metadata.is_dir()) {
+            (true, false) => CmpOrdering::Less,
+            (false, true) => CmpOrdering::Greater,
+            _ => LANGUAGE_SORTER.compare(&a.display_name, &b.display_name),
+        });
+        items
+    }
+
+    pub fn scan_search_trash<F: Fn(SearchItem) -> bool + Sync>(callback: F, regex: &Regex) {
+        let entries = match trash::os_limited::list() {
+            Ok(entries) => entries,
+            Err(err) => {
+                log::warn!("failed to read trash items: {err}");
+                return;
+            }
+        };
+
+        for entry in entries {
+            if let Ok(metadata) = trash::os_limited::metadata(&entry).inspect_err(|err| {
+                log::warn!("failed to get metadata for trash item {entry:?}: {err}")
+            }) {
+                let name = entry.name.to_string_lossy();
+                if regex.is_match(&name) && !callback(SearchItem::Trash(entry, metadata)) {
+                    break;
+                }
+            }
+        }
+    }
+}
+
+pub use os_limited::*;

--- a/src/trash_helpers.rs
+++ b/src/trash_helpers.rs
@@ -2,6 +2,7 @@
 use cosmic::widget;
 use regex::Regex;
 use std::cmp::Ordering as CmpOrdering;
+use std::path::PathBuf;
 use crate::config::IconSizes;
 use crate::localize::LANGUAGE_SORTER;
 use crate::tab::{Item, SearchItem, item_from_trash_entry};
@@ -18,17 +19,25 @@ use crate::tab::{Item, SearchItem, item_from_trash_entry};
 mod os_limited {
     use super::*;
 
+    pub fn is_empty_blocking() -> bool {
+        true
+    }
+
+    pub fn trash_folders_blocking() -> Vec<PathBuf> {
+        Vec::new()
+    }
+
     pub fn trash_entries() -> usize {
         0
     }
 
-    pub fn trash_icon(icon_size: u16) -> widget::icon::Handle {
+    pub fn trash_icon(icon_size: u16, _is_empty: bool) -> widget::icon::Handle {
         widget::icon::from_name("user-trash")
             .size(icon_size)
             .handle()
     }
 
-    pub fn trash_icon_symbolic(icon_size: u16) -> widget::icon::Handle {
+    pub fn trash_icon_symbolic(icon_size: u16, _is_empty: bool) -> widget::icon::Handle {
         widget::icon::from_name("user-trash-symbolic")
             .size(icon_size)
             .handle()
@@ -54,6 +63,14 @@ mod os_limited {
 mod os_limited {
     use super::*;
 
+    pub fn is_empty_blocking() -> bool {
+        trash::os_limited::is_empty().unwrap_or(true)
+    }
+
+    pub fn trash_folders_blocking() -> Vec<PathBuf> {
+        trash::os_limited::trash_folders().unwrap_or_default().into_iter().collect()
+    }
+
     pub fn trash_entries() -> usize {
         match trash::os_limited::list() {
             Ok(entries) => entries.len(),
@@ -61,8 +78,8 @@ mod os_limited {
         }
     }
 
-    pub fn trash_icon(icon_size: u16) -> widget::icon::Handle {
-        widget::icon::from_name(if trash::os_limited::is_empty().unwrap_or(true) {
+    pub fn trash_icon(icon_size: u16, is_empty: bool) -> widget::icon::Handle {
+        widget::icon::from_name(if is_empty {
             "user-trash"
         } else {
             "user-trash-full"
@@ -71,8 +88,8 @@ mod os_limited {
         .handle()
     }
 
-    pub fn trash_icon_symbolic(icon_size: u16) -> widget::icon::Handle {
-        widget::icon::from_name(if trash::os_limited::is_empty().unwrap_or(true) {
+    pub fn trash_icon_symbolic(icon_size: u16, is_empty: bool) -> widget::icon::Handle {
+        widget::icon::from_name(if is_empty {
             "user-trash-symbolic"
         } else {
             "user-trash-full-symbolic"

--- a/src/trash_helpers.rs
+++ b/src/trash_helpers.rs
@@ -2,86 +2,70 @@
 use cosmic::widget;
 use regex::Regex;
 use std::cmp::Ordering as CmpOrdering;
+use std::path::PathBuf;
 use crate::config::IconSizes;
 use crate::localize::LANGUAGE_SORTER;
 use crate::tab::{Item, SearchItem, item_from_trash_entry};
 
-#[cfg(not(any(
-    target_os = "windows",
-    all(
-        unix,
-        not(target_os = "macos"),
-        not(target_os = "ios"),
-        not(target_os = "android")
-    )
-)))]
-mod os_limited {
-    use super::*;
-
-    pub fn trash_entries() -> usize {
-        0
+pub fn is_empty_blocking() -> bool {
+    #[cfg(any(target_os = "windows", all(unix, not(target_os = "macos"), not(target_os = "ios"), not(target_os = "android"))))]
+    {
+        trash::os_limited::is_empty().unwrap_or(true)
     }
-
-    pub fn trash_icon(icon_size: u16) -> widget::icon::Handle {
-        widget::icon::from_name("user-trash")
-            .size(icon_size)
-            .handle()
+    #[cfg(not(any(target_os = "windows", all(unix, not(target_os = "macos"), not(target_os = "ios"), not(target_os = "android")))))]
+    {
+        true
     }
-
-    pub fn trash_icon_symbolic(icon_size: u16) -> widget::icon::Handle {
-        widget::icon::from_name("user-trash-symbolic")
-            .size(icon_size)
-            .handle()
-    }
-
-    pub fn scan_trash(_sizes: IconSizes) -> Vec<Item> {
-        log::warn!("viewing trash not supported on this platform");
-        Vec::new()
-    }
-
-    pub fn scan_search_trash<F: Fn(SearchItem) -> bool + Sync>(_callback: F, _regex: &Regex) {}
 }
 
-#[cfg(any(
-    target_os = "windows",
-    all(
-        unix,
-        not(target_os = "macos"),
-        not(target_os = "ios"),
-        not(target_os = "android")
-    )
-))]
-mod os_limited {
-    use super::*;
+pub fn trash_folders_blocking() -> Vec<PathBuf> {
+    #[cfg(any(target_os = "windows", all(unix, not(target_os = "macos"), not(target_os = "ios"), not(target_os = "android"))))]
+    {
+        trash::os_limited::trash_folders().unwrap_or_default().into_iter().collect()
+    }
+    #[cfg(not(any(target_os = "windows", all(unix, not(target_os = "macos"), not(target_os = "ios"), not(target_os = "android")))))]
+    {
+        Vec::new()
+    }
+}
 
-    pub fn trash_entries() -> usize {
+pub fn trash_entries() -> usize {
+    #[cfg(any(target_os = "windows", all(unix, not(target_os = "macos"), not(target_os = "ios"), not(target_os = "android"))))]
+    {
         match trash::os_limited::list() {
             Ok(entries) => entries.len(),
             Err(_err) => 0,
         }
     }
-
-    pub fn trash_icon(icon_size: u16) -> widget::icon::Handle {
-        widget::icon::from_name(if trash::os_limited::is_empty().unwrap_or(true) {
-            "user-trash"
-        } else {
-            "user-trash-full"
-        })
-        .size(icon_size)
-        .handle()
+    #[cfg(not(any(target_os = "windows", all(unix, not(target_os = "macos"), not(target_os = "ios"), not(target_os = "android")))))]
+    {
+        0
     }
+}
 
-    pub fn trash_icon_symbolic(icon_size: u16) -> widget::icon::Handle {
-        widget::icon::from_name(if trash::os_limited::is_empty().unwrap_or(true) {
-            "user-trash-symbolic"
-        } else {
-            "user-trash-full-symbolic"
-        })
-        .size(icon_size)
-        .handle()
-    }
+pub fn trash_icon(icon_size: u16, is_empty: bool) -> widget::icon::Handle {
+    widget::icon::from_name(if is_empty {
+        "user-trash"
+    } else {
+        "user-trash-full"
+    })
+    .size(icon_size)
+    .handle()
+}
 
-    pub fn scan_trash(sizes: IconSizes) -> Vec<Item> {
+pub fn trash_icon_symbolic(icon_size: u16, is_empty: bool) -> widget::icon::Handle {
+    widget::icon::from_name(if is_empty {
+        "user-trash-symbolic"
+    } else {
+        "user-trash-full-symbolic"
+    })
+    .size(icon_size)
+    .handle()
+}
+
+pub fn scan_trash(sizes: IconSizes) -> Vec<Item> {
+    #[cfg(any(target_os = "windows", all(unix, not(target_os = "macos"), not(target_os = "ios"), not(target_os = "android"))))]
+    {
         let entries = match trash::os_limited::list() {
             Ok(entry) => entry,
             Err(err) => {
@@ -107,8 +91,16 @@ mod os_limited {
         });
         items
     }
+    #[cfg(not(any(target_os = "windows", all(unix, not(target_os = "macos"), not(target_os = "ios"), not(target_os = "android")))))]
+    {
+        log::warn!("viewing trash not supported on this platform");
+        Vec::new()
+    }
+}
 
-    pub fn scan_search_trash<F: Fn(SearchItem) -> bool + Sync>(callback: F, regex: &Regex) {
+pub fn scan_search_trash<F: Fn(SearchItem) -> bool + Sync>(callback: F, regex: &Regex) {
+    #[cfg(any(target_os = "windows", all(unix, not(target_os = "macos"), not(target_os = "ios"), not(target_os = "android"))))]
+    {
         let entries = match trash::os_limited::list() {
             Ok(entries) => entries,
             Err(err) => {
@@ -128,6 +120,8 @@ mod os_limited {
             }
         }
     }
+    #[cfg(not(any(target_os = "windows", all(unix, not(target_os = "macos"), not(target_os = "ios"), not(target_os = "android")))))]
+    {
+        let _ = (callback, regex);
+    }
 }
-
-pub use os_limited::*;


### PR DESCRIPTION
### Description
Fixes an issue where `cosmic-files` would take several minutes to start up or completely freeze<del>, spamming the console with `TrySendError { kind: Full }` warnings from `iced_futures::subscription::tracker` </del>.

### Cause
The `trash` crate's `is_empty()` and `trash_folders()` methods query all mounted filesystems. If the system has an unresponsive or slow network drive (NFS, SMB, or GVFS mounts), these synchronous calls block the thread they are running on. Because these methods were being called on the main UI thread (during menu/icon generation) and inside the subscription tracker, they prevented the application from rendering and blocked `iced` window events from being dispatched.

### Solution
* Created an `AtomicBool` (`TRASH_IS_EMPTY`) to act as an instantaneous cache for the UI to read from during synchronous menu and icon rendering.
* Shifted the `is_empty()` checks to `tokio::task::spawn_blocking` via a new `Message::UpdateTrashState`, triggered on app initialization and whenever `Message::RescanTrash` is dispatched. 
* Wrapped the `trash::os_limited::trash_folders()` call inside the `TrashWatcherSubscription` stream with a `tokio::task::spawn_blocking` block so it no longer locks up the `iced` event loop.

### Testing
- [x] Application starts instantly, even with unreachable network drives mounted.

Disclaimer:
* I used Gemini 3.1 Pro preview and Mistral devstral-2.
* There is a little bit of harmless unrelated stuff because I ran cargo clippy --fix.

I tested the changes; `cargo run --release` on https://github.com/pop-os/cosmic-files/commit/b17f8889a8a350a9a07ab3e00155d9b35f136152 results in a 2 minutes and 35 seconds start time (not counting build time). After these changes, `cosmic-files` start in < 1 second.

I've had this issue for months.
<del>This may be related to https://github.com/pop-os/libcosmic/issues/671</del>
It most likely  fixes #1314 


- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

