### PR TITLE
Add rust-toolchain to enforce 1.93 MSRV

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "1.93.0"
+components = ["clippy", "rustfmt"]

--- a/src/app.rs
+++ b/src/app.rs
@@ -442,7 +442,7 @@ pub enum Message {
     TabRescan(
         Entity,
         Location,
-        Option<tab::Item>,
+        Option<Box<tab::Item>>,
         Vec<tab::Item>,
         Option<Vec<PathBuf>>,
     ),

--- a/src/app.rs
+++ b/src/app.rs
@@ -287,7 +287,7 @@ impl MenuAction for Action {
 }
 
 #[derive(Clone, Debug)]
-pub struct PreviewItem(pub tab::Item);
+pub struct PreviewItem(pub Box<tab::Item>);
 
 impl PartialEq for PreviewItem {
     fn eq(&self, other: &Self) -> bool {
@@ -573,8 +573,8 @@ pub enum DialogPage {
         dir: bool,
     },
     Replace {
-        from: tab::Item,
-        to: tab::Item,
+        from: Box<tab::Item>,
+        to: Box<tab::Item>,
         multiple: bool,
         apply_to_all: bool,
         conflict_count: usize,
@@ -5205,7 +5205,7 @@ impl Application for App {
                             Ok(item) => {
                                 self.context_page = ContextPage::Preview(
                                     None,
-                                    PreviewKind::Custom(PreviewItem(item)),
+                                    PreviewKind::Custom(PreviewItem(Box::new(item))),
                                 );
                                 self.set_show_context(true);
                             }

--- a/src/dialog.rs
+++ b/src/dialog.rs
@@ -475,7 +475,7 @@ enum Message {
     TabMessage(tab::Message),
     TabRescan(
         Location,
-        Option<tab::Item>,
+        Option<Box<tab::Item>>,
         Vec<tab::Item>,
         Option<Vec<PathBuf>>,
     ),

--- a/src/mime_app.rs
+++ b/src/mime_app.rs
@@ -60,21 +60,24 @@ pub fn exec_to_command(
                         }
 
                         // %f and %u behave the same in a file manager.
-                        Some('f' | 'u')
+                        Some('f' | 'u') => {
                             if let Some(path) = path
-                                && !field_code_used =>
-                        {
-                            // TODO: files on remote file systems should be copied to a temporary local file.
-                            batch_process = true;
-                            field_code_used = true;
-                            new_argument.push_str(path.as_bytes());
+                                && !field_code_used
+                            {
+                                // TODO: files on remote file systems should be copied to a temporary local file.
+                                batch_process = true;
+                                field_code_used = true;
+                                new_argument.push_str(path.as_bytes());
+                            }
                         }
 
                         // %F and %U behave the same in a file manager.
-                        Some('F') | Some('U') if !field_code_used && new_argument.is_empty() => {
-                            field_code_used = true;
-                            for path in path_opt.iter().map(AsRef::as_ref) {
-                                args.push(BString::new(path.as_bytes().to_owned()));
+                        Some('F') | Some('U') => {
+                            if !field_code_used && new_argument.is_empty() {
+                                field_code_used = true;
+                                for path in path_opt.iter().map(AsRef::as_ref) {
+                                    args.push(BString::new(path.as_bytes().to_owned()));
+                                }
                             }
                         }
 

--- a/src/operation/mod.rs
+++ b/src/operation/mod.rs
@@ -34,7 +34,7 @@ async fn handle_replace(
     conflict_count: usize,
 ) -> ReplaceResult {
     let item_from = match tab::item_from_path(file_from, IconSizes::default()) {
-        Ok(ok) => ok,
+        Ok(ok) => Box::new(ok),
         Err(err) => {
             log::warn!("{err}");
             return ReplaceResult::Cancel;
@@ -42,7 +42,7 @@ async fn handle_replace(
     };
 
     let item_to = match tab::item_from_path(file_to, IconSizes::default()) {
-        Ok(ok) => ok,
+        Ok(ok) => Box::new(ok),
         Err(err) => {
             log::warn!("{err}");
             return ReplaceResult::Cancel;

--- a/src/tab.rs
+++ b/src/tab.rs
@@ -3587,7 +3587,7 @@ impl Tab {
                             match item_from_path(&path, IconSizes::default()) {
                                 Ok(item) => {
                                     commands.push(Command::Preview(PreviewKind::Custom(
-                                        PreviewItem(item),
+                                        PreviewItem(Box::new(item)),
                                     )));
                                 }
                                 Err(err) => {

--- a/src/tab.rs
+++ b/src/tab.rs
@@ -1538,7 +1538,7 @@ impl Location {
         }
     }
 
-    pub fn scan(&self, sizes: IconSizes) -> (Option<Item>, Vec<Item>) {
+    pub fn scan(&self, sizes: IconSizes) -> (Option<Box<Item>>, Vec<Item>) {
         let items = match self {
             Self::Desktop(path, display, desktop_config) => {
                 scan_desktop(path, display, *desktop_config, sizes)
@@ -1554,7 +1554,7 @@ impl Location {
         };
         let parent_item_opt = match self.path_opt() {
             Some(path) => match item_from_path(path, sizes) {
-                Ok(item) => Some(item),
+                Ok(item) => Some(Box::new(item)),
                 Err(err) => {
                     log::warn!("failed to get item for {}: {}", path.display(), err);
                     None
@@ -2637,7 +2637,7 @@ pub struct Tab {
     pub sort_name: HeadingOptions,
     pub sort_direction: bool,
     pub gallery: bool,
-    pub(crate) parent_item_opt: Option<Item>,
+    pub(crate) parent_item_opt: Option<Box<Item>>,
     pub(crate) items_opt: Option<Vec<Item>>,
     pub dnd_hovered: Option<(Location, Instant)>,
     pub(crate) scrollable_id: widget::Id,


### PR DESCRIPTION
Lowers required Rust version to 1.93 and adds rust-toolchain to enforce it. Clippy also pointed out that `tab::Item` should be boxed to lower the `Message` enum size by 800 bytes and the `DialogPage` enum by 1000 bytes.

- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

