### PR TITLE
Add "create new folder" button in open folder dialog (Issue #1666)

### DIFF
--- a/src/dialog.rs
+++ b/src/dialog.rs
@@ -1257,7 +1257,7 @@ impl Application for App {
             );
         }
 
-        if self.flags.kind.save() {
+        if self.flags.kind.save() || self.flags.kind.is_dir() {
             elements.push(
                 widget::button::icon(widget::icon::from_name("folder-new-symbolic"))
                     .on_press(Message::NewFolder)


### PR DESCRIPTION
This PR adds the "Create New Folder" button when in open folder dialog (in save all attachment dialog window)

This PR Closes : #1666

---

- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

