### PR TITLE
Fix 24h time format in file dialog

### DIFF
--- a/src/dialog.rs
+++ b/src/dialog.rs
@@ -1393,7 +1393,10 @@ impl Application for App {
             Message::Config(config) => {
                 if config != self.flags.config {
                     log::info!("update config");
+                    // Don't overwrite military time
+                    let military_time = self.flags.config.tab.military_time;
                     self.flags.config = config;
+                    self.flags.config.tab.military_time = military_time;
                     return self.update_config();
                 }
             }

--- a/src/dialog.rs
+++ b/src/dialog.rs
@@ -825,9 +825,9 @@ impl App {
 
     fn update_config(&mut self) -> Task<Message> {
         self.core.window.show_context = self.flags.config.dialog.show_details;
-        self.tab.config = self.flags.config.dialog_tab();
+        let config = self.flags.config.dialog_tab();
         self.update_nav_model();
-        self.update(Message::TabMessage(tab::Message::Config(self.tab.config)))
+        self.update(Message::TabMessage(tab::Message::Config(config)))
     }
 
     fn with_dialog_config<F: Fn(&mut DialogConfig)>(&mut self, f: F) -> Task<Message> {

--- a/src/dialog.rs
+++ b/src/dialog.rs
@@ -826,6 +826,7 @@ impl App {
     fn update_config(&mut self) -> Task<Message> {
         self.core.window.show_context = self.flags.config.dialog.show_details;
         let config = self.flags.config.dialog_tab();
+        self.tab.config.view = config.view;
         self.update_nav_model();
         self.update(Message::TabMessage(tab::Message::Config(config)))
     }


### PR DESCRIPTION
- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

Closes #1504
Tested with xdg-desktop-portal-cosmic