### PR TITLE
feat(files): show count and total size of selected files in bottom bar (issue #1683)

### DIFF
--- a/i18n/en/cosmic_files.ftl
+++ b/i18n/en/cosmic_files.ftl
@@ -365,6 +365,21 @@ copy = Copy
 copy-path = Copy path
 paste = Paste
 select-all = Select all
+deselect-all = Deselect all
+duplicate = Duplicate
+folder-count = {$count} {$count ->
+    [one] folder
+   *[other] folders
+}
+file-count = {$count} {$count ->
+    [one] file
+   *[other] files
+}
+contains-item-count = contains {$count} {$count ->
+    [one] item
+   *[other] items
+}
+selection-footer-summary = {$folders}, {$files} selected ({$size})
 
 ## View
 zoom-in = Zoom in

--- a/src/app.rs
+++ b/src/app.rs
@@ -23,7 +23,7 @@ use cosmic::{
     executor,
     iced::core::widget::operation::focusable::unfocus,
     iced::runtime::{clipboard, task},
-    iced::widget::{button::focus, scrollable::AbsoluteOffset},
+    iced::widget::{button::focus, scrollable::AbsoluteOffset, stack},
     iced::{
         self, Alignment, Event, Length, Rectangle, Size, Subscription,
         clipboard::dnd::DndAction,
@@ -126,17 +126,10 @@ static FAVORITE_PATH_ERROR_REMOVE_BUTTON_ID: LazyLock<widget::Id> =
 static MOUNT_ERROR_TRY_AGAIN_BUTTON_ID: LazyLock<widget::Id> =
     LazyLock::new(|| widget::Id::new("mount-error-try-again-button"));
 
-#[allow(dead_code)]
-#[derive(Clone, Copy)]
-enum SelectionFooterAlignment {
-    Left,
-    Center,
-    Right,
-}
-
-const SELECTION_FOOTER_ALIGNMENT: SelectionFooterAlignment = SelectionFooterAlignment::Right;
 const SELECTION_FOOTER_DIVIDER_TOP_PADDING: u16 = 2;
 const SELECTION_FOOTER_VERTICAL_PADDING: u16 = 2;
+const FLOATING_FOOTER_SCROLL_INSET: u16 = 56;
+const COMPACT_SELECTION_FOOTER_SCROLL_INSET: u16 = 96;
 
 pub(crate) static REPLACE_BUTTON_ID: LazyLock<widget::Id> =
     LazyLock::new(|| widget::Id::new("replace-button"));
@@ -172,6 +165,7 @@ pub enum Action {
     CosmicSettingsWallpaper,
     DesktopViewOptions,
     Delete,
+    Duplicate,
     EditHistory,
     EditLocation,
     Eject,
@@ -243,6 +237,7 @@ impl Action {
             Self::CosmicSettingsWallpaper => Message::CosmicSettings("wallpaper"),
             Self::Delete => Message::Delete(entity_opt),
             Self::DesktopViewOptions => Message::DesktopViewOptions,
+            Self::Duplicate => Message::Duplicate(entity_opt),
             Self::EditHistory => Message::ToggleContextPage(ContextPage::EditHistory),
             Self::EditLocation => Message::TabMessage(entity_opt, tab::Message::EditLocationEnable),
             Self::Eject => Message::Eject,
@@ -371,6 +366,7 @@ pub enum Message {
     CosmicSettings(&'static str),
     Cut(Option<Entity>),
     Delete(Option<Entity>),
+    Duplicate(Option<Entity>),
     DesktopConfig(DesktopConfig),
     DesktopViewOptions,
     DesktopDialogs(bool),
@@ -695,12 +691,18 @@ enum MimeAppMatch {
 pub struct MounterData(MounterKey, MounterItem);
 
 #[derive(Clone, Debug)]
+pub enum FileDialogContext {
+    Paths(Box<[PathBuf]>),
+    TrashItems(Vec<TrashItem>),
+}
+
+#[derive(Clone, Debug)]
 pub enum WindowKind {
     ContextMenu(Entity, widget::Id),
     Desktop(Entity),
     DesktopViewOptions,
     Dialogs(widget::Id),
-    FileDialog(Option<Box<[PathBuf]>>),
+    FileDialog(Option<FileDialogContext>),
     Preview(Option<Entity>, PreviewKind),
 }
 
@@ -801,6 +803,10 @@ pub struct App {
 }
 
 impl App {
+    fn floating_footer_surface_color(theme: &theme::Theme) -> iced::Color {
+        theme.cosmic().primary.base.into()
+    }
+
     /// Returns true if the clipboard cache contains pasteable content
     fn clipboard_has_content(&self) -> bool {
         !matches!(self.clipboard_cache, ClipboardCache::Empty)
@@ -813,99 +819,212 @@ impl App {
             .is_some_and(|items| items.iter().any(|item| item.selected))
     }
 
-    fn selection_footer_summary(&self) -> Option<String> {
-        let items = self.tab_model.active_data::<Tab>()?.items_opt()?;
-        let mut selected_count = 0_usize;
-        let mut total_size = 0_u64;
-        let mut calculating_dir_size = false;
-        let mut unknown_size = false;
-        let mut dir_size_error = None;
+    fn selection_footer_stats(&self) -> Option<(tab::SelectionStats, bool, bool)> {
+        let tab = self.tab_model.active_data::<Tab>()?;
+        let stats = tab.selection_stats()?;
+        (stats.selected_items > 0).then_some((
+            stats,
+            tab.location.is_trash(),
+            tab.all_selectable_items_selected(),
+        ))
+    }
 
-        for item in items {
-            if !item.selected {
-                continue;
-            }
+    fn uses_compact_selection_footer(&self) -> bool {
+        self.core.is_condensed() || self.size.is_some_and(|size| size.width < 720.0)
+    }
 
-            selected_count += 1;
+    fn floating_footer_scroll_inset(&self) -> u16 {
+        if self.selection_footer_stats().is_some() && self.uses_compact_selection_footer() {
+            COMPACT_SELECTION_FOOTER_SCROLL_INSET
+        } else {
+            FLOATING_FOOTER_SCROLL_INSET
+        }
+    }
 
-            if item.metadata.is_dir() {
-                match &item.dir_size {
-                    tab::DirSize::Calculating(_) => {
-                        calculating_dir_size = true;
-                    }
-                    tab::DirSize::Directory(size) => {
-                        total_size = total_size.saturating_add(*size);
-                    }
-                    tab::DirSize::NotDirectory => {
-                        unknown_size = true;
-                    }
-                    tab::DirSize::Error(err) => {
-                        if dir_size_error.is_none() {
-                            dir_size_error = Some(err.clone());
-                        }
-                    }
-                }
-            } else if let Some(size) = item.metadata.file_size() {
-                total_size = total_size.saturating_add(size);
-            } else {
-                unknown_size = true;
-            }
+    fn floating_footer_style(theme: &theme::Theme) -> widget::container::Style {
+        let cosmic = theme.cosmic();
+        let background = Self::floating_footer_surface_color(theme);
+
+        widget::container::Style {
+            icon_color: Some(cosmic.background.component.on.into()),
+            text_color: Some(cosmic.background.component.on.into()),
+            background: Some(iced::Background::Color(background)),
+            border: iced::Border {
+                radius: cosmic.corner_radii.radius_s.into(),
+                width: 0.0,
+                color: iced::Color::TRANSPARENT,
+            },
+            snap: true,
+            ..Default::default()
+        }
+    }
+
+    fn floating_footer_menu_style(theme: &theme::Theme) -> theme::menu_bar::Appearance {
+        menu::overlay_menu_style(theme, Self::floating_footer_surface_color)
+    }
+
+    fn floating_footer_menu_item(
+        &self,
+        label: String,
+        action: Action,
+    ) -> widget::menu::Tree<Message> {
+        let shortcut = self.key_binds.iter().find_map(|(key_bind, bound_action)| {
+            (*bound_action == action).then(|| key_bind.to_string())
+        });
+
+        menu::menu_tree_item(
+            label,
+            shortcut,
+            menu::custom_menu_item_button_class(Self::floating_footer_surface_color),
+            action.message(None),
+        )
+    }
+
+    fn floating_footer_more_menu_button() -> widget::Button<'static, Message> {
+        widget::button::custom(
+            widget::container(widget::icon::from_name("view-more-symbolic").size(16))
+                .width(Length::Fill)
+                .height(Length::Fill)
+                .center_x(Length::Fill)
+                .center_y(Length::Fill),
+        )
+        .width(Length::Fixed(32.0))
+        .height(Length::Fixed(32.0))
+        .padding(0)
+        .class(theme::Button::Icon)
+        .on_press(Message::None)
+    }
+
+    fn floating_footer_shell<'a>(&self, content: Element<'a, Message>) -> Element<'a, Message> {
+        let cosmic_theme::Spacing {
+            space_xxs, space_s, ..
+        } = theme::active().cosmic().spacing;
+        let footer_edge_padding = space_xxs.saturating_sub(1);
+
+        widget::container(
+            widget::container(content)
+                .padding([SELECTION_FOOTER_VERTICAL_PADDING + space_xxs, space_xxs])
+                .width(Length::Fill)
+                .style(Self::floating_footer_style),
+        )
+        .padding([
+            SELECTION_FOOTER_DIVIDER_TOP_PADDING + space_xxs,
+            space_s,
+            footer_edge_padding,
+            footer_edge_padding,
+        ])
+        .into()
+    }
+
+    fn trash_footer(&self) -> Option<Element<'_, Message>> {
+        let tab = self.tab_model.active_data::<Tab>()?;
+        if !tab.location.is_trash() || self.active_tab_has_selection() {
+            return None;
         }
 
-        Some(if selected_count == 0 {
-            fl!("items", items = items.len())
-        } else {
-            let size = if calculating_dir_size || unknown_size {
-                fl!("calculating")
-            } else if let Some(error) = dir_size_error {
-                error
-            } else {
-                tab::format_size(total_size)
-            };
-
-            format!(
-                "{} • {}",
-                fl!("items", items = selected_count),
-                fl!("item-size", size = size),
+        tab.items_opt().filter(|items| !items.is_empty()).map(|_| {
+            self.floating_footer_shell(
+                widget::row::with_children([
+                    widget::space::horizontal().into(),
+                    widget::button::standard(fl!("empty-trash"))
+                        .on_press(Message::TabMessage(None, tab::Message::EmptyTrash))
+                        .into(),
+                ])
+                .align_y(Alignment::Center)
+                .into(),
             )
         })
     }
 
+    fn floating_footer(&self) -> Option<Element<'_, Message>> {
+        self.selection_footer().or_else(|| self.trash_footer())
+    }
+
     fn selection_footer(&self) -> Option<Element<'_, Message>> {
-        let cosmic_theme::Spacing { space_xs, .. } = theme::active().cosmic().spacing;
+        let cosmic_theme::Spacing { space_xxs, .. } = theme::active().cosmic().spacing;
+        let (stats, in_trash, all_selected) = self.selection_footer_stats()?;
+        let compact = self.uses_compact_selection_footer();
+        let summary = stats.footer_summary();
+        let selection_button_label = if all_selected {
+            fl!("deselect-all")
+        } else {
+            fl!("select-all")
+        };
+        let selection_button_message = if all_selected {
+            tab::Message::SelectNone
+        } else {
+            tab::Message::SelectAll
+        };
 
-        let summary = self.selection_footer_summary()?;
+        let menu_items = tab::selection_menu_actions(&stats, in_trash, in_trash || !compact);
 
-        let summary_row = match SELECTION_FOOTER_ALIGNMENT {
-            SelectionFooterAlignment::Left => widget::row::with_children([
-                widget::text::caption(summary).into(),
-                widget::space::horizontal().into(),
-            ]),
-            SelectionFooterAlignment::Center => widget::row::with_children([
-                widget::space::horizontal().into(),
-                widget::text::caption(summary).into(),
-                widget::space::horizontal().into(),
-            ]),
-            SelectionFooterAlignment::Right => widget::row::with_children([
-                widget::space::horizontal().into(),
-                widget::text::caption(summary).into(),
-            ]),
-        }
+        let build_actions = || {
+            let mut actions = widget::row::with_capacity(4)
+                .spacing(space_xxs)
+                .align_y(Alignment::Center)
+                .push(
+                    widget::button::standard(selection_button_label.clone())
+                        .on_press(Message::TabMessage(None, selection_button_message.clone())),
+                );
+            if compact {
+                actions = actions
+                    .push(widget::button::standard(fl!("move-to")).on_press(Message::MoveTo(None)));
+            }
+            actions
+                .push(
+                    widget::button::custom(
+                        widget::container(widget::icon::icon(tab::delete_action_icon(16)).size(16))
+                            .width(Length::Fill)
+                            .height(Length::Fill)
+                            .center_x(Length::Fill)
+                            .center_y(Length::Fill),
+                    )
+                    .width(Length::Fixed(32.0))
+                    .height(Length::Fixed(32.0))
+                    .padding(0)
+                    .class(theme::Button::Icon)
+                    .on_press(Message::Delete(None)),
+                )
+                .push(
+                    widget::menu::MenuBar::new(vec![widget::menu::Tree::with_children(
+                        Element::from(Self::floating_footer_more_menu_button()),
+                        menu_items
+                            .clone()
+                            .into_iter()
+                            .map(|action| {
+                                self.floating_footer_menu_item(
+                                    action.label(),
+                                    action.app_action(),
+                                )
+                            })
+                            .collect(),
+                    )])
+                    .item_height(widget::menu::ItemHeight::Dynamic(40))
+                    .item_width(widget::menu::ItemWidth::Uniform(220))
+                    .style(Self::floating_footer_menu_style as fn(&theme::Theme) -> _),
+                )
+        };
+
+        let wide_row = widget::row::with_children([
+            widget::text::caption(summary.clone()).into(),
+            widget::space::horizontal().into(),
+            build_actions().into(),
+        ])
         .align_y(Alignment::Center);
 
-        Some(
-            widget::column::with_children([
-                widget::container(widget::divider::horizontal::light())
-                    .padding([SELECTION_FOOTER_DIVIDER_TOP_PADDING, 0, 0, 0])
-                    .into(),
-                widget::container(summary_row)
-                    .class(style::Container::Background)
-                    .padding([SELECTION_FOOTER_VERTICAL_PADDING, space_xs])
-                    .width(Length::Fill)
-                    .into(),
-            ])
-            .into(),
-        )
+        let compact_column = widget::column::with_children([
+            build_actions().into(),
+            widget::text::caption(summary).into(),
+        ])
+        .spacing(space_xxs);
+
+        let footer_content: Element<_> = if compact {
+            compact_column.into()
+        } else {
+            wide_row.into()
+        };
+
+        Some(self.floating_footer_shell(footer_content))
     }
 
     fn progress_footer(&self) -> Option<Element<'_, Message>> {
@@ -1235,6 +1354,7 @@ impl App {
     fn destination_selection_dialog(
         &mut self,
         paths: &[impl AsRef<Path>],
+        context: FileDialogContext,
         on_result: impl Fn(DialogResult) -> Message + 'static,
         title: impl Into<String>,
         accept_label: impl AsRef<str>,
@@ -1255,9 +1375,7 @@ impl App {
             dialog.set_accept_label(accept_label);
             self.windows.insert(
                 dialog.window_id(),
-                Window::new(WindowKind::FileDialog(Some(
-                    paths.iter().map(|x| x.as_ref().to_path_buf()).collect(),
-                ))),
+                Window::new(WindowKind::FileDialog(Some(context))),
             );
             self.file_dialog_opt = Some(dialog);
             Task::batch([set_title_task, dialog_task])
@@ -1269,6 +1387,7 @@ impl App {
     fn extract_to(&mut self, paths: &[impl AsRef<Path>]) -> Task<Message> {
         self.destination_selection_dialog(
             paths,
+            FileDialogContext::Paths(paths.iter().map(|x| x.as_ref().to_path_buf()).collect()),
             Message::ExtractToResult,
             fl!("extract-to-title"),
             fl!("extract-here"),
@@ -1278,6 +1397,7 @@ impl App {
     fn move_to(&mut self, paths: &[impl AsRef<Path>]) -> Task<Message> {
         self.destination_selection_dialog(
             paths,
+            FileDialogContext::Paths(paths.iter().map(|x| x.as_ref().to_path_buf()).collect()),
             Message::MoveToResult,
             fl!("move-to-title"),
             fl!("move-to-button-label"),
@@ -1287,10 +1407,20 @@ impl App {
     fn copy_to(&mut self, paths: &[impl AsRef<Path>]) -> Task<Message> {
         self.destination_selection_dialog(
             paths,
+            FileDialogContext::Paths(paths.iter().map(|x| x.as_ref().to_path_buf()).collect()),
             Message::CopyToResult,
             fl!("copy-to-title"),
             fl!("copy-to-button-label"),
         )
+    }
+
+    fn take_file_dialog_context(&mut self) -> Option<FileDialogContext> {
+        let file_dialog = self.file_dialog_opt.take()?;
+        let window = self.windows.remove(&file_dialog.window_id())?;
+        match window.kind {
+            WindowKind::FileDialog(context) => context,
+            _ => None,
+        }
     }
 
     #[cfg(all(feature = "wayland", feature = "desktop-applet"))]
@@ -1903,6 +2033,56 @@ impl App {
             })
     }
 
+    fn selected_trash_items(&self, entity_opt: Option<Entity>) -> Vec<TrashItem> {
+        let entity = entity_opt.unwrap_or_else(|| self.tab_model.active());
+        self.tab_model
+            .data::<Tab>(entity)
+            .and_then(Tab::items_opt)
+            .into_iter()
+            .flatten()
+            .filter_map(|item| {
+                if item.selected {
+                    match &item.metadata {
+                        ItemMetadata::Trash { entry, .. } => Some(entry.clone()),
+                        _ => None,
+                    }
+                } else {
+                    None
+                }
+            })
+            .collect()
+    }
+
+    fn duplicate_selected(&mut self, entity_opt: Option<Entity>) -> Task<Message> {
+        let mut grouped: BTreeMap<PathBuf, Vec<PathBuf>> = BTreeMap::new();
+        for path in self.selected_paths(entity_opt) {
+            let Some(parent) = path.parent() else {
+                continue;
+            };
+            grouped
+                .entry(parent.to_path_buf())
+                .or_default()
+                .push(path.to_path_buf());
+        }
+
+        Task::batch(
+            grouped
+                .into_iter()
+                .map(|(to, paths)| self.operation(Operation::Copy { paths, to })),
+        )
+    }
+
+    fn move_from_trash(&mut self, items: Vec<TrashItem>) -> Task<Message> {
+        let paths: Box<[_]> = items.iter().map(|item| item.original_path()).collect();
+        self.destination_selection_dialog(
+            &paths,
+            FileDialogContext::TrashItems(items),
+            Message::MoveToResult,
+            fl!("move-to-title"),
+            fl!("move-to-button-label"),
+        )
+    }
+
     fn set_cut(&mut self, entity_opt: Option<Entity>) {
         let entity = entity_opt.unwrap_or_else(|| self.tab_model.active());
         if let Some(tab) = self.tab_model.data_mut::<Tab>(entity) {
@@ -2405,11 +2585,11 @@ impl App {
                         let mut selected = items.iter().filter(|item| item.selected);
 
                         match (selected.next(), selected.next()) {
-                            // At least two selected items
+                            // At least two selected items use the selection details layout
                             (Some(_), Some(_)) => {
                                 Some(tab.multi_preview_view(Some(&self.mime_app_cache)))
                             }
-                            // Exactly one selected item
+                            // Exactly one selected item keeps the existing preview/details layout
                             (Some(item), None) => {
                                 Some(item.preview_view(Some(&self.mime_app_cache), military_time))
                             }
@@ -3224,17 +3404,10 @@ impl Application for App {
                 match result {
                     DialogResult::Cancel => {}
                     DialogResult::Open(selected_paths) => {
-                        let mut file_paths = None;
-                        if let Some(file_dialog) = &self.file_dialog_opt
-                            && let Some(window) = self.windows.remove(&file_dialog.window_id())
-                            && let WindowKind::FileDialog(paths) = window.kind
-                        {
-                            file_paths = paths;
-                        }
-                        if let Some(file_paths) = file_paths
+                        if let Some(FileDialogContext::Paths(file_paths)) =
+                            self.take_file_dialog_context()
                             && !selected_paths.is_empty()
                         {
-                            self.file_dialog_opt = None;
                             return self.operation(Operation::Copy {
                                 paths: file_paths.to_vec(),
                                 to: selected_paths[0].clone(),
@@ -3242,7 +3415,7 @@ impl Application for App {
                         }
                     }
                 }
-                self.file_dialog_opt = None;
+                self.take_file_dialog_context();
             }
             Message::Cut(entity_opt) => {
                 self.set_cut(entity_opt);
@@ -3276,23 +3449,12 @@ impl Application for App {
                 let entity = entity_opt.unwrap_or_else(|| self.tab_model.active());
                 if let Some(tab) = self.tab_model.data::<Tab>(entity) {
                     if tab.location.is_trash() {
-                        if let Some(items) = tab.items_opt() {
-                            let mut trash_items = Vec::new();
-                            for item in items {
-                                if item.selected {
-                                    if let ItemMetadata::Trash { entry, .. } = &item.metadata {
-                                        trash_items.push(entry.clone());
-                                    } else {
-                                        //TODO: error on trying to permanently delete non-trash file?
-                                    }
-                                }
-                            }
-                            if !trash_items.is_empty() {
-                                return self.update(Message::DialogPush(
-                                    DialogPage::DeleteTrash { items: trash_items },
-                                    Some(DELETE_TRASH_BUTTON_ID.clone()),
-                                ));
-                            }
+                        let trash_items = self.selected_trash_items(entity_opt);
+                        if !trash_items.is_empty() {
+                            return self.update(Message::DialogPush(
+                                DialogPage::DeleteTrash { items: trash_items },
+                                Some(DELETE_TRASH_BUTTON_ID.clone()),
+                            ));
                         }
                     } else {
                         let paths: Box<[_]> = self.selected_paths(entity_opt).collect();
@@ -3301,6 +3463,9 @@ impl Application for App {
                         }
                     }
                 }
+            }
+            Message::Duplicate(entity_opt) => {
+                return self.duplicate_selected(entity_opt);
             }
             Message::DesktopConfig(config) => {
                 if config != self.config.desktop {
@@ -3561,17 +3726,10 @@ impl Application for App {
                 match result {
                     DialogResult::Cancel => {}
                     DialogResult::Open(selected_paths) => {
-                        let mut archive_paths = None;
-                        if let Some(file_dialog) = &self.file_dialog_opt
-                            && let Some(window) = self.windows.remove(&file_dialog.window_id())
-                            && let WindowKind::FileDialog(paths) = window.kind
-                        {
-                            archive_paths = paths;
-                        }
-                        if let Some(archive_paths) = archive_paths
+                        if let Some(FileDialogContext::Paths(archive_paths)) =
+                            self.take_file_dialog_context()
                             && !selected_paths.is_empty()
                         {
-                            self.file_dialog_opt = None;
                             return self.operation(Operation::Extract {
                                 paths: archive_paths,
                                 to: selected_paths[0].clone(),
@@ -3580,7 +3738,7 @@ impl Application for App {
                         }
                     }
                 }
-                self.file_dialog_opt = None;
+                self.take_file_dialog_context();
             }
             Message::FileDialogMessage(dialog_message) => {
                 if let Some(dialog) = &mut self.file_dialog_opt {
@@ -3790,33 +3948,48 @@ impl Application for App {
                 }
             }
             Message::MoveTo(entity_opt) => {
-                let selected_paths: Box<[_]> = self.selected_paths(entity_opt).collect();
-                return self.move_to(&selected_paths);
+                let entity = entity_opt.unwrap_or_else(|| self.tab_model.active());
+                if self
+                    .tab_model
+                    .data::<Tab>(entity)
+                    .is_some_and(|tab| tab.location.is_trash())
+                {
+                    let items = self.selected_trash_items(entity_opt);
+                    if !items.is_empty() {
+                        return self.move_from_trash(items);
+                    }
+                } else {
+                    let selected_paths: Box<[_]> = self.selected_paths(entity_opt).collect();
+                    return self.move_to(&selected_paths);
+                }
             }
             Message::MoveToResult(result) => {
                 match result {
                     DialogResult::Cancel => {}
                     DialogResult::Open(selected_paths) => {
-                        let mut file_paths = None;
-                        if let Some(file_dialog) = &self.file_dialog_opt
-                            && let Some(window) = self.windows.remove(&file_dialog.window_id())
-                            && let WindowKind::FileDialog(paths) = window.kind
-                        {
-                            file_paths = paths;
-                        }
-                        if let Some(file_paths) = file_paths
-                            && !selected_paths.is_empty()
-                        {
-                            self.file_dialog_opt = None;
-                            return self.operation(Operation::Move {
-                                paths: file_paths.to_vec(),
-                                to: selected_paths[0].clone(),
-                                cross_device_copy: false,
-                            });
+                        if !selected_paths.is_empty() {
+                            match self.take_file_dialog_context() {
+                                Some(FileDialogContext::Paths(paths)) => {
+                                    return self.operation(Operation::Move {
+                                        paths: paths.to_vec(),
+                                        to: selected_paths[0].clone(),
+                                        cross_device_copy: false,
+                                    });
+                                }
+                                Some(FileDialogContext::TrashItems(items)) => {
+                                    return self.operation(Operation::MoveFromTrash {
+                                        items,
+                                        to: selected_paths[0].clone(),
+                                    });
+                                }
+                                None => {}
+                            }
+                        } else {
+                            self.take_file_dialog_context();
                         }
                     }
                 }
-                self.file_dialog_opt = None;
+                self.take_file_dialog_context();
             }
             Message::NetworkAuth(mounter_key, uri, auth, auth_tx) => {
                 return self.push_dialog(
@@ -4528,21 +4701,7 @@ impl Application for App {
                 }
             }
             Message::RestoreFromTrash(entity_opt) => {
-                let mut trash_items = Vec::new();
-                let entity = entity_opt.unwrap_or_else(|| self.tab_model.active());
-                if let Some(tab) = self.tab_model.data_mut::<Tab>(entity)
-                    && let Some(items) = tab.items_opt()
-                {
-                    for item in items {
-                        if item.selected {
-                            if let ItemMetadata::Trash { entry, .. } = &item.metadata {
-                                trash_items.push(entry.clone());
-                            } else {
-                                //TODO: error on trying to restore non-trash file?
-                            }
-                        }
-                    }
-                }
+                let trash_items = self.selected_trash_items(entity_opt);
                 if !trash_items.is_empty() {
                     return self.operation(Operation::Restore { items: trash_items });
                 }
@@ -6599,18 +6758,44 @@ impl Application for App {
 
         let entity = self.tab_model.active();
         if let Some(tab) = self.tab_model.data::<Tab>(entity) {
-            let tab_view = tab
+            let use_sidebar_selection = self.core.window.show_context
+                && matches!(
+                    self.context_page,
+                    ContextPage::Preview(_, PreviewKind::Selected)
+                );
+            let floating_footer = if !use_sidebar_selection {
+                self.floating_footer()
+            } else {
+                None
+            };
+            let footer_scroll_inset = floating_footer
+                .as_ref()
+                .map(|_| self.floating_footer_scroll_inset())
+                .unwrap_or(0);
+            let tab_view: Element<_> = tab
                 .view(
                     &self.key_binds,
                     &self.modifiers,
+                    footer_scroll_inset,
                     self.clipboard_has_content(),
                     &self.config.context_actions,
                 )
                 .map(move |message| Message::TabMessage(Some(entity), message));
-            tab_column = tab_column.push(tab_view);
-            if let Some(selection_footer) = self.selection_footer() {
-                tab_column = tab_column.push(selection_footer);
-            }
+            let tab_layer: Element<_> = if let Some(selection_footer) = floating_footer {
+                stack([
+                    tab_view,
+                    widget::container(selection_footer)
+                        .width(Length::Fill)
+                        .height(Length::Fill)
+                        .align_x(iced::alignment::Horizontal::Center)
+                        .align_y(iced::alignment::Vertical::Bottom)
+                        .into(),
+                ])
+                .into()
+            } else {
+                tab_view
+            };
+            tab_column = tab_column.push(tab_layer);
         } else {
             //TODO
         }
@@ -6653,6 +6838,7 @@ impl Application for App {
                             .view(
                                 &self.key_binds,
                                 &window.modifiers,
+                                0,
                                 self.clipboard_has_content(),
                                 &self.config.context_actions,
                             )

--- a/src/app.rs
+++ b/src/app.rs
@@ -126,6 +126,18 @@ static FAVORITE_PATH_ERROR_REMOVE_BUTTON_ID: LazyLock<widget::Id> =
 static MOUNT_ERROR_TRY_AGAIN_BUTTON_ID: LazyLock<widget::Id> =
     LazyLock::new(|| widget::Id::new("mount-error-try-again-button"));
 
+#[allow(dead_code)]
+#[derive(Clone, Copy)]
+enum SelectionFooterAlignment {
+    Left,
+    Center,
+    Right,
+}
+
+const SELECTION_FOOTER_ALIGNMENT: SelectionFooterAlignment = SelectionFooterAlignment::Right;
+const SELECTION_FOOTER_DIVIDER_TOP_PADDING: u16 = 2;
+const SELECTION_FOOTER_VERTICAL_PADDING: u16 = 2;
+
 pub(crate) static REPLACE_BUTTON_ID: LazyLock<widget::Id> =
     LazyLock::new(|| widget::Id::new("replace-button"));
 
@@ -792,6 +804,223 @@ impl App {
     /// Returns true if the clipboard cache contains pasteable content
     fn clipboard_has_content(&self) -> bool {
         !matches!(self.clipboard_cache, ClipboardCache::Empty)
+    }
+
+    fn active_tab_has_selection(&self) -> bool {
+        self.tab_model
+            .active_data::<Tab>()
+            .and_then(Tab::items_opt)
+            .is_some_and(|items| items.iter().any(|item| item.selected))
+    }
+
+    fn selection_footer_summary(&self) -> Option<String> {
+        let items = self.tab_model.active_data::<Tab>()?.items_opt()?;
+        let mut selected_count = 0_usize;
+        let mut total_size = 0_u64;
+        let mut calculating_dir_size = false;
+        let mut unknown_size = false;
+        let mut dir_size_error = None;
+
+        for item in items {
+            if !item.selected {
+                continue;
+            }
+
+            selected_count += 1;
+
+            if item.metadata.is_dir() {
+                match &item.dir_size {
+                    tab::DirSize::Calculating(_) => {
+                        calculating_dir_size = true;
+                    }
+                    tab::DirSize::Directory(size) => {
+                        total_size = total_size.saturating_add(*size);
+                    }
+                    tab::DirSize::NotDirectory => {
+                        unknown_size = true;
+                    }
+                    tab::DirSize::Error(err) => {
+                        if dir_size_error.is_none() {
+                            dir_size_error = Some(err.clone());
+                        }
+                    }
+                }
+            } else if let Some(size) = item.metadata.file_size() {
+                total_size = total_size.saturating_add(size);
+            } else {
+                unknown_size = true;
+            }
+        }
+
+        Some(if selected_count == 0 {
+            fl!("items", items = items.len())
+        } else {
+            let size = if calculating_dir_size || unknown_size {
+                fl!("calculating")
+            } else if let Some(error) = dir_size_error {
+                error
+            } else {
+                tab::format_size(total_size)
+            };
+
+            format!(
+                "{} • {}",
+                fl!("items", items = selected_count),
+                fl!("item-size", size = size),
+            )
+        })
+    }
+
+    fn selection_footer(&self) -> Option<Element<'_, Message>> {
+        let cosmic_theme::Spacing { space_xs, .. } = theme::active().cosmic().spacing;
+
+        let summary = self.selection_footer_summary()?;
+
+        let summary_row = match SELECTION_FOOTER_ALIGNMENT {
+            SelectionFooterAlignment::Left => widget::row::with_children([
+                widget::text::caption(summary).into(),
+                widget::space::horizontal().into(),
+            ]),
+            SelectionFooterAlignment::Center => widget::row::with_children([
+                widget::space::horizontal().into(),
+                widget::text::caption(summary).into(),
+                widget::space::horizontal().into(),
+            ]),
+            SelectionFooterAlignment::Right => widget::row::with_children([
+                widget::space::horizontal().into(),
+                widget::text::caption(summary).into(),
+            ]),
+        }
+        .align_y(Alignment::Center);
+
+        Some(
+            widget::column::with_children([
+                widget::container(widget::divider::horizontal::light())
+                    .padding([SELECTION_FOOTER_DIVIDER_TOP_PADDING, 0, 0, 0])
+                    .into(),
+                widget::container(summary_row)
+                    .class(style::Container::Background)
+                    .padding([SELECTION_FOOTER_VERTICAL_PADDING, space_xs])
+                    .width(Length::Fill)
+                    .into(),
+            ])
+            .into(),
+        )
+    }
+
+    fn progress_footer(&self) -> Option<Element<'_, Message>> {
+        if self.progress_operations.is_empty() {
+            return None;
+        }
+
+        let cosmic_theme::Spacing {
+            space_xs, space_s, ..
+        } = theme::active().cosmic().spacing;
+
+        let mut title = String::new();
+        let mut total_progress = 0.0;
+        let mut count = 0;
+        let mut all_paused = true;
+        for (op, controller) in self.pending_operations.values() {
+            if !controller.is_paused() {
+                all_paused = false;
+            }
+            if op.show_progress_notification() {
+                let progress = controller.progress();
+                if title.is_empty() {
+                    title = op.pending_text(progress, controller.state());
+                }
+                total_progress += progress;
+                count += 1;
+            }
+        }
+        let running = count;
+        // Adjust the progress bar so it does not jump around when operations finish
+        for id in &self.progress_operations {
+            if self.complete_operations.contains_key(id) {
+                total_progress += 1.0;
+                count += 1;
+            }
+        }
+        let finished = count - running;
+        total_progress /= count as f32;
+        if running >= 1 && (running > 1 || finished > 0) {
+            if finished > 0 {
+                title = fl!(
+                    "operations-running-finished",
+                    running = running,
+                    finished = finished,
+                    percent = ((total_progress * 100.0) as i32)
+                );
+            } else {
+                title = fl!(
+                    "operations-running",
+                    running = running,
+                    percent = ((total_progress * 100.0) as i32)
+                );
+            }
+        }
+
+        //TODO: get height from theme?
+        let progress_bar_height = Length::Fixed(4.0);
+        let progress_bar = widget::determinate_linear(total_progress)
+            .width(Length::Fill)
+            .girth(progress_bar_height);
+
+        Some(
+            widget::layer_container(widget::column::with_children([
+                widget::row::with_children([
+                    progress_bar.into(),
+                    if all_paused {
+                        widget::tooltip(
+                            widget::button::icon(icon::from_name("media-playback-start-symbolic"))
+                                .on_press(Message::PendingPauseAll(false))
+                                .padding(8),
+                            widget::text::body(fl!("resume")),
+                            widget::tooltip::Position::Top,
+                        )
+                        .into()
+                    } else {
+                        widget::tooltip(
+                            widget::button::icon(icon::from_name("media-playback-pause-symbolic"))
+                                .on_press(Message::PendingPauseAll(true))
+                                .padding(8),
+                            widget::text::body(fl!("pause")),
+                            widget::tooltip::Position::Top,
+                        )
+                        .into()
+                    },
+                    widget::tooltip(
+                        widget::button::icon(icon::from_name("window-close-symbolic"))
+                            .on_press(Message::PendingCancelAll)
+                            .padding(8),
+                        widget::text::body(fl!("cancel")),
+                        widget::tooltip::Position::Top,
+                    )
+                    .into(),
+                ])
+                .align_y(Alignment::Center)
+                .into(),
+                widget::text::body(title).into(),
+                widget::space::vertical().height(space_s).into(),
+                widget::row::with_children([
+                    widget::button::link(fl!("details"))
+                        .on_press(Message::ToggleContextPage(ContextPage::EditHistory))
+                        .padding(0)
+                        .trailing_icon(true)
+                        .into(),
+                    widget::space::horizontal().into(),
+                    widget::button::standard(fl!("dismiss"))
+                        .on_press(Message::PendingDismiss)
+                        .into(),
+                ])
+                .align_y(Alignment::Center)
+                .into(),
+            ]))
+            .padding([8, space_xs])
+            .layer(cosmic_theme::Layer::Primary)
+            .into(),
+        )
     }
 
     fn push_dialog(&mut self, page: DialogPage, focus_id: Option<widget::Id>) -> Task<Message> {
@@ -6272,117 +6501,7 @@ impl Application for App {
     }
 
     fn footer(&self) -> Option<Element<'_, Message>> {
-        if self.progress_operations.is_empty() {
-            return None;
-        }
-
-        let cosmic_theme::Spacing {
-            space_xs, space_s, ..
-        } = theme::active().cosmic().spacing;
-
-        let mut title = String::new();
-        let mut total_progress = 0.0;
-        let mut count = 0;
-        let mut all_paused = true;
-        for (op, controller) in self.pending_operations.values() {
-            if !controller.is_paused() {
-                all_paused = false;
-            }
-            if op.show_progress_notification() {
-                let progress = controller.progress();
-                if title.is_empty() {
-                    title = op.pending_text(progress, controller.state());
-                }
-                total_progress += progress;
-                count += 1;
-            }
-        }
-        let running = count;
-        // Adjust the progress bar so it does not jump around when operations finish
-        for id in &self.progress_operations {
-            if self.complete_operations.contains_key(id) {
-                total_progress += 1.0;
-                count += 1;
-            }
-        }
-        let finished = count - running;
-        total_progress /= count as f32;
-        if running >= 1 && (running > 1 || finished > 0) {
-            if finished > 0 {
-                title = fl!(
-                    "operations-running-finished",
-                    running = running,
-                    finished = finished,
-                    percent = ((total_progress * 100.0) as i32)
-                );
-            } else {
-                title = fl!(
-                    "operations-running",
-                    running = running,
-                    percent = ((total_progress * 100.0) as i32)
-                );
-            }
-        }
-
-        //TODO: get height from theme?
-        let progress_bar_height = Length::Fixed(4.0);
-        let progress_bar = widget::determinate_linear(total_progress)
-            .width(Length::Fill)
-            .girth(progress_bar_height);
-
-        let container = widget::layer_container(widget::column::with_children([
-            widget::row::with_children([
-                progress_bar.into(),
-                if all_paused {
-                    widget::tooltip(
-                        widget::button::icon(icon::from_name("media-playback-start-symbolic"))
-                            .on_press(Message::PendingPauseAll(false))
-                            .padding(8),
-                        widget::text::body(fl!("resume")),
-                        widget::tooltip::Position::Top,
-                    )
-                    .into()
-                } else {
-                    widget::tooltip(
-                        widget::button::icon(icon::from_name("media-playback-pause-symbolic"))
-                            .on_press(Message::PendingPauseAll(true))
-                            .padding(8),
-                        widget::text::body(fl!("pause")),
-                        widget::tooltip::Position::Top,
-                    )
-                    .into()
-                },
-                widget::tooltip(
-                    widget::button::icon(icon::from_name("window-close-symbolic"))
-                        .on_press(Message::PendingCancelAll)
-                        .padding(8),
-                    widget::text::body(fl!("cancel")),
-                    widget::tooltip::Position::Top,
-                )
-                .into(),
-            ])
-            .align_y(Alignment::Center)
-            .into(),
-            widget::text::body(title).into(),
-            widget::space::vertical().height(space_s).into(),
-            widget::row::with_children([
-                widget::button::link(fl!("details"))
-                    .on_press(Message::ToggleContextPage(ContextPage::EditHistory))
-                    .padding(0)
-                    .trailing_icon(true)
-                    .into(),
-                widget::space::horizontal().into(),
-                widget::button::standard(fl!("dismiss"))
-                    .on_press(Message::PendingDismiss)
-                    .into(),
-            ])
-            .align_y(Alignment::Center)
-            .into(),
-        ]))
-        .padding([8, space_xs])
-        .layer(cosmic_theme::Layer::Primary);
-
-        Some(container.into())
+        self.progress_footer()
     }
 
     fn header_start(&self) -> Vec<Element<'_, Self::Message>> {
@@ -6489,6 +6608,9 @@ impl Application for App {
                 )
                 .map(move |message| Message::TabMessage(Some(entity), message));
             tab_column = tab_column.push(tab_view);
+            if let Some(selection_footer) = self.selection_footer() {
+                tab_column = tab_column.push(selection_footer);
+            }
         } else {
             //TODO
         }
@@ -7015,13 +7137,17 @@ impl Application for App {
             }
         }
 
+        let active_entity = self.tab_model.active();
+        let active_tab_has_selection = self.active_tab_has_selection();
+
         subscriptions.extend(self.tab_model.iter().filter_map(|entity| {
             let tab = self.tab_model.data::<Tab>(entity)?;
             Some(
                 tab.subscription(
                     selected_previews
                         .iter()
-                        .any(|preview| preview.as_ref() == Some(entity).as_ref()),
+                        .any(|preview| preview.as_ref() == Some(entity).as_ref())
+                        || (entity == active_entity && active_tab_has_selection),
                 )
                 .with(entity)
                 .map(|(entity, tab_msg)| Message::TabMessage(Some(entity), tab_msg)),

--- a/src/app.rs
+++ b/src/app.rs
@@ -918,7 +918,14 @@ impl App {
 
     fn trash_footer(&self) -> Option<Element<'_, Message>> {
         let tab = self.tab_model.active_data::<Tab>()?;
-        if !tab.location.is_trash() || self.active_tab_has_selection() {
+        let showing_selection_details = self.core.window.show_context
+            && matches!(
+                self.context_page,
+                ContextPage::Preview(_, PreviewKind::Selected)
+            );
+        if !tab.location.is_trash()
+            || (self.active_tab_has_selection() && !showing_selection_details)
+        {
             return None;
         }
 
@@ -992,10 +999,7 @@ impl App {
                             .clone()
                             .into_iter()
                             .map(|action| {
-                                self.floating_footer_menu_item(
-                                    action.label(),
-                                    action.app_action(),
-                                )
+                                self.floating_footer_menu_item(action.label(), action.app_action())
                             })
                             .collect(),
                     )])
@@ -2610,6 +2614,7 @@ impl App {
                 }
             }
         }
+
         widget::column::with_children(children)
             .padding(if context_drawer {
                 [0, 0, 0, 0]
@@ -6763,10 +6768,12 @@ impl Application for App {
                     self.context_page,
                     ContextPage::Preview(_, PreviewKind::Selected)
                 );
-            let floating_footer = if !use_sidebar_selection {
-                self.floating_footer()
-            } else {
+            let floating_footer = if use_sidebar_selection && tab.location.is_trash() {
+                self.trash_footer()
+            } else if use_sidebar_selection {
                 None
+            } else {
+                self.floating_footer()
             };
             let footer_scroll_inset = floating_footer
                 .as_ref()

--- a/src/dialog.rs
+++ b/src/dialog.rs
@@ -441,13 +441,8 @@ impl<M: Send + 'static> Dialog<M> {
 
 #[derive(Clone, Debug)]
 enum DialogPage {
-    NewFolder {
-        parent: PathBuf,
-        name: String,
-    },
-    Replace {
-        filename: String,
-    },
+    NewFolder { parent: PathBuf, name: String },
+    Replace { filename: String },
 }
 
 #[derive(Clone, Debug)]
@@ -2031,8 +2026,8 @@ impl Application for App {
         }
 
         col = col.push(
-                self.tab
-                .view(&self.key_binds, &self.modifiers, false, &[])
+            self.tab
+                .view(&self.key_binds, &self.modifiers, 0, false, &[])
                 .map(Message::TabMessage),
         );
 

--- a/src/menu.rs
+++ b/src/menu.rs
@@ -4,7 +4,7 @@ use cosmic::{
     Element,
     app::Core,
     iced::{
-        Alignment, Background, Border, Length, advanced::widget::text::Style as TextStyle,
+        Alignment, Background, Border, Color, Length, advanced::widget::text::Style as TextStyle,
         keyboard::Modifiers,
     },
     theme,
@@ -43,6 +43,105 @@ macro_rules! menu_button {
     );
 }
 
+pub fn shortcut_tip_style(theme: &cosmic::Theme) -> TextStyle {
+    let mut color = theme.cosmic().background.component.on;
+    color.alpha *= 0.75;
+    TextStyle {
+        color: Some(color.into()),
+    }
+}
+
+pub fn standard_menu_surface_color(theme: &theme::Theme) -> Color {
+    theme.cosmic().background.component.base.into()
+}
+
+pub fn overlay_menu_style(
+    theme: &theme::Theme,
+    background: fn(&theme::Theme) -> Color,
+) -> theme::menu_bar::Appearance {
+    let cosmic = theme.cosmic();
+
+    theme::menu_bar::Appearance {
+        background: background(theme),
+        border_width: 1.0,
+        bar_border_radius: cosmic.corner_radii.radius_s,
+        menu_border_radius: cosmic.corner_radii.radius_s,
+        border_color: cosmic.background.component.divider.into(),
+        background_expand: [1; 4],
+        path: cosmic.background.component.hover.into(),
+    }
+}
+
+pub fn standard_overlay_menu_style(theme: &theme::Theme) -> theme::menu_bar::Appearance {
+    overlay_menu_style(theme, standard_menu_surface_color)
+}
+
+pub fn custom_menu_item_button_class(background: fn(&theme::Theme) -> Color) -> theme::Button {
+    fn button_style(
+        theme: &theme::Theme,
+        background: fn(&theme::Theme) -> Color,
+        hovered: bool,
+        pressed: bool,
+        disabled: bool,
+    ) -> widget::button::Style {
+        let cosmic = theme.cosmic();
+        let mut appearance = widget::button::Style::new();
+        let mut color = if pressed {
+            cosmic.background.component.pressed.into()
+        } else if hovered {
+            cosmic.background.component.hover.into()
+        } else {
+            background(theme)
+        };
+
+        appearance.text_color = Some(cosmic.background.component.on.into());
+        appearance.icon_color = Some(cosmic.background.component.on.into());
+        appearance.border_radius = cosmic.corner_radii.radius_s.into();
+        if disabled {
+            color.a *= 0.5;
+            appearance.text_color = Some(cosmic.background.component.on_disabled.into());
+            appearance.icon_color = Some(cosmic.background.component.on_disabled.into());
+        }
+        appearance.background = Some(Background::Color(color));
+        appearance
+    }
+
+    theme::Button::Custom {
+        active: Box::new(move |_, theme| button_style(theme, background, false, false, false)),
+        disabled: Box::new(move |theme| button_style(theme, background, false, false, true)),
+        hovered: Box::new(move |_, theme| button_style(theme, background, true, false, false)),
+        pressed: Box::new(move |_, theme| button_style(theme, background, true, true, false)),
+    }
+}
+
+pub fn menu_tree_item<Message: Clone + 'static>(
+    label: String,
+    shortcut: Option<String>,
+    button_class: theme::Button,
+    on_press: Message,
+) -> widget::menu::Tree<Message> {
+    let mut children = vec![text::body(label).into(), space::horizontal().into()];
+    if let Some(shortcut) = shortcut.filter(|shortcut| !shortcut.is_empty()) {
+        children.push(
+            text::body(shortcut)
+                .class(theme::Text::Custom(shortcut_tip_style))
+                .into(),
+        );
+    }
+
+    widget::menu::Tree::from(Element::from(
+        button::custom(
+            Row::with_children(children)
+                .height(Length::Fixed(24.0))
+                .align_y(Alignment::Center),
+        )
+        .padding([theme::active().cosmic().spacing.space_xxs, 16])
+        .width(Length::Fill)
+        .class(button_class)
+        .on_press(on_press),
+    ))
+}
+
 const fn menu_button_optional(
     label: String,
     action: Action,
@@ -70,13 +169,6 @@ pub fn context_menu<'a>(
         }
         String::new()
     };
-    fn key_style(theme: &cosmic::Theme) -> TextStyle {
-        let mut color = theme.cosmic().background.component.on;
-        color.alpha *= 0.75;
-        TextStyle {
-            color: Some(color.into()),
-        }
-    }
     fn disabled_style(theme: &cosmic::Theme) -> TextStyle {
         let mut color = theme.cosmic().background.component.on;
         color.alpha *= 0.5;
@@ -90,7 +182,7 @@ pub fn context_menu<'a>(
         menu_button!(
             text::body(label),
             space::horizontal(),
-            text::body(key).class(theme::Text::Custom(key_style))
+            text::body(key).class(theme::Text::Custom(shortcut_tip_style))
         )
         .on_press(tab::Message::ContextAction(action))
     };

--- a/src/operation/mod.rs
+++ b/src/operation/mod.rs
@@ -80,6 +80,16 @@ fn get_directory_name(file_name: &str) -> &str {
     file_name
 }
 
+fn retarget_trashed_items(items: Vec<trash::TrashItem>, to: &Path) -> Vec<trash::TrashItem> {
+    items
+        .into_iter()
+        .map(|mut item| {
+            item.original_parent = to.to_path_buf();
+            item
+        })
+        .collect()
+}
+
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub enum ReplaceResult {
     Replace(bool),
@@ -245,7 +255,6 @@ pub fn copy_unique_path(from: &Path, to: &Path) -> PathBuf {
         ".tar.Z",
         ".tar.pz",
     ];
-
     let mut to = to.to_owned();
     if let Some(file_name) = from.file_name().and_then(|name| name.to_str()) {
         let (stem, ext) = if from.is_dir() {
@@ -373,6 +382,11 @@ pub enum Operation {
         paths: Vec<PathBuf>,
         to: PathBuf,
         cross_device_copy: bool,
+    },
+    /// Restore items from trash and move them to a selected destination
+    MoveFromTrash {
+        items: Vec<trash::TrashItem>,
+        to: PathBuf,
     },
     NewFile {
         path: PathBuf,
@@ -515,6 +529,13 @@ impl Operation {
                 to = file_name(to),
                 progress = progress()
             ),
+            Self::MoveFromTrash { items, to } => fl!(
+                "moving",
+                items = items.len(),
+                from = fl!("trash"),
+                to = file_name(to),
+                progress = progress()
+            ),
             Self::NewFile { path } => fl!(
                 "creating",
                 name = file_name(path),
@@ -582,6 +603,12 @@ impl Operation {
                 from = paths_parent_name(paths),
                 to = file_name(to)
             ),
+            Self::MoveFromTrash { items, to } => fl!(
+                "moved",
+                items = items.len(),
+                from = fl!("trash"),
+                to = file_name(to)
+            ),
             Self::NewFile { path } => fl!(
                 "created",
                 name = file_name(path),
@@ -619,6 +646,7 @@ impl Operation {
             | Self::EmptyTrash
             | Self::Extract { .. }
             | Self::Move { .. }
+            | Self::MoveFromTrash { .. }
             | Self::PermanentlyDelete { .. }
             | Self::Restore { .. } => true,
             Self::NewFile { .. }
@@ -1011,6 +1039,19 @@ impl Operation {
                 )
                 .await
             }
+            Self::MoveFromTrash { items, to } => {
+                let moved_items = retarget_trashed_items(items, &to);
+                let controller_clone = controller.clone();
+                compio::runtime::spawn_blocking(move || {
+                    controller_clone.set_progress(0.0);
+                    trash::os_limited::restore_all(moved_items)
+                        .map_err(|e| OperationError::from_err(e, &controller_clone))?;
+                    controller_clone.set_progress(1.0);
+                    Ok(OperationSelection::default())
+                })
+                .await
+                .map_err(wrap_compio_spawn_error)?
+            }
             Self::NewFolder { path } => {
                 let controller_clone = controller.clone();
                 compio::runtime::spawn(async move {
@@ -1242,11 +1283,11 @@ mod tests {
     use super::{Controller, Operation, OperationError, OperationSelection, ReplaceResult};
     use crate::{
         app::{
-            DialogPage, Message,
-            test_utils::{
-                NAME_LEN, NUM_DIRS, NUM_FILES, NUM_HIDDEN, NUM_NESTED, empty_fs, filter_dirs,
-                filter_files, simple_fs,
-            },
+        DialogPage, Message,
+        test_utils::{
+            NAME_LEN, NUM_DIRS, NUM_FILES, NUM_HIDDEN, NUM_NESTED, empty_fs, filter_dirs,
+            filter_files, simple_fs,
+        },
         },
         fl,
     };

--- a/src/operation/mod.rs
+++ b/src/operation/mod.rs
@@ -1283,11 +1283,11 @@ mod tests {
     use super::{Controller, Operation, OperationError, OperationSelection, ReplaceResult};
     use crate::{
         app::{
-        DialogPage, Message,
-        test_utils::{
-            NAME_LEN, NUM_DIRS, NUM_FILES, NUM_HIDDEN, NUM_NESTED, empty_fs, filter_dirs,
-            filter_files, simple_fs,
-        },
+            DialogPage, Message,
+            test_utils::{
+                NAME_LEN, NUM_DIRS, NUM_FILES, NUM_HIDDEN, NUM_NESTED, empty_fs, filter_dirs,
+                filter_files, simple_fs,
+            },
         },
         fl,
     };

--- a/src/tab.rs
+++ b/src/tab.rs
@@ -6787,12 +6787,9 @@ impl Tab {
                 "Items"
             }
         )));
-        details = details.push(widget::text::body(fl!("type", mime = mime_label)));
         details = details.push(widget::text::body(selection_stats.breakdown_text()));
-        details = details.push(widget::text::body(fl!(
-            "item-size",
-            size = selection_stats.size_text()
-        )));
+        details = details.push(widget::text::body(selection_stats.size_text()));
+        details = details.push(widget::text::body(fl!("type", mime = mime_label)));
 
         let overflow_items = selection_menu_actions(&selection_stats, in_trash, in_trash);
 

--- a/src/tab.rs
+++ b/src/tab.rs
@@ -353,7 +353,7 @@ fn tab_complete(path: &Path) -> Result<Vec<(String, PathBuf)>, Box<dyn Error>> {
 }
 
 //TODO: translate, add more levels?
-fn format_size(size: u64) -> String {
+pub(crate) fn format_size(size: u64) -> String {
     const KB: u64 = 1000;
     const MB: u64 = 1000 * KB;
     const GB: u64 = 1000 * MB;

--- a/src/tab.rs
+++ b/src/tab.rs
@@ -287,8 +287,99 @@ fn button_style(
     }
 }
 
+fn selection_action_button_appearance(
+    theme: &theme::Theme,
+    hovered: bool,
+    pressed: bool,
+    disabled: bool,
+) -> widget::button::Style {
+    let cosmic = theme.cosmic();
+    let mut appearance = widget::button::Style::new();
+    let mut background: Color = if pressed {
+        cosmic.button.pressed.into()
+    } else if hovered {
+        cosmic.button.hover.into()
+    } else {
+        cosmic.button.base.into()
+    };
+
+    appearance.text_color = Some(cosmic.button.on.into());
+    appearance.icon_color = Some(cosmic.button.on.into());
+    appearance.border_radius = cosmic.corner_radii.radius_xl.into();
+
+    if disabled {
+        background.a *= 0.5;
+        appearance.text_color = Some(cosmic.button.on_disabled.into());
+        appearance.icon_color = Some(cosmic.button.on_disabled.into());
+    }
+
+    appearance.background = Some(background.into());
+    appearance
+}
+
+fn selection_action_button_class() -> theme::Button {
+    theme::Button::Custom {
+        active: Box::new(|_, theme| selection_action_button_appearance(theme, false, false, false)),
+        disabled: Box::new(|theme| selection_action_button_appearance(theme, false, false, true)),
+        hovered: Box::new(|_, theme| selection_action_button_appearance(theme, true, false, false)),
+        pressed: Box::new(|_, theme| selection_action_button_appearance(theme, true, true, false)),
+    }
+}
+
+fn selection_action_icon_button(
+    icon: widget::icon::Handle,
+    message: Message,
+) -> widget::Button<'static, Message> {
+    widget::button::custom(
+        widget::container(widget::icon::icon(icon).size(16))
+            .width(Length::Fill)
+            .height(Length::Fill)
+            .center_x(Length::Fill)
+            .center_y(Length::Fill),
+    )
+    .width(Length::Fixed(32.0))
+    .height(Length::Fixed(32.0))
+    .padding(0)
+    .class(theme::Button::Icon)
+    .on_press(message)
+}
+
+fn selection_action_button(label: String, message: Message) -> widget::Button<'static, Message> {
+    widget::button::custom(
+        widget::container(widget::text(label))
+            .width(Length::Shrink)
+            .height(Length::Fill)
+            .center_y(Length::Fill),
+    )
+    .height(Length::Fixed(36.0))
+    .padding([0, 18])
+    .class(selection_action_button_class())
+    .on_press(message)
+}
+
+fn selection_more_menu_button() -> widget::Button<'static, Message> {
+    widget::button::custom(
+        widget::container(widget::icon::from_name("view-more-symbolic").size(16))
+            .width(Length::Fill)
+            .height(Length::Fill)
+            .center_x(Length::Fill)
+            .center_y(Length::Fill),
+    )
+    .width(Length::Fixed(32.0))
+    .height(Length::Fixed(32.0))
+    .padding(0)
+    .class(theme::Button::Icon)
+    .on_press(Message::None)
+}
+
 pub fn folder_icon(path: &PathBuf, icon_size: u16) -> widget::icon::Handle {
     widget::icon::from_name(SPECIAL_DIRS.get(path).map_or("folder", |x| *x))
+        .size(icon_size)
+        .handle()
+}
+
+pub fn delete_action_icon(icon_size: u16) -> widget::icon::Handle {
+    widget::icon::from_name("edit-delete-symbolic")
         .size(icon_size)
         .handle()
 }
@@ -889,6 +980,11 @@ pub fn item_from_trash_entry(
         }
     };
 
+    let dir_size = match metadata.size {
+        trash::TrashItemSize::Entries(_) => DirSize::Calculating(Controller::default()),
+        trash::TrashItemSize::Bytes(_) => DirSize::NotDirectory,
+    };
+
     Item {
         name,
         display_name,
@@ -907,7 +1003,7 @@ pub fn item_from_trash_entry(
         selected: false,
         highlighted: false,
         overlaps_drag_rect: false,
-        dir_size: DirSize::NotDirectory,
+        dir_size,
         cut: false,
     }
 }
@@ -1842,6 +1938,7 @@ pub enum Message {
     ItemUp,
     Location(Location),
     LocationUp,
+    None,
     Open(Option<PathBuf>),
     Reload,
     RightClick(Option<Point>, Option<usize>),
@@ -1853,6 +1950,7 @@ pub enum Message {
     SearchContext(Location, SearchContextWrapper),
     SearchReady(bool),
     SelectAll,
+    SelectNone,
     SelectFirst,
     SelectLast,
     SetOpenWith(Mime, String),
@@ -1890,6 +1988,42 @@ impl MenuAction for LocationMenuAction {
 
     fn message(&self) -> Self::Message {
         Message::LocationMenuAction(*self)
+    }
+}
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum SelectionMenuAction {
+    Open,
+    Duplicate,
+    MoveTo,
+    RestoreFromTrash,
+}
+
+impl SelectionMenuAction {
+    pub fn app_action(self) -> Action {
+        match self {
+            Self::Open => Action::Open,
+            Self::Duplicate => Action::Duplicate,
+            Self::MoveTo => Action::MoveTo,
+            Self::RestoreFromTrash => Action::RestoreFromTrash,
+        }
+    }
+
+    pub fn label(self) -> String {
+        match self {
+            Self::Open => fl!("open"),
+            Self::Duplicate => fl!("duplicate"),
+            Self::MoveTo => fl!("move-to"),
+            Self::RestoreFromTrash => fl!("restore-from-trash"),
+        }
+    }
+}
+
+impl MenuAction for SelectionMenuAction {
+    type Message = Message;
+
+    fn message(&self) -> Self::Message {
+        Message::ContextAction(self.app_action())
     }
 }
 
@@ -1972,6 +2106,94 @@ impl ItemMetadata {
             _ => None,
         }
     }
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct SelectionStats {
+    pub selected_items: usize,
+    pub selected_files: usize,
+    pub selected_folders: usize,
+    pub contained_items: u64,
+    pub contains_items_known: bool,
+    pub total_size: u64,
+    pub calculating_dir_size: bool,
+    pub unknown_size: bool,
+    pub dir_size_error: Option<String>,
+}
+
+impl SelectionStats {
+    pub fn can_open(&self) -> bool {
+        (self.selected_items > 0 && self.selected_folders == 0)
+            || (self.selected_folders == 1 && self.selected_items == 1)
+    }
+
+    pub fn files_label(&self) -> String {
+        fl!("file-count", count = self.selected_files)
+    }
+
+    pub fn folders_label(&self) -> String {
+        fl!("folder-count", count = self.selected_folders)
+    }
+
+    pub fn contains_label(&self) -> Option<String> {
+        if self.selected_folders == 0 || !self.contains_items_known {
+            return None;
+        }
+
+        Some(fl!("contains-item-count", count = self.contained_items))
+    }
+
+    pub fn breakdown_text(&self) -> String {
+        let mut text = format!("{}, {}", self.folders_label(), self.files_label());
+        if let Some(contains) = self.contains_label() {
+            text.push_str(&format!(" ({contains})"));
+        }
+        text
+    }
+
+    pub fn size_text(&self) -> String {
+        if self.calculating_dir_size || self.unknown_size {
+            fl!("calculating")
+        } else if let Some(error) = &self.dir_size_error {
+            error.clone()
+        } else {
+            format_size(self.total_size)
+        }
+    }
+
+    pub fn footer_summary(&self) -> String {
+        fl!(
+            "selection-footer-summary",
+            folders = self.folders_label(),
+            files = self.files_label(),
+            size = self.size_text()
+        )
+    }
+}
+
+pub fn selection_menu_actions(
+    stats: &SelectionStats,
+    in_trash: bool,
+    include_move_to: bool,
+) -> Vec<SelectionMenuAction> {
+    let mut actions = Vec::new();
+
+    if in_trash {
+        actions.push(SelectionMenuAction::RestoreFromTrash);
+        if include_move_to {
+            actions.push(SelectionMenuAction::MoveTo);
+        }
+    } else {
+        if stats.can_open() {
+            actions.push(SelectionMenuAction::Open);
+        }
+        actions.push(SelectionMenuAction::Duplicate);
+        if include_move_to {
+            actions.push(SelectionMenuAction::MoveTo);
+        }
+    }
+
+    actions
 }
 
 #[derive(Debug)]
@@ -2363,6 +2585,20 @@ impl Item {
 
     pub fn path_opt(&self) -> Option<&PathBuf> {
         self.location_opt.as_ref()?.path_opt()
+    }
+
+    pub fn dir_size_path(&self) -> Option<PathBuf> {
+        match &self.metadata {
+            ItemMetadata::Trash { metadata, entry }
+                if matches!(metadata.size, TrashItemSize::Entries(_)) =>
+            {
+                let info_file = Path::new(&entry.id);
+                let trash_folder = info_file.parent()?.parent()?;
+                let name_in_trash = info_file.file_stem()?;
+                Some(trash_folder.join("files").join(name_in_trash))
+            }
+            _ => self.path_opt().cloned(),
+        }
     }
 
     pub fn can_gallery(&self) -> bool {
@@ -2842,6 +3078,104 @@ pub fn parse_hidden_file(path: &PathBuf) -> Box<[String]> {
 }
 
 impl Tab {
+    pub fn selection_stats(&self) -> Option<SelectionStats> {
+        let items = self.items_opt()?;
+        let mut stats = SelectionStats {
+            contains_items_known: true,
+            ..SelectionStats::default()
+        };
+
+        for item in items {
+            if !item.selected {
+                continue;
+            }
+
+            stats.selected_items += 1;
+
+            if item.metadata.is_dir() {
+                stats.selected_folders += 1;
+                match &item.metadata {
+                    ItemMetadata::Path { children_opt, .. } => {
+                        if let Some(children) = children_opt {
+                            stats.contained_items =
+                                stats.contained_items.saturating_add(*children as u64);
+                        } else {
+                            stats.contains_items_known = false;
+                        }
+                    }
+                    ItemMetadata::Trash { metadata, .. } => match metadata.size {
+                        TrashItemSize::Entries(entries) => {
+                            stats.contained_items =
+                                stats.contained_items.saturating_add(entries as u64);
+                        }
+                        TrashItemSize::Bytes(_) => {
+                            stats.contains_items_known = false;
+                        }
+                    },
+                    ItemMetadata::SimpleDir { entries } => {
+                        stats.contained_items = stats.contained_items.saturating_add(*entries);
+                    }
+                    ItemMetadata::SimpleFile { .. } => {}
+                    #[cfg(feature = "gvfs")]
+                    ItemMetadata::GvfsPath { children_opt, .. } => {
+                        if let Some(children) = children_opt {
+                            stats.contained_items =
+                                stats.contained_items.saturating_add(*children as u64);
+                        } else {
+                            stats.contains_items_known = false;
+                        }
+                    }
+                }
+
+                match &item.dir_size {
+                    DirSize::Calculating(_) => {
+                        stats.calculating_dir_size = true;
+                    }
+                    DirSize::Directory(size) => {
+                        stats.total_size = stats.total_size.saturating_add(*size);
+                    }
+                    DirSize::NotDirectory => {
+                        stats.unknown_size = true;
+                    }
+                    DirSize::Error(err) => {
+                        if stats.dir_size_error.is_none() {
+                            stats.dir_size_error = Some(err.clone());
+                        }
+                    }
+                }
+            } else {
+                stats.selected_files += 1;
+                if let Some(size) = item.metadata.file_size() {
+                    stats.total_size = stats.total_size.saturating_add(size);
+                } else {
+                    stats.unknown_size = true;
+                }
+            }
+        }
+
+        Some(stats)
+    }
+
+    pub fn all_selectable_items_selected(&self) -> bool {
+        self.items_opt().is_some_and(|items| {
+            let mut selectable_items = 0;
+            let mut selected_items = 0;
+
+            for item in items {
+                if !self.config.show_hidden && item.hidden {
+                    continue;
+                }
+
+                selectable_items += 1;
+                if item.selected {
+                    selected_items += 1;
+                }
+            }
+
+            selectable_items > 0 && selected_items == selectable_items
+        })
+    }
+
     pub fn new(
         location: Location,
         config: TabConfig,
@@ -3438,6 +3772,7 @@ impl Tab {
             Message::AutoScroll(auto_scroll) => {
                 commands.push(Command::AutoScroll(auto_scroll));
             }
+            Message::None => {}
             Message::ClickRelease(click_i_opt) => {
                 // Single click to open.
                 if !mod_ctrl && self.config.single_click {
@@ -4386,6 +4721,13 @@ impl Tab {
                     ));
                 }
             }
+            Message::SelectNone => {
+                if self.select_none() {
+                    commands.push(Command::Iced(
+                        widget::button::focus(widget::Id::unique()).into(),
+                    ));
+                }
+            }
             Message::SelectFirst => {
                 if self.select_position(0, 0, mod_shift) {
                     if let Some(offset) = self.select_focus_scroll() {
@@ -4611,15 +4953,14 @@ impl Tab {
                 commands.push(Command::Action(Action::ZoomOut));
             }
             Message::DirectorySize(path, dir_size) => {
-                let location = Location::Path(path);
                 if let Some(ref mut item) = self.parent_item_opt
-                    && item.location_opt.as_ref() == Some(&location)
+                    && item.dir_size_path().as_ref() == Some(&path)
                 {
                     item.dir_size.clone_from(&dir_size);
                 }
                 if let Some(ref mut items) = self.items_opt {
                     for item in items.iter_mut() {
-                        if item.location_opt.as_ref() == Some(&location) {
+                        if item.dir_size_path().as_ref() == Some(&path) {
                             item.dir_size = dir_size;
                             break;
                         }
@@ -6178,6 +6519,7 @@ impl Tab {
         key_binds: &'a HashMap<KeyBind, Action>,
         modifiers: &'a Modifiers,
         size: Size,
+        bottom_inset: u16,
         clipboard_paste_available: bool,
         context_actions: &'a [ContextActionPreset],
     ) -> Element<'a, Message> {
@@ -6284,12 +6626,21 @@ impl Tab {
             tab_column = tab_column.push(location_view);
         }
         if can_scroll {
+            let scroll_content: Element<_> = if bottom_inset > 0 {
+                widget::column::with_children([
+                    popover.into(),
+                    widget::space::vertical().height(bottom_inset).into(),
+                ])
+                .into()
+            } else {
+                popover.into()
+            };
             tab_column = tab_column.push(
                 // FIXME: new responsive widget will remove the state from the scrollable
                 // id_container with custom id forces the state to be extracted in a diff
                 // pre-processing step
                 widget::id_container(
-                    widget::scrollable(popover)
+                    widget::scrollable(scroll_content)
                         .id(self.scrollable_id.clone())
                         .on_scroll(Message::Scroll)
                         .width(Length::Fill)
@@ -6301,24 +6652,6 @@ impl Tab {
             tab_column = tab_column.push(popover);
         }
         match &self.location {
-            Location::Trash | Location::Search(SearchLocation::Trash, ..) => {
-                if let Some(items) = self.items_opt()
-                    && !items.is_empty()
-                {
-                    tab_column = tab_column.push(
-                        widget::layer_container(widget::row::with_children([
-                            widget::space::horizontal().into(),
-                            widget::button::standard(fl!("empty-trash"))
-                                .on_press(Message::EmptyTrash)
-                                .into(),
-                        ]))
-                        .padding([space_xxs, space_xs])
-                        .layer(cosmic_theme::Layer::Primary)
-                        .apply(widget::container)
-                        .padding([0, 0, 7, 0]),
-                    );
-                }
-            }
             Location::Network(uri, _display_name, _path) if uri == "network:///" => {
                 tab_column = tab_column.push(
                     widget::layer_container(widget::row::with_children([
@@ -6383,6 +6716,7 @@ impl Tab {
     ) -> Element<'a, Message> {
         let cosmic_theme::Spacing {
             space_xxxs,
+            space_xxs,
             space_m,
             ..
         } = theme::active().cosmic().spacing;
@@ -6410,57 +6744,34 @@ impl Tab {
         );
 
         let selected_items: Vec<&Item> = self.items_opt().map_or(Vec::new(), |items| {
-            items
-                .iter()
-                .filter(|item| {
-                    if item.selected {
-                        item.location_opt
-                            .as_ref()
-                            .and_then(Location::path_opt)
-                            .is_some()
-                    } else {
-                        false
-                    }
-                })
-                .collect()
+            items.iter().filter(|item| item.selected).collect()
         });
 
-        let mut details = widget::column::with_capacity(3).spacing(space_xxxs);
-        details = details.push(widget::text::body(fl!(
-            "items",
-            items = selected_items.len()
-        )));
+        let selection_stats = self.selection_stats().unwrap_or_default();
+        let in_trash = self.location.is_trash();
+        let all_selected = self.all_selectable_items_selected();
+        let selection_button_label = if all_selected {
+            fl!("deselect-all")
+        } else {
+            fl!("select-all")
+        };
+        let selection_button_message = if all_selected {
+            Message::SelectNone
+        } else {
+            Message::SelectAll
+        };
 
-        let mut total_size: u64 = 0;
+        let mut details = widget::column::with_capacity(3).spacing(space_xxxs);
         let mut mime_type_counts: BTreeMap<String, u64> = BTreeMap::new();
         let mut user_name: BTreeSet<String> = BTreeSet::new();
         let mut mode_user: BTreeSet<u32> = BTreeSet::new();
         let mut group_name: BTreeSet<String> = BTreeSet::new();
         let mut mode_group: BTreeSet<u32> = BTreeSet::new();
         let mut mode_other: BTreeSet<u32> = BTreeSet::new();
-        let mut calculating_dir_size = false;
-        let mut dir_size_error: Option<String> = None;
-
         for item in selected_items.iter() {
             *mime_type_counts.entry(item.mime.to_string()).or_insert(0) += 1;
 
             if let Some(metadata) = item.file_metadata() {
-                if metadata.is_dir() {
-                    match &item.dir_size {
-                        DirSize::Calculating(_) => {
-                            calculating_dir_size = true;
-                        }
-                        DirSize::Directory(size) => {
-                            total_size = total_size.saturating_add(*size);
-                        }
-                        DirSize::NotDirectory => (),
-                        DirSize::Error(err) => {
-                            dir_size_error = Some(err.clone());
-                        }
-                    };
-                } else {
-                    total_size = total_size.saturating_add(metadata.len());
-                }
                 let mode = metadata.mode();
                 user_name.insert(
                     get_user_by_uid(metadata.uid())
@@ -6492,26 +6803,59 @@ impl Tab {
             mime_type_strings.push("...".to_string());
         }
 
+        details = details.push(widget::text::body(selection_stats.breakdown_text()));
+        details = details.push(widget::text::body(selection_stats.size_text()));
         details = details.push(widget::text::body(fl!(
             "type",
             mime = mime_type_strings.join(", ")
         )));
 
-        let size = {
-            if calculating_dir_size {
-                fl!("calculating")
-            } else if let Some(error) = dir_size_error {
-                error
-            } else {
-                format_size(total_size)
-            }
-        };
+        let overflow_items = selection_menu_actions(&selection_stats, in_trash, in_trash);
 
-        details = details.push(widget::text::body(fl!("item-size", size = size)));
+        let mut action_row = widget::row::with_capacity(4)
+            .spacing(space_xxs)
+            .align_y(Alignment::Center)
+            .width(Length::Fill)
+            .push(selection_action_button(
+                selection_button_label,
+                selection_button_message,
+            ));
+        if !in_trash {
+            action_row = action_row.push(selection_action_button(
+                fl!("move-to"),
+                Message::ContextAction(Action::MoveTo),
+            ));
+        }
+        action_row = action_row
+            .push(widget::space::horizontal())
+            .push(selection_action_icon_button(
+                delete_action_icon(16),
+                Message::ContextAction(Action::Delete),
+            ))
+            .push(
+                widget::menu::MenuBar::new(vec![widget::menu::Tree::with_children(
+                    Element::from(selection_more_menu_button()),
+                    overflow_items
+                        .into_iter()
+                        .map(|action| {
+                            menu::menu_tree_item(
+                                action.label(),
+                                None,
+                                menu::custom_menu_item_button_class(
+                                    menu::standard_menu_surface_color,
+                                ),
+                                action.message(),
+                            )
+                        })
+                        .collect(),
+                )])
+                .item_height(widget::menu::ItemHeight::Dynamic(40))
+                .item_width(widget::menu::ItemWidth::Uniform(220))
+                .style(menu::standard_overlay_menu_style as fn(&theme::Theme) -> _),
+            );
 
+        column = column.push(action_row);
         column = column.push(details);
-
-        column = column.push(widget::button::standard(fl!("open")).on_press(Message::Open(None)));
 
         let mut settings = Vec::new();
         // Only allow modifying open-with if all mime types are the same
@@ -6637,6 +6981,7 @@ impl Tab {
         &'a self,
         key_binds: &'a HashMap<KeyBind, Action>,
         modifiers: &'a Modifiers,
+        bottom_inset: u16,
         clipboard_paste_available: bool,
         context_actions: &'a [ContextActionPreset],
     ) -> Element<'a, Message> {
@@ -6646,6 +6991,7 @@ impl Tab {
                     key_binds,
                     modifiers,
                     size,
+                    bottom_inset,
                     clipboard_paste_available,
                     context_actions,
                 ),
@@ -6826,7 +7172,7 @@ impl Tab {
                 }
                 for item in selected_items {
                     // Item must have a path
-                    if let Some(path) = item.path_opt().cloned() {
+                    if let Some(path) = item.dir_size_path() {
                         // Item must be calculating directory size
                         if let DirSize::Calculating(controller) = &item.dir_size {
                             struct Wrapper {

--- a/src/tab.rs
+++ b/src/tab.rs
@@ -46,7 +46,7 @@ use std::{
     borrow::Cow,
     cell::Cell,
     cmp::{Ordering, Reverse},
-    collections::{BTreeMap, BTreeSet, HashMap},
+    collections::{BTreeMap, HashMap},
     error::Error,
     fmt::{self, Display},
     fs::{self, File, Metadata},
@@ -2144,7 +2144,15 @@ impl SelectionStats {
     }
 
     pub fn breakdown_text(&self) -> String {
-        let mut text = format!("{}, {}", self.folders_label(), self.files_label());
+        let mut parts = Vec::with_capacity(2);
+        if self.selected_files > 0 {
+            parts.push(self.files_label());
+        }
+        if self.selected_folders > 0 {
+            parts.push(self.folders_label());
+        }
+
+        let mut text = parts.join(", ");
         if let Some(contains) = self.contains_label() {
             text.push_str(&format!(" ({contains})"));
         }
@@ -2162,12 +2170,7 @@ impl SelectionStats {
     }
 
     pub fn footer_summary(&self) -> String {
-        fl!(
-            "selection-footer-summary",
-            folders = self.folders_label(),
-            files = self.files_label(),
-            size = self.size_text()
-        )
+        format!("{} selected ({})", self.breakdown_text(), self.size_text())
     }
 }
 
@@ -6712,7 +6715,7 @@ impl Tab {
     }
     pub fn multi_preview_view<'a>(
         &'a self,
-        mime_app_cache_opt: Option<&'a mime_app::MimeAppCache>,
+        _mime_app_cache_opt: Option<&'a mime_app::MimeAppCache>,
     ) -> Element<'a, Message> {
         let cosmic_theme::Spacing {
             space_xxxs,
@@ -6723,6 +6726,9 @@ impl Tab {
 
         let mut column = widget::column::with_capacity(4).spacing(space_m);
 
+        let selected_items: Vec<&Item> = self.items_opt().map_or(Vec::new(), |items| {
+            items.iter().filter(|item| item.selected).collect()
+        });
         let handle = widget::icon::from_name("text-x-generic")
             .size(IconSizes::default().grid())
             .handle();
@@ -6735,17 +6741,14 @@ impl Tab {
         let icon_container2 =
             widget::container(icon.clone()).padding(padding::top(5).bottom(5).left(5).right(5));
         let icon_container3 = widget::container(icon).padding(padding::top(10).right(10));
-        let stack = stack![icon_container1, icon_container2, icon_container3];
+        let preview_stack: Element<'a, Message> =
+            stack![icon_container1, icon_container2, icon_container3].into();
 
         column = column.push(
-            widget::container(stack)
+            widget::container(preview_stack)
                 .center_x(Length::Fill)
                 .max_height(THUMBNAIL_SIZE as f32),
         );
-
-        let selected_items: Vec<&Item> = self.items_opt().map_or(Vec::new(), |items| {
-            items.iter().filter(|item| item.selected).collect()
-        });
 
         let selection_stats = self.selection_stats().unwrap_or_default();
         let in_trash = self.location.is_trash();
@@ -6761,53 +6764,34 @@ impl Tab {
             Message::SelectAll
         };
 
-        let mut details = widget::column::with_capacity(3).spacing(space_xxxs);
+        let mut details = widget::column::with_capacity(4).spacing(space_xxxs);
         let mut mime_type_counts: BTreeMap<String, u64> = BTreeMap::new();
-        let mut user_name: BTreeSet<String> = BTreeSet::new();
-        let mut mode_user: BTreeSet<u32> = BTreeSet::new();
-        let mut group_name: BTreeSet<String> = BTreeSet::new();
-        let mut mode_group: BTreeSet<u32> = BTreeSet::new();
-        let mut mode_other: BTreeSet<u32> = BTreeSet::new();
         for item in selected_items.iter() {
             *mime_type_counts.entry(item.mime.to_string()).or_insert(0) += 1;
+        }
+        let mime_label = match mime_type_counts.len() {
+            1 => mime_type_counts
+                .into_iter()
+                .next()
+                .map(|(mime, _)| mime)
+                .unwrap_or_else(|| fl!("mixed")),
+            _ => fl!("mixed"),
+        };
 
-            if let Some(metadata) = item.file_metadata() {
-                let mode = metadata.mode();
-                user_name.insert(
-                    get_user_by_uid(metadata.uid())
-                        .and_then(|user| user.name().to_str().map(ToOwned::to_owned))
-                        .unwrap_or_default(),
-                );
-                mode_user.insert(get_mode_part(mode, MODE_SHIFT_USER));
-                group_name.insert(
-                    get_group_by_gid(metadata.gid())
-                        .and_then(|group| group.name().to_str().map(ToOwned::to_owned))
-                        .unwrap_or_default(),
-                );
-                mode_group.insert(get_mode_part(mode, MODE_SHIFT_GROUP));
-                mode_other.insert(get_mode_part(mode, MODE_SHIFT_OTHER));
+        details = details.push(widget::text::heading(format!(
+            "{} {}",
+            selection_stats.selected_items,
+            if selection_stats.selected_items == 1 {
+                "Item"
+            } else {
+                "Items"
             }
-        }
-        let mut mime_types: Vec<(String, u64)> = mime_type_counts.into_iter().collect();
-        mime_types.sort_by(|(_, v1), (_, v2)| v2.cmp(v1));
-
-        // Limit the number of displayed mime types
-        let limit = usize::min(10, mime_types.len());
-
-        let mut mime_type_strings: Vec<String> = mime_types[..limit]
-            .iter()
-            .map(|(mime, count)| format!("{} ({})", mime, count))
-            .collect();
-
-        if mime_types.len() > limit {
-            mime_type_strings.push("...".to_string());
-        }
-
+        )));
+        details = details.push(widget::text::body(fl!("type", mime = mime_label)));
         details = details.push(widget::text::body(selection_stats.breakdown_text()));
-        details = details.push(widget::text::body(selection_stats.size_text()));
         details = details.push(widget::text::body(fl!(
-            "type",
-            mime = mime_type_strings.join(", ")
+            "item-size",
+            size = selection_stats.size_text()
         )));
 
         let overflow_items = selection_menu_actions(&selection_stats, in_trash, in_trash);
@@ -6856,124 +6840,6 @@ impl Tab {
 
         column = column.push(action_row);
         column = column.push(details);
-
-        let mut settings = Vec::new();
-        // Only allow modifying open-with if all mime types are the same
-        if mime_types.len() == 1 {
-            if let Some(mime) = mime_types
-                .get(0)
-                .and_then(|(mime, _)| mime.parse::<Mime>().ok())
-            {
-                if let Some(mime_app_cache) = mime_app_cache_opt {
-                    let mime_apps = mime_app_cache.get(&mime);
-                    if !mime_apps.is_empty() {
-                        let mime_closure = mime.clone();
-                        settings.push(
-                            widget::settings::item::builder(fl!("open-with")).control(
-                                Element::from(
-                                    widget::dropdown(
-                                        mime_apps,
-                                        mime_apps.iter().position(|x| x.is_default),
-                                        move |index| (index, mime_closure.clone()),
-                                    )
-                                    .icons(Cow::Borrowed(mime_app_cache.icons(&mime))),
-                                )
-                                .map(|(index, mime)| {
-                                    let mime_app = &mime_apps[index];
-                                    Message::SetOpenWith(mime, mime_app.id.clone())
-                                }),
-                            ),
-                        );
-                    }
-                }
-            }
-        }
-
-        #[cfg(unix)]
-        {
-            // Only return mode part if it's the only one
-            fn selected_mode_part(mut modes: BTreeSet<u32>) -> Option<usize> {
-                match (modes.pop_first(), modes.pop_first()) {
-                    (Some(mode), None) => Some(mode.try_into().unwrap()),
-                    _ => None,
-                }
-            }
-
-            // Convert a limited number of values from a set into a comma separated list
-            fn join_set(set: BTreeSet<String>) -> String {
-                let limit = 5;
-                let mut title = set.into_iter().collect::<Vec<String>>();
-                if title.len() > limit {
-                    title.truncate(limit);
-                    title.push("...".to_string());
-                }
-                title.join(", ")
-            }
-
-            let mode_part_user = selected_mode_part(mode_user);
-            settings.push(
-                widget::settings::item::builder(join_set(user_name))
-                    .description(fl!("owner"))
-                    .control(
-                        widget::dropdown(
-                            Cow::Borrowed(MODE_NAMES.as_slice()),
-                            mode_part_user,
-                            move |selected| {
-                                Message::ShiftPermissions(
-                                    None,
-                                    MODE_SHIFT_USER,
-                                    selected.try_into().unwrap(),
-                                )
-                            },
-                        )
-                        .placeholder(fl!("mixed")),
-                    ),
-            );
-
-            let mode_part_group = selected_mode_part(mode_group);
-            settings.push(
-                widget::settings::item::builder(join_set(group_name))
-                    .description(fl!("group"))
-                    .control(
-                        widget::dropdown(
-                            Cow::Borrowed(MODE_NAMES.as_slice()),
-                            mode_part_group,
-                            move |selected| {
-                                Message::ShiftPermissions(
-                                    None,
-                                    MODE_SHIFT_GROUP,
-                                    selected.try_into().unwrap(),
-                                )
-                            },
-                        )
-                        .placeholder(fl!("mixed")),
-                    ),
-            );
-
-            let mode_part_other = selected_mode_part(mode_other);
-            settings.push(
-                widget::settings::item::builder(fl!("other")).control(
-                    widget::dropdown(
-                        Cow::Borrowed(MODE_NAMES.as_slice()),
-                        mode_part_other,
-                        move |selected| {
-                            Message::ShiftPermissions(
-                                None,
-                                MODE_SHIFT_OTHER,
-                                selected.try_into().unwrap(),
-                            )
-                        },
-                    )
-                    .placeholder(fl!("mixed")),
-                ),
-            );
-        }
-
-        if !settings.is_empty() {
-            let mut section = widget::settings::section();
-            section = section.extend(settings);
-            column = column.push(section);
-        }
 
         column.into()
     }


### PR DESCRIPTION
Alright, this is an edit of the original message because the inital design got quite an overhaul.

This PR implements the file size + counter as described in issue #1683 and with additional UI/UX suggestions from #1766.

### Key Features
- when items are selected a floating footer appears, which shows file number and size as well as action buttons
-- the available actions are `Select all`, `Delete`, `Open`, `Duplicate` and `Move to...`
- when the file details tab is open, these elements appear in the right panel
- when inside the trash folder the options change to `Select all`, `Delete permanently`, `Restore from trash` and `Move to...`

### Behaviour Details
- when all items are selected the `Select all` button changes to a `Deselect all` button
- using the `Move to...` action from trash will restore the items in the specified directory
- selecting only a single file will display the old details tab; selecting 2 or more will display the new details tab

### Image gallary
<img width="900" height="625" alt="Screenshot_2026-04-23_00-07-51" src="https://github.com/user-attachments/assets/73c5a41e-880a-4030-a303-db463be2eee4" />
<img width="900" height="625" alt="Screenshot_2026-04-23_00-08-09" src="https://github.com/user-attachments/assets/bd6c8b36-fbbd-4522-9861-97d8b07c884e" />
<img width="900" height="625" alt="Screenshot_2026-04-23_00-08-23" src="https://github.com/user-attachments/assets/22eef6b5-6743-4ff3-82de-bacb53006e12" />
<img width="900" height="625" alt="Screenshot_2026-04-23_00-11-17" src="https://github.com/user-attachments/assets/24833111-c377-4842-bdcb-c00a5bcc79e3" />
<img width="900" height="625" alt="Screenshot_2026-04-23_00-08-39" src="https://github.com/user-attachments/assets/e3140693-3656-446a-bf07-de81b37fbe79" />
<img width="900" height="625" alt="Screenshot_2026-04-23_00-09-03" src="https://github.com/user-attachments/assets/00b51484-6751-46f3-90fd-021ce3926f9f" />


A couple of notes:
- The floating footer is overlaid on top of the tab view, and the tab content gets a bottom inset when that footer is present. This was done to keep the bottom most content visible even if the footer is active.
- The destination dialog flow is shared between normal move actions and move-from-trash via `FileDialogContext`, rather than adding a separate dialog/result path for trashed items.

I'm not 100% happy with the current details page implementation. When only one item is selected I chose to show the old page to avoid dealing with coming up with a new UI. #1766 unfortunatly omitted the file details display (type, size, created, modified, accessed) in their design, so I couldn't take theirs 1 for 1. 
This causes a huge UI shift when selecting 1 item vs selecting multiple, which should be changed at a later stage I guess.



---


- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.