### PR TITLE
fix: hide no-display apps in open-with select

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -2306,6 +2306,7 @@ impl App {
             self.mime_app_cache
                 .apps()
                 .iter()
+                .filter(|mime_app| !mime_app.no_display)
                 .filter(|&mime_app| dedupe.insert(&mime_app.id))
                 .map(|mime_app| (mime_app, MimeAppMatch::Other)),
         );

--- a/src/mime_app.rs
+++ b/src/mime_app.rs
@@ -2,8 +2,6 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 use bstr::{BString, ByteSlice, ByteVec};
-#[cfg(feature = "desktop")]
-use cosmic::desktop;
 use cosmic::widget;
 pub use mime_guess::Mime;
 #[cfg(feature = "desktop")]
@@ -186,6 +184,7 @@ pub struct MimeApp {
     pub exec: Option<String>,
     pub icon: widget::icon::Handle,
     is_default: Arc<AtomicBool>,
+    pub no_display: bool,
 }
 
 impl MimeApp {
@@ -208,25 +207,6 @@ impl MimeApp {
 impl AsRef<str> for MimeApp {
     fn as_ref(&self) -> &str {
         &self.name
-    }
-}
-
-#[cfg(feature = "desktop")]
-impl From<&desktop::DesktopEntryData> for MimeApp {
-    fn from(app: &desktop::DesktopEntryData) -> Self {
-        Self {
-            id: app.id.clone(),
-            path: app.path.clone(),
-            name: app.name.clone(),
-            exec: app.exec.clone(),
-            icon: match &app.icon {
-                desktop::fde::IconSource::Name(name) => {
-                    widget::icon::from_name(name.as_str()).size(32).handle()
-                }
-                desktop::fde::IconSource::Path(path) => widget::icon::from_path(path.clone()),
-            },
-            is_default: Arc::new(AtomicBool::new(false)),
-        }
     }
 }
 
@@ -271,9 +251,7 @@ impl MimeAppCache {
         list.load_from_paths(&paths);
         let locales = fde::get_languages_from_env();
 
-        let desktop_entries = fde::Iter::new(fde::default_paths())
-            .entries(Some(&locales))
-            .filter(move |de| !de.no_display());
+        let desktop_entries = fde::Iter::new(fde::default_paths()).entries(Some(&locales));
 
         for desktop_entry in desktop_entries {
             let name = desktop_entry
@@ -294,6 +272,7 @@ impl MimeAppCache {
                     }
                 },
                 is_default: Arc::new(AtomicBool::new(false)),
+                no_display: desktop_entry.no_display(),
             });
 
             tracing::info!(target: "mime-apps", id = app.id, "detected desktop entry");

--- a/src/mime_app.rs
+++ b/src/mime_app.rs
@@ -270,7 +270,12 @@ impl MimeAppCache {
         let paths = cosmic_mime_apps::list_paths();
         list.load_from_paths(&paths);
         let locales = fde::get_languages_from_env();
-        for desktop_entry in fde::Iter::new(fde::default_paths()).entries(Some(&locales)) {
+
+        let desktop_entries = fde::Iter::new(fde::default_paths())
+            .entries(Some(&locales))
+            .filter(move |de| !de.no_display());
+
+        for desktop_entry in desktop_entries {
             let name = desktop_entry
                 .name(&locales)
                 .unwrap_or_else(|| Cow::Borrowed(desktop_entry.id()));


### PR DESCRIPTION
Prevents desktop entries with `NoDisplay` set from appearing in the "Open With" section.

Closes #1833 

---
- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

