### PR TITLE
fix: Use name for network location

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -1771,6 +1771,8 @@ impl App {
             if let Some(path) = favorite.path_opt() {
                 let name = if matches!(favorite, Favorite::Home) {
                     fl!("home")
+                } else if let Favorite::Network { name, .. } = favorite {
+                    name.clone()
                 } else if let Some(file_name) = path.file_name().and_then(|x| x.to_str()) {
                     file_name.to_string()
                 } else {

--- a/src/dialog.rs
+++ b/src/dialog.rs
@@ -902,6 +902,8 @@ impl App {
             if let Some(path) = favorite.path_opt() {
                 let name = if matches!(favorite, Favorite::Home) {
                     fl!("home")
+                } else if let Favorite::Network { name, .. } = favorite {
+                    name.clone()
                 } else if let Some(file_name) = path.file_name().and_then(|x| x.to_str()) {
                     file_name.to_string()
                 } else {


### PR DESCRIPTION
Use the name of network favorites instead of the last folder in its path.

Given the following network favorite:

```ron
Network(
    uri: "sftp://beets/mnt",
    name: "beets",
    path: "/run/user/1000/gvfs/sftp:host=beets/mnt",
)
```

Pre-fix would use `mnt`, the last folder in the path. Post-fix it uses `beets`.

Tested with a variety of custom names and paths. Couple cases worth mentioning:
- Missing `name` field causes the entry to not appear, and
- An empty name value will show up with an empty name

Both of these cannot happen with normal usage; they require a user to manually edit the favorites file. Not worth addressing.

Fixes #1724 

- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

