### PR TITLE
feat(files): Add button to clear recents

### DIFF
--- a/i18n/en/cosmic_files.ftl
+++ b/i18n/en/cosmic_files.ftl
@@ -62,9 +62,6 @@ empty-trash = Empty trash
 empty-trash-title = Empty trash?
 empty-trash-warning = Items in the Trash folder will be permanently deleted
 
-## Clear Recents
-clear-recents = Clear Recents
-
 ## Mount Error Dialog
 mount-error = Unable to access drive
 

--- a/i18n/en/cosmic_files.ftl
+++ b/i18n/en/cosmic_files.ftl
@@ -62,6 +62,9 @@ empty-trash = Empty trash
 empty-trash-title = Empty trash?
 empty-trash-warning = Items in the Trash folder will be permanently deleted
 
+## Clear Recents
+clear-recents = Clear Recents
+
 ## Mount Error Dialog
 mount-error = Unable to access drive
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -4588,6 +4588,14 @@ impl Application for App {
                         tab::Command::DropFiles(to, from) => {
                             commands.push(self.update(Message::PasteContents(to, from)));
                         }
+                        tab::Command::ClearRecents => {
+                            match recently_used_xbel::clear_recently_used() {
+                                Ok(()) => {}
+                                Err(err) => {
+                                    log::warn!("failed to clear recents history: {}", err);
+                                }
+                            }
+                        }
                         tab::Command::EmptyTrash => {
                             return self.push_dialog(
                                 DialogPage::EmptyTrash,

--- a/src/tab.rs
+++ b/src/tab.rs
@@ -6228,7 +6228,7 @@ impl Tab {
                     tab_column = tab_column.push(
                         widget::layer_container(widget::row::with_children([
                             widget::space::horizontal().into(),
-                            widget::button::standard(fl!("clear-recents"))
+                            widget::button::standard(fl!("clear-recents-history"))
                                 .on_press(Message::ClearRecents)
                                 .into(),
                         ]))

--- a/src/tab.rs
+++ b/src/tab.rs
@@ -1683,6 +1683,7 @@ pub enum Command {
     ContextMenu(Option<Point>, Option<window::Id>),
     Delete(Vec<PathBuf>),
     DropFiles(PathBuf, ClipboardPaste),
+    ClearRecents,
     EmptyTrash,
     #[cfg(feature = "desktop")]
     ExecEntryAction(cosmic::desktop::DesktopEntryData, usize),
@@ -1722,6 +1723,7 @@ pub enum Message {
     EditLocationSubmit,
     EditLocationTab,
     OpenInNewTab(PathBuf),
+    ClearRecents,
     EmptyTrash,
     #[cfg(feature = "desktop")]
     ExecEntryAction(Option<PathBuf>, usize),
@@ -3696,6 +3698,9 @@ impl Tab {
             }
             Message::OpenInNewTab(path) => {
                 commands.push(Command::OpenInNewTab(path));
+            }
+            Message::ClearRecents => {
+                commands.push(Command::ClearRecents);
             }
             Message::EmptyTrash => {
                 commands.push(Command::EmptyTrash);
@@ -6207,6 +6212,24 @@ impl Tab {
                             widget::space::horizontal().into(),
                             widget::button::standard(fl!("empty-trash"))
                                 .on_press(Message::EmptyTrash)
+                                .into(),
+                        ]))
+                        .padding([space_xxs, space_xs])
+                        .layer(cosmic_theme::Layer::Primary)
+                        .apply(widget::container)
+                        .padding([0, 0, 7, 0]),
+                    );
+                }
+            }
+            Location::Recents | Location::Search(SearchLocation::Recents, ..) => {
+                if let Some(items) = self.items_opt()
+                    && !items.is_empty()
+                {
+                    tab_column = tab_column.push(
+                        widget::layer_container(widget::row::with_children([
+                            widget::space::horizontal().into(),
+                            widget::button::standard(fl!("clear-recents"))
+                                .on_press(Message::ClearRecents)
                                 .into(),
                         ]))
                         .padding([space_xxs, space_xs])


### PR DESCRIPTION
Add a "Clear Recents history" button in the Recents view if any files can be cleared.

Functionality is identical to the existing context menu option of the same name.

Button placement and style is basically copied from "Empty Trash".

Tests:
- Button does not appear if no recents exist
- Button works with one recent item
- Button works with multiple recent items
- Button works when using search button within Recents location

Fixes #1727 

- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

