### PR TITLE
docs: update PR template to clarify AI/LLM code policy

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,6 @@
-- [ ] I have disclosed use of any AI generated code in my commit messages.
-  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
-  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
+- [ ] I have not included AI generated code in this PR.
+  - Using an LLM/AI agent to generate code used in your PR is forbidden.
+  - In our experience, AI generated code results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs will be closed without comment.
 - [ ] I understand these changes in full and will be able to respond to review comments.
 - [ ] My change is accurately described in the commit message.
 - [ ] My contribution is tested and working as described.


### PR DESCRIPTION
_(Given this PR updates the PR template, I'm using the version in the PR)_

- [x] I have not included AI generated code in this PR.
  - Using an LLM/AI agent to generate code used in your PR is forbidden.
  - In our experience, AI generated code results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs will be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

My motivation for this change is [this comment](https://github.com/pop-os/cosmic-files/pull/1680#issuecomment-4187094274), which pretty clearly contradicts the old PR template. Previously, the PR template allowed for the use of AI generated code provided the person submitting the PR sufficiently understood the changes. Given this comment, it appears that is an outdated policy. This PR fixes the discrepancy.

I get that this is the kind of change that you likely want to have made by the team and not by an external contributor. I'm taking the initiative because I'd like to prompt discussion internally about how best to handle this apparent policy discrepancy, and to help ensure that nobody else wastes their time trying to contribute using an LLM/AI agent.