### PR TITLE
fix: don't overwrite military time in Message::Config()

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -2949,10 +2949,12 @@ impl Application for App {
             Message::Config(config) => {
                 if config != self.config {
                     log::info!("update config");
-                    // Show details is preserved for existing instances
+                    // Show details and military time are preserved for existing instances
                     let show_details = self.config.show_details;
+                    let military_time = self.config.tab.military_time;
                     self.config = config;
                     self.config.show_details = show_details;
+                    self.config.tab.military_time = military_time;
                     return self.update_config();
                 }
             }


### PR DESCRIPTION
- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x ] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

Closes #1798

