### PR TITLE
fix(i18n): use separate 'rename' keys for menu and dialog confirm button

### DIFF
--- a/i18n/en/cosmic_files.ftl
+++ b/i18n/en/cosmic_files.ftl
@@ -116,6 +116,7 @@ permanently-delete-warning = {$target} will be permanently deleted. This action 
 ## Rename Dialog
 rename-file = Rename file
 rename-folder = Rename folder
+rename-confirm = Rename
 
 ## Replace Dialog
 replace = Replace

--- a/src/app.rs
+++ b/src/app.rs
@@ -6140,7 +6140,7 @@ impl Application for App {
 
                 dialog
                     .primary_action(
-                        widget::button::suggested(fl!("rename"))
+                        widget::button::suggested(fl!("rename-confirm"))
                             .on_press_maybe(complete_maybe.clone()),
                     )
                     .secondary_action(


### PR DESCRIPTION
- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

---

Currently, when a user wants to rename a file/folder:

The key/string `rename = Rename...` is used for

- The entry in the right-click context menu - good
- The confirm button inside the subsequent dialog - not good, the 3 dots don't make sense here

This introduces a separate key/string `rename-confirm = Rename` and makes the confirm button use it

Fixes #1762 