### PR TITLE
Add context menu to text fields and Selectable Text widget

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1338,10 +1338,23 @@ dependencies = [
 [[package]]
 name = "cosmic-client-toolkit"
 version = "0.2.0"
+source = "git+https://github.com/pop-os/cosmic-protocols?rev=32283d7#32283d76a8d0342da74c4cc022a533c52dcf378f"
+dependencies = [
+ "bitflags 2.13.0",
+ "cosmic-protocols 0.2.0 (git+https://github.com/pop-os/cosmic-protocols?rev=32283d7)",
+ "libc",
+ "smithay-client-toolkit",
+ "wayland-client",
+ "wayland-protocols",
+]
+
+[[package]]
+name = "cosmic-client-toolkit"
+version = "0.2.0"
 source = "git+https://github.com/pop-os/cosmic-protocols?rev=c253ec1#c253ec1d6804afbcdf250f5cc37ae1194bba7bd2"
 dependencies = [
  "bitflags 2.13.0",
- "cosmic-protocols",
+ "cosmic-protocols 0.2.0 (git+https://github.com/pop-os/cosmic-protocols?rev=c253ec1)",
  "libc",
  "smithay-client-toolkit",
  "wayland-client",
@@ -1351,7 +1364,7 @@ dependencies = [
 [[package]]
 name = "cosmic-config"
 version = "1.0.0"
-source = "git+https://github.com/pop-os/libcosmic.git#e7f278d17f0cf8275173ab127a9b47fdd7440d9a"
+source = "git+https://github.com/hojjatabdollahi/libcosmic.git?branch=hojjat%2Fselect-popup#468f15e551a86cec3a0b9cbd5f06552588064d8c"
 dependencies = [
  "atomicwrites",
  "cosmic-config-derive",
@@ -1372,7 +1385,7 @@ dependencies = [
 [[package]]
 name = "cosmic-config-derive"
 version = "1.0.0"
-source = "git+https://github.com/pop-os/libcosmic.git#e7f278d17f0cf8275173ab127a9b47fdd7440d9a"
+source = "git+https://github.com/hojjatabdollahi/libcosmic.git?branch=hojjat%2Fselect-popup#468f15e551a86cec3a0b9cbd5f06552588064d8c"
 dependencies = [
  "quote",
  "syn",
@@ -1387,7 +1400,7 @@ dependencies = [
  "bstr",
  "bzip2",
  "compio",
- "cosmic-client-toolkit",
+ "cosmic-client-toolkit 0.2.0 (git+https://github.com/pop-os/cosmic-protocols?rev=c253ec1)",
  "cosmic-mime-apps",
  "dirs 6.0.0",
  "fastrand",
@@ -1484,6 +1497,20 @@ dependencies = [
 [[package]]
 name = "cosmic-protocols"
 version = "0.2.0"
+source = "git+https://github.com/pop-os/cosmic-protocols?rev=32283d7#32283d76a8d0342da74c4cc022a533c52dcf378f"
+dependencies = [
+ "bitflags 2.13.0",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "wayland-protocols-wlr",
+ "wayland-scanner",
+ "wayland-server",
+]
+
+[[package]]
+name = "cosmic-protocols"
+version = "0.2.0"
 source = "git+https://github.com/pop-os/cosmic-protocols?rev=c253ec1#c253ec1d6804afbcdf250f5cc37ae1194bba7bd2"
 dependencies = [
  "bitflags 2.13.0",
@@ -1498,7 +1525,7 @@ dependencies = [
 [[package]]
 name = "cosmic-settings-config"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/cosmic-settings-daemon#75c0480f1315ec96ec3eb216fc939f93f57d7612"
+source = "git+https://github.com/pop-os/cosmic-settings-daemon#276fef9834b05c57b67e8ba36b74bea1ba690cee"
 dependencies = [
  "cosmic-config",
  "ron 0.11.0",
@@ -1543,13 +1570,14 @@ dependencies = [
 [[package]]
 name = "cosmic-theme"
 version = "1.0.0"
-source = "git+https://github.com/pop-os/libcosmic.git#e7f278d17f0cf8275173ab127a9b47fdd7440d9a"
+source = "git+https://github.com/hojjatabdollahi/libcosmic.git?branch=hojjat%2Fselect-popup#468f15e551a86cec3a0b9cbd5f06552588064d8c"
 dependencies = [
  "almost",
  "configparser",
  "cosmic-config",
  "csscolorparser",
  "dirs 6.0.0",
+ "hex_color",
  "palette",
  "ron 0.12.2",
  "serde",
@@ -2973,6 +3001,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "hex_color"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d37f101bf4c633f7ca2e4b5e136050314503dd198e78e325ea602c327c484ef0"
+dependencies = [
+ "arrayvec",
+ "rand 0.8.6",
+ "serde",
+]
+
+[[package]]
 name = "hexf-parse"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3090,7 +3129,7 @@ dependencies = [
 [[package]]
 name = "iced"
 version = "0.14.0"
-source = "git+https://github.com/pop-os/libcosmic.git#e7f278d17f0cf8275173ab127a9b47fdd7440d9a"
+source = "git+https://github.com/hojjatabdollahi/libcosmic.git?branch=hojjat%2Fselect-popup#468f15e551a86cec3a0b9cbd5f06552588064d8c"
 dependencies = [
  "dnd",
  "iced_accessibility",
@@ -3111,7 +3150,7 @@ dependencies = [
 [[package]]
 name = "iced_accessibility"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/libcosmic.git#e7f278d17f0cf8275173ab127a9b47fdd7440d9a"
+source = "git+https://github.com/hojjatabdollahi/libcosmic.git?branch=hojjat%2Fselect-popup#468f15e551a86cec3a0b9cbd5f06552588064d8c"
 dependencies = [
  "accesskit",
  "accesskit_winit",
@@ -3120,11 +3159,11 @@ dependencies = [
 [[package]]
 name = "iced_core"
 version = "0.14.0"
-source = "git+https://github.com/pop-os/libcosmic.git#e7f278d17f0cf8275173ab127a9b47fdd7440d9a"
+source = "git+https://github.com/hojjatabdollahi/libcosmic.git?branch=hojjat%2Fselect-popup#468f15e551a86cec3a0b9cbd5f06552588064d8c"
 dependencies = [
  "bitflags 2.13.0",
  "bytes",
- "cosmic-client-toolkit",
+ "cosmic-client-toolkit 0.2.0 (git+https://github.com/pop-os/cosmic-protocols?rev=32283d7)",
  "dnd",
  "glam",
  "lilt",
@@ -3145,7 +3184,7 @@ dependencies = [
 [[package]]
 name = "iced_debug"
 version = "0.14.0"
-source = "git+https://github.com/pop-os/libcosmic.git#e7f278d17f0cf8275173ab127a9b47fdd7440d9a"
+source = "git+https://github.com/hojjatabdollahi/libcosmic.git?branch=hojjat%2Fselect-popup#468f15e551a86cec3a0b9cbd5f06552588064d8c"
 dependencies = [
  "iced_core",
  "iced_futures",
@@ -3155,7 +3194,7 @@ dependencies = [
 [[package]]
 name = "iced_futures"
 version = "0.14.0"
-source = "git+https://github.com/pop-os/libcosmic.git#e7f278d17f0cf8275173ab127a9b47fdd7440d9a"
+source = "git+https://github.com/hojjatabdollahi/libcosmic.git?branch=hojjat%2Fselect-popup#468f15e551a86cec3a0b9cbd5f06552588064d8c"
 dependencies = [
  "futures",
  "iced_core",
@@ -3169,7 +3208,7 @@ dependencies = [
 [[package]]
 name = "iced_graphics"
 version = "0.14.0"
-source = "git+https://github.com/pop-os/libcosmic.git#e7f278d17f0cf8275173ab127a9b47fdd7440d9a"
+source = "git+https://github.com/hojjatabdollahi/libcosmic.git?branch=hojjat%2Fselect-popup#468f15e551a86cec3a0b9cbd5f06552588064d8c"
 dependencies = [
  "bitflags 2.13.0",
  "bytemuck",
@@ -3190,7 +3229,7 @@ dependencies = [
 [[package]]
 name = "iced_program"
 version = "0.14.0"
-source = "git+https://github.com/pop-os/libcosmic.git#e7f278d17f0cf8275173ab127a9b47fdd7440d9a"
+source = "git+https://github.com/hojjatabdollahi/libcosmic.git?branch=hojjat%2Fselect-popup#468f15e551a86cec3a0b9cbd5f06552588064d8c"
 dependencies = [
  "iced_graphics",
  "iced_runtime",
@@ -3199,7 +3238,7 @@ dependencies = [
 [[package]]
 name = "iced_renderer"
 version = "0.14.0"
-source = "git+https://github.com/pop-os/libcosmic.git#e7f278d17f0cf8275173ab127a9b47fdd7440d9a"
+source = "git+https://github.com/hojjatabdollahi/libcosmic.git?branch=hojjat%2Fselect-popup#468f15e551a86cec3a0b9cbd5f06552588064d8c"
 dependencies = [
  "iced_graphics",
  "iced_tiny_skia",
@@ -3211,10 +3250,10 @@ dependencies = [
 [[package]]
 name = "iced_runtime"
 version = "0.14.0"
-source = "git+https://github.com/pop-os/libcosmic.git#e7f278d17f0cf8275173ab127a9b47fdd7440d9a"
+source = "git+https://github.com/hojjatabdollahi/libcosmic.git?branch=hojjat%2Fselect-popup#468f15e551a86cec3a0b9cbd5f06552588064d8c"
 dependencies = [
  "bytes",
- "cosmic-client-toolkit",
+ "cosmic-client-toolkit 0.2.0 (git+https://github.com/pop-os/cosmic-protocols?rev=32283d7)",
  "dnd",
  "iced_core",
  "iced_futures",
@@ -3226,7 +3265,7 @@ dependencies = [
 [[package]]
 name = "iced_tiny_skia"
 version = "0.14.0"
-source = "git+https://github.com/pop-os/libcosmic.git#e7f278d17f0cf8275173ab127a9b47fdd7440d9a"
+source = "git+https://github.com/hojjatabdollahi/libcosmic.git?branch=hojjat%2Fselect-popup#468f15e551a86cec3a0b9cbd5f06552588064d8c"
 dependencies = [
  "bytemuck",
  "cosmic-text",
@@ -3243,12 +3282,12 @@ dependencies = [
 [[package]]
 name = "iced_wgpu"
 version = "0.14.0"
-source = "git+https://github.com/pop-os/libcosmic.git#e7f278d17f0cf8275173ab127a9b47fdd7440d9a"
+source = "git+https://github.com/hojjatabdollahi/libcosmic.git?branch=hojjat%2Fselect-popup#468f15e551a86cec3a0b9cbd5f06552588064d8c"
 dependencies = [
  "as-raw-xcb-connection",
  "bitflags 2.13.0",
  "bytemuck",
- "cosmic-client-toolkit",
+ "cosmic-client-toolkit 0.2.0 (git+https://github.com/pop-os/cosmic-protocols?rev=32283d7)",
  "cryoglyph",
  "futures",
  "glam",
@@ -3274,9 +3313,9 @@ dependencies = [
 [[package]]
 name = "iced_widget"
 version = "0.14.2"
-source = "git+https://github.com/pop-os/libcosmic.git#e7f278d17f0cf8275173ab127a9b47fdd7440d9a"
+source = "git+https://github.com/hojjatabdollahi/libcosmic.git?branch=hojjat%2Fselect-popup#468f15e551a86cec3a0b9cbd5f06552588064d8c"
 dependencies = [
- "cosmic-client-toolkit",
+ "cosmic-client-toolkit 0.2.0 (git+https://github.com/pop-os/cosmic-protocols?rev=32283d7)",
  "dnd",
  "iced_renderer",
  "iced_runtime",
@@ -3292,9 +3331,9 @@ dependencies = [
 [[package]]
 name = "iced_winit"
 version = "0.14.0"
-source = "git+https://github.com/pop-os/libcosmic.git#e7f278d17f0cf8275173ab127a9b47fdd7440d9a"
+source = "git+https://github.com/hojjatabdollahi/libcosmic.git?branch=hojjat%2Fselect-popup#468f15e551a86cec3a0b9cbd5f06552588064d8c"
 dependencies = [
- "cosmic-client-toolkit",
+ "cosmic-client-toolkit 0.2.0 (git+https://github.com/pop-os/cosmic-protocols?rev=32283d7)",
  "cursor-icon",
  "dnd",
  "iced_debug",
@@ -4402,12 +4441,12 @@ checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 [[package]]
 name = "libcosmic"
 version = "1.0.0"
-source = "git+https://github.com/pop-os/libcosmic.git#e7f278d17f0cf8275173ab127a9b47fdd7440d9a"
+source = "git+https://github.com/hojjatabdollahi/libcosmic.git?branch=hojjat%2Fselect-popup#468f15e551a86cec3a0b9cbd5f06552588064d8c"
 dependencies = [
  "apply",
  "ashpd 0.12.3",
  "auto_enums",
- "cosmic-client-toolkit",
+ "cosmic-client-toolkit 0.2.0 (git+https://github.com/pop-os/cosmic-protocols?rev=32283d7)",
  "cosmic-config",
  "cosmic-freedesktop-icons",
  "cosmic-settings-config",
@@ -4415,6 +4454,7 @@ dependencies = [
  "cosmic-theme",
  "css-color",
  "derive_setters",
+ "enumflags2",
  "float-cmp 0.10.0",
  "freedesktop-desktop-entry",
  "futures",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -826,7 +826,7 @@ dependencies = [
 [[package]]
 name = "build_helpers"
 version = "0.14.0"
-source = "git+https://github.com/pop-os/libcosmic.git#0ca1b784c931c946517379795ce87328c6a902b8"
+source = "git+https://github.com/pop-os/libcosmic.git#1f8d8786940cc6db59d412153c5a03f69a20375c"
 dependencies = [
  "cfg_aliases",
 ]
@@ -1359,7 +1359,7 @@ dependencies = [
 [[package]]
 name = "cosmic-config"
 version = "1.0.0"
-source = "git+https://github.com/pop-os/libcosmic.git#0ca1b784c931c946517379795ce87328c6a902b8"
+source = "git+https://github.com/pop-os/libcosmic.git#1f8d8786940cc6db59d412153c5a03f69a20375c"
 dependencies = [
  "atomicwrites",
  "cosmic-config-derive",
@@ -1380,7 +1380,7 @@ dependencies = [
 [[package]]
 name = "cosmic-config-derive"
 version = "1.0.0"
-source = "git+https://github.com/pop-os/libcosmic.git#0ca1b784c931c946517379795ce87328c6a902b8"
+source = "git+https://github.com/pop-os/libcosmic.git#1f8d8786940cc6db59d412153c5a03f69a20375c"
 dependencies = [
  "quote",
  "syn 2.0.119",
@@ -1551,7 +1551,7 @@ dependencies = [
 [[package]]
 name = "cosmic-theme"
 version = "1.0.0"
-source = "git+https://github.com/pop-os/libcosmic.git#0ca1b784c931c946517379795ce87328c6a902b8"
+source = "git+https://github.com/pop-os/libcosmic.git#1f8d8786940cc6db59d412153c5a03f69a20375c"
 dependencies = [
  "almost",
  "configparser",
@@ -2871,7 +2871,7 @@ dependencies = [
  "log",
  "presser",
  "thiserror 2.0.19",
- "windows 0.62.2",
+ "windows 0.56.0",
 ]
 
 [[package]]
@@ -3105,7 +3105,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core 0.56.0",
 ]
 
 [[package]]
@@ -3120,7 +3120,7 @@ dependencies = [
 [[package]]
 name = "iced"
 version = "0.14.0"
-source = "git+https://github.com/pop-os/libcosmic.git#0ca1b784c931c946517379795ce87328c6a902b8"
+source = "git+https://github.com/pop-os/libcosmic.git#1f8d8786940cc6db59d412153c5a03f69a20375c"
 dependencies = [
  "build_helpers",
  "dnd",
@@ -3142,7 +3142,7 @@ dependencies = [
 [[package]]
 name = "iced_accessibility"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/libcosmic.git#0ca1b784c931c946517379795ce87328c6a902b8"
+source = "git+https://github.com/pop-os/libcosmic.git#1f8d8786940cc6db59d412153c5a03f69a20375c"
 dependencies = [
  "accesskit",
  "accesskit_winit",
@@ -3151,7 +3151,7 @@ dependencies = [
 [[package]]
 name = "iced_core"
 version = "0.14.0"
-source = "git+https://github.com/pop-os/libcosmic.git#0ca1b784c931c946517379795ce87328c6a902b8"
+source = "git+https://github.com/pop-os/libcosmic.git#1f8d8786940cc6db59d412153c5a03f69a20375c"
 dependencies = [
  "bitflags 2.13.1",
  "build_helpers",
@@ -3177,7 +3177,7 @@ dependencies = [
 [[package]]
 name = "iced_debug"
 version = "0.14.0"
-source = "git+https://github.com/pop-os/libcosmic.git#0ca1b784c931c946517379795ce87328c6a902b8"
+source = "git+https://github.com/pop-os/libcosmic.git#1f8d8786940cc6db59d412153c5a03f69a20375c"
 dependencies = [
  "iced_core",
  "iced_futures",
@@ -3187,7 +3187,7 @@ dependencies = [
 [[package]]
 name = "iced_futures"
 version = "0.14.0"
-source = "git+https://github.com/pop-os/libcosmic.git#0ca1b784c931c946517379795ce87328c6a902b8"
+source = "git+https://github.com/pop-os/libcosmic.git#1f8d8786940cc6db59d412153c5a03f69a20375c"
 dependencies = [
  "futures",
  "iced_core",
@@ -3201,7 +3201,7 @@ dependencies = [
 [[package]]
 name = "iced_graphics"
 version = "0.14.0"
-source = "git+https://github.com/pop-os/libcosmic.git#0ca1b784c931c946517379795ce87328c6a902b8"
+source = "git+https://github.com/pop-os/libcosmic.git#1f8d8786940cc6db59d412153c5a03f69a20375c"
 dependencies = [
  "bitflags 2.13.1",
  "bytemuck",
@@ -3222,7 +3222,7 @@ dependencies = [
 [[package]]
 name = "iced_program"
 version = "0.14.0"
-source = "git+https://github.com/pop-os/libcosmic.git#0ca1b784c931c946517379795ce87328c6a902b8"
+source = "git+https://github.com/pop-os/libcosmic.git#1f8d8786940cc6db59d412153c5a03f69a20375c"
 dependencies = [
  "iced_graphics",
  "iced_runtime",
@@ -3231,7 +3231,7 @@ dependencies = [
 [[package]]
 name = "iced_renderer"
 version = "0.14.0"
-source = "git+https://github.com/pop-os/libcosmic.git#0ca1b784c931c946517379795ce87328c6a902b8"
+source = "git+https://github.com/pop-os/libcosmic.git#1f8d8786940cc6db59d412153c5a03f69a20375c"
 dependencies = [
  "iced_graphics",
  "iced_tiny_skia",
@@ -3243,7 +3243,7 @@ dependencies = [
 [[package]]
 name = "iced_runtime"
 version = "0.14.0"
-source = "git+https://github.com/pop-os/libcosmic.git#0ca1b784c931c946517379795ce87328c6a902b8"
+source = "git+https://github.com/pop-os/libcosmic.git#1f8d8786940cc6db59d412153c5a03f69a20375c"
 dependencies = [
  "build_helpers",
  "bytes",
@@ -3259,7 +3259,7 @@ dependencies = [
 [[package]]
 name = "iced_tiny_skia"
 version = "0.14.0"
-source = "git+https://github.com/pop-os/libcosmic.git#0ca1b784c931c946517379795ce87328c6a902b8"
+source = "git+https://github.com/pop-os/libcosmic.git#1f8d8786940cc6db59d412153c5a03f69a20375c"
 dependencies = [
  "bytemuck",
  "cosmic-text",
@@ -3276,7 +3276,7 @@ dependencies = [
 [[package]]
 name = "iced_wgpu"
 version = "0.14.0"
-source = "git+https://github.com/pop-os/libcosmic.git#0ca1b784c931c946517379795ce87328c6a902b8"
+source = "git+https://github.com/pop-os/libcosmic.git#1f8d8786940cc6db59d412153c5a03f69a20375c"
 dependencies = [
  "as-raw-xcb-connection",
  "bitflags 2.13.1",
@@ -3308,7 +3308,7 @@ dependencies = [
 [[package]]
 name = "iced_widget"
 version = "0.14.2"
-source = "git+https://github.com/pop-os/libcosmic.git#0ca1b784c931c946517379795ce87328c6a902b8"
+source = "git+https://github.com/pop-os/libcosmic.git#1f8d8786940cc6db59d412153c5a03f69a20375c"
 dependencies = [
  "build_helpers",
  "cosmic-client-toolkit",
@@ -3327,7 +3327,7 @@ dependencies = [
 [[package]]
 name = "iced_winit"
 version = "0.14.0"
-source = "git+https://github.com/pop-os/libcosmic.git#0ca1b784c931c946517379795ce87328c6a902b8"
+source = "git+https://github.com/pop-os/libcosmic.git#1f8d8786940cc6db59d412153c5a03f69a20375c"
 dependencies = [
  "build_helpers",
  "cosmic-client-toolkit",
@@ -4449,7 +4449,7 @@ checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 [[package]]
 name = "libcosmic"
 version = "1.0.0"
-source = "git+https://github.com/pop-os/libcosmic.git#0ca1b784c931c946517379795ce87328c6a902b8"
+source = "git+https://github.com/pop-os/libcosmic.git#1f8d8786940cc6db59d412153c5a03f69a20375c"
 dependencies = [
  "apply",
  "ashpd 0.12.3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,8 +47,8 @@ lzma-rust2 = { version = "0.16", optional = true }
 ordermap = { version = "1.2.0", features = ["serde"] }
 # Internationalization
 i18n-embed = { version = "0.16", features = [
-    "fluent-system",
-    "desktop-requester",
+  "fluent-system",
+  "desktop-requester",
 ] }
 i18n-embed-fl = "0.10"
 rust-embed = "8"
@@ -79,13 +79,13 @@ git = "https://github.com/pop-os/libcosmic.git"
 default-features = false
 #TODO: a11y feature crashes
 features = [
-    "about",
-    "advanced-shaping",
-    "autosize",
-    "multi-window",
-    "tokio",
-    "winit",
-    "surface-message",
+  "about",
+  "advanced-shaping",
+  "autosize",
+  "multi-window",
+  "tokio",
+  "winit",
+  "surface-message",
 ]
 
 [[example]]
@@ -102,15 +102,15 @@ required-features = ["gvfs"]
 
 [features]
 default = [
-    "bzip2",
-    "dbus-config",
-    "desktop",
-    "gvfs",
-    "io-uring",
-    "lzma-rust2",
-    "notify",
-    "wayland",
-    "wgpu",
+  "bzip2",
+  "dbus-config",
+  "desktop",
+  "gvfs",
+  "io-uring",
+  "lzma-rust2",
+  "notify",
+  "wayland",
+  "wgpu",
 ]
 dbus-config = ["libcosmic/dbus-config"]
 desktop = ["libcosmic/desktop", "dep:cosmic-mime-apps", "dep:xdg"]
@@ -149,15 +149,13 @@ tokio = { version = "1", features = ["rt", "macros"] }
 # [patch.'https://github.com/pop-os/cosmic-text']
 # cosmic-text = { path = "../cosmic-text" }
 
-# [patch.'https://github.com/pop-os/libcosmic']
-# libcosmic = { path = "../libcosmic" }
-# cosmic-config = { path = "../libcosmic/cosmic-config" }
-# cosmic-theme = { path = "../libcosmic/cosmic-theme" }
-# libcosmic = { git = "https://github.com/pop-os/libcosmic//", branch = "iced-rebase" }
-# cosmic-config = { git = "https://github.com/pop-os/libcosmic//", branch = "iced-rebase" }
-# cosmic-theme = { git = "https://github.com/pop-os/libcosmic//", branch = "iced-rebase" }
-
-
+[patch.'https://github.com/pop-os/libcosmic']
+# cosmic-config = { path = "../libcosmic-popup/cosmic-config" }
+# libcosmic = { path = "../libcosmic-popup" }
+# cosmic-theme = { path = "../libcosmic-popup/cosmic-theme" }
+libcosmic = { git = "https://github.com/hojjatabdollahi/libcosmic.git", branch = "hojjat/select-popup" }
+cosmic-theme = { git = "https://github.com/hojjatabdollahi/libcosmic.git", branch = "hojjat/select-popup" }
+cosmic-config = { git = "https://github.com/hojjatabdollahi/libcosmic.git", branch = "hojjat/select-popup" }
 # [patch.'https://github.com/pop-os/smithay-clipboard']
 # smithay-clipboard = { path = "../smithay-clipboard" }
 

--- a/src/tab.rs
+++ b/src/tab.rs
@@ -2367,10 +2367,8 @@ impl Item {
                 widget::image(handle.clone()).into()
             }
             ItemThumbnail::Svg(handle) => widget::svg(handle.clone()).into(),
-            ItemThumbnail::Text(content) => widget::text_editor(content)
-                .class(cosmic::theme::iced::TextEditor::Custom(Box::new(
-                    text_editor_class,
-                )))
+            ItemThumbnail::Text(content) => widget::text_editor::text_editor(content)
+                .style(text_editor_class)
                 .width(THUMBNAIL_SIZE as f32)
                 .height(Length::Fixed(THUMBNAIL_SIZE as f32))
                 .padding(spacing.space_xxs)
@@ -2421,7 +2419,7 @@ impl Item {
         );
 
         let mut details = widget::column::with_capacity(8).spacing(space_xxxs);
-        details = details.push(widget::text::heading(self.name.clone()));
+        details = details.push(widget::selectable_text::heading(self.name.clone()));
         details = details.push(widget::text::body(fl!(
             "type",
             mime = self.mime.to_string()
@@ -2478,21 +2476,21 @@ impl Item {
             let time_formatter = time_formatter(military_time);
 
             if let Ok(time) = metadata.created() {
-                details = details.push(widget::text::body(fl!(
+                details = details.push(widget::selectable_text::body(fl!(
                     "item-created",
                     created = format_time(time, &date_time_formatter, &time_formatter).to_string()
                 )));
             }
 
             if let Ok(time) = metadata.modified() {
-                details = details.push(widget::text::body(fl!(
+                details = details.push(widget::selectable_text::body(fl!(
                     "item-modified",
                     modified = format_time(time, &date_time_formatter, &time_formatter).to_string()
                 )));
             }
 
             if let Ok(time) = metadata.accessed() {
-                details = details.push(widget::text::body(fl!(
+                details = details.push(widget::selectable_text::body(fl!(
                     "item-accessed",
                     accessed = format_time(time, &date_time_formatter, &time_formatter).to_string()
                 )));
@@ -5159,9 +5157,11 @@ impl Tab {
                 }
                 ItemThumbnail::Text(text) => {
                     element_opt = Some(
-                        widget::container(widget::text_editor(text).padding(space_xxs).class(
-                            cosmic::theme::iced::TextEditor::Custom(Box::new(text_editor_class)),
-                        ))
+                        widget::container(
+                            widget::text_editor::text_editor(text)
+                                .padding(space_xxs)
+                                .style(text_editor_class),
+                        )
                         .center(Length::Fill)
                         .into(),
                     );

--- a/src/tab.rs
+++ b/src/tab.rs
@@ -2386,10 +2386,8 @@ impl Item {
                 widget::image(handle.clone()).into()
             }
             ItemThumbnail::Svg(handle) => widget::svg(handle.clone()).into(),
-            ItemThumbnail::Text(content) => widget::text_editor(content)
-                .class(cosmic::theme::iced::TextEditor::Custom(Box::new(
-                    text_editor_class,
-                )))
+            ItemThumbnail::Text(content) => widget::text_editor::text_editor(content)
+                .style(text_editor_class)
                 .width(THUMBNAIL_SIZE as f32)
                 .height(Length::Fixed(THUMBNAIL_SIZE as f32))
                 .padding(spacing.space_xxs)
@@ -2440,7 +2438,7 @@ impl Item {
         );
 
         let mut details = widget::column::with_capacity(8).spacing(space_xxxs);
-        details = details.push(widget::text::heading(self.name.clone()));
+        details = details.push(widget::selectable_text::heading(self.name.clone()));
         details = details.push(widget::text::body(fl!(
             "type",
             mime = self.mime.to_string()
@@ -2497,21 +2495,21 @@ impl Item {
             let time_formatter = time_formatter(military_time);
 
             if let Ok(time) = metadata.created() {
-                details = details.push(widget::text::body(fl!(
+                details = details.push(widget::selectable_text::body(fl!(
                     "item-created",
                     created = format_time(time, &date_time_formatter, &time_formatter).to_string()
                 )));
             }
 
             if let Ok(time) = metadata.modified() {
-                details = details.push(widget::text::body(fl!(
+                details = details.push(widget::selectable_text::body(fl!(
                     "item-modified",
                     modified = format_time(time, &date_time_formatter, &time_formatter).to_string()
                 )));
             }
 
             if let Ok(time) = metadata.accessed() {
-                details = details.push(widget::text::body(fl!(
+                details = details.push(widget::selectable_text::body(fl!(
                     "item-accessed",
                     accessed = format_time(time, &date_time_formatter, &time_formatter).to_string()
                 )));
@@ -5178,9 +5176,11 @@ impl Tab {
                 }
                 ItemThumbnail::Text(text) => {
                     element_opt = Some(
-                        widget::container(widget::text_editor(text).padding(space_xxs).class(
-                            cosmic::theme::iced::TextEditor::Custom(Box::new(text_editor_class)),
-                        ))
+                        widget::container(
+                            widget::text_editor::text_editor(text)
+                                .padding(space_xxs)
+                                .style(text_editor_class),
+                        )
                         .center(Length::Fill)
                         .into(),
                     );


### PR DESCRIPTION
- Adds context menu to text input fields
- Adds selectable text to context drawer, but only to file name, created/modified/accessed date. I'm sure more places could use the selectable text.
- Also pulls the latest changes in Iced and libcosmic that removes "redraw on any message", which means moving the cursor doesn't automatically call a redraw, widgets need to ask for it. I have found all places that previously was working normally because we were redrawing almost unconditionally. But it is possible that a custom widget somewhere still isn't asking for a redraw explicitly when its state changes. So, for QA I'd keep an eye on that.

Depends on:
- [x] https://github.com/pop-os/libcosmic/pull/1288
- [x] https://github.com/pop-os/iced/pull/378
- [x] https://github.com/pop-os/libcosmic/pull/1384
- [x] https://github.com/pop-os/libcosmic/pull/1388

https://github.com/user-attachments/assets/caf8f940-0793-4665-844a-b6153b35d7bb



___
- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

