### PR TITLE
 fix: Deleted Files Arent Visible In Trash

### DIFF
--- a/src/trash.rs
+++ b/src/trash.rs
@@ -3,8 +3,24 @@ use regex::Regex;
 use std::collections::HashSet;
 use std::path::PathBuf;
 
+#[cfg(all(
+    unix,
+    not(target_os = "macos"),
+    not(target_os = "ios"),
+    not(target_os = "android")
+))]
+use std::path::Path;
+
 use crate::config::IconSizes;
 use crate::tab::{Item, SearchItem};
+
+#[cfg(all(
+    unix,
+    not(target_os = "macos"),
+    not(target_os = "ios"),
+    not(target_os = "android")
+))]
+const MISSING_TRASH_FILE: &str = "trash item referenced by .trashinfo is missing from trash/files";
 
 pub trait TrashExt {
     fn is_empty() -> bool {
@@ -51,6 +67,89 @@ pub trait TrashExt {
 
 pub struct Trash;
 
+#[cfg(target_os = "windows")]
+fn metadata(item: &trash::TrashItem) -> Result<trash::TrashItemMetadata, trash::Error> {
+    trash::os_limited::metadata(item)
+}
+
+#[cfg(all(
+    unix,
+    not(target_os = "macos"),
+    not(target_os = "ios"),
+    not(target_os = "android")
+))]
+fn metadata(item: &trash::TrashItem) -> Result<trash::TrashItemMetadata, trash::Error> {
+    let file = restorable_file_in_trash_from_info_file(&item.id)?;
+    ensure_virtually_exists(&file)?;
+
+    let metadata = std::fs::symlink_metadata(&file).map_err(|e| fs_error(&file, e))?;
+    let size = if metadata.is_dir() {
+        trash::TrashItemSize::Entries(
+            std::fs::read_dir(&file)
+                .map_err(|e| fs_error(&file, e))?
+                .count(),
+        )
+    } else {
+        trash::TrashItemSize::Bytes(metadata.len())
+    };
+
+    Ok(trash::TrashItemMetadata { size })
+}
+
+#[cfg(all(
+    unix,
+    not(target_os = "macos"),
+    not(target_os = "ios"),
+    not(target_os = "android")
+))]
+fn restorable_file_in_trash_from_info_file(
+    info_file: impl AsRef<std::ffi::OsStr>,
+) -> Result<PathBuf, trash::Error> {
+    let info_path = Path::new(info_file.as_ref());
+    let trash_folder =
+        info_path
+            .parent()
+            .and_then(Path::parent)
+            .ok_or_else(|| trash::Error::Unknown {
+                description: format!("invalid trash info path: {info_path:?}"),
+            })?;
+    let name_in_trash = info_path.file_stem().ok_or_else(|| trash::Error::Unknown {
+        description: format!("invalid trash info path: {info_path:?}"),
+    })?;
+
+    Ok(trash_folder.join("files").join(name_in_trash))
+}
+
+#[cfg(all(
+    unix,
+    not(target_os = "macos"),
+    not(target_os = "ios"),
+    not(target_os = "android")
+))]
+fn ensure_virtually_exists(path: &Path) -> Result<(), trash::Error> {
+    if path.try_exists().map_err(|e| fs_error(path, e))? || path.is_symlink() {
+        Ok(())
+    } else {
+        Err(fs_error(
+            path,
+            std::io::Error::new(std::io::ErrorKind::NotFound, MISSING_TRASH_FILE),
+        ))
+    }
+}
+
+#[cfg(all(
+    unix,
+    not(target_os = "macos"),
+    not(target_os = "ios"),
+    not(target_os = "android")
+))]
+fn fs_error(path: impl Into<PathBuf>, source: std::io::Error) -> trash::Error {
+    trash::Error::FileSystem {
+        path: path.into(),
+        source,
+    }
+}
+
 // This config statement is from trash::os_limited
 #[cfg(any(
     target_os = "windows",
@@ -94,7 +193,7 @@ impl TrashExt for Trash {
         let mut items: Vec<_> = entries
             .into_iter()
             .filter_map(|entry| {
-                let metadata = trash::os_limited::metadata(&entry)
+                let metadata = metadata(&entry)
                     .inspect_err(|err| {
                         log::warn!("failed to get metadata for trash item {entry:?}: {err}")
                     })
@@ -120,7 +219,7 @@ impl TrashExt for Trash {
         };
 
         for entry in entries {
-            if let Ok(metadata) = trash::os_limited::metadata(&entry).inspect_err(|err| {
+            if let Ok(metadata) = metadata(&entry).inspect_err(|err| {
                 log::warn!("failed to get metadata for trash item {entry:?}: {err}")
             }) {
                 let name = entry.name.to_string_lossy();
@@ -143,3 +242,77 @@ impl TrashExt for Trash {
     )
 )))]
 impl TrashExt for Trash {}
+
+#[cfg(test)]
+#[cfg(all(
+    unix,
+    not(target_os = "macos"),
+    not(target_os = "ios"),
+    not(target_os = "android")
+))]
+mod tests {
+    use std::ffi::OsString;
+    use std::path::{Path, PathBuf};
+    use std::{fs, io};
+
+    use tempfile::tempdir;
+
+    use super::metadata;
+
+    fn trash_item(info_file: &Path, original_parent: &Path, name: &str) -> trash::TrashItem {
+        trash::TrashItem {
+            id: info_file.as_os_str().to_os_string(),
+            name: OsString::from(name),
+            original_parent: original_parent.to_path_buf(),
+            time_deleted: 0,
+        }
+    }
+
+    fn assert_missing_trash_file(err: trash::Error, expected_path: PathBuf) {
+        match err {
+            trash::Error::FileSystem { path, source } => {
+                assert_eq!(expected_path, path);
+                assert_eq!(io::ErrorKind::NotFound, source.kind());
+            }
+            other => panic!("expected missing trash file error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn metadata_returns_error_when_trash_file_is_missing() -> io::Result<()> {
+        let temp = tempdir()?;
+        let trash = temp.path().join("Trash");
+        let info_dir = trash.join("info");
+        fs::create_dir_all(&info_dir)?;
+
+        let info_file = info_dir.join("missing.trashinfo");
+        fs::write(&info_file, "")?;
+
+        let item = trash_item(&info_file, temp.path(), "missing");
+        let err = metadata(&item).expect_err("missing trash file should be an error");
+
+        assert_missing_trash_file(err, trash.join("files").join("missing"));
+        Ok(())
+    }
+
+    #[test]
+    fn metadata_reads_existing_trash_file_size() -> io::Result<()> {
+        let temp = tempdir()?;
+        let trash = temp.path().join("Trash");
+        let info_dir = trash.join("info");
+        let files_dir = trash.join("files");
+        fs::create_dir_all(&info_dir)?;
+        fs::create_dir_all(&files_dir)?;
+
+        let info_file = info_dir.join("example.trashinfo");
+        let trashed_file = files_dir.join("example");
+        fs::write(&info_file, "")?;
+        fs::write(&trashed_file, b"data")?;
+
+        let item = trash_item(&info_file, temp.path(), "example");
+        let metadata = metadata(&item).expect("existing trash file should have metadata");
+
+        assert_eq!(trash::TrashItemSize::Bytes(4), metadata.size);
+        Ok(())
+    }
+}


### PR DESCRIPTION
If a .trashinfo file exists without a matching item in trash/files, trash-rs panics while reading metadata during Trash scans.

Check the referenced trash/files path first and return a filesystem error so Cosmic Files skips only the stale entry and still shows valid trash contents.

Fixes: https://github.com/pop-os/cosmic-files/issues/1374

- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

