### PR TITLE
Fix: Space Key Overrides Type to Search Setting

### DIFF
--- a/src/key_bind.rs
+++ b/src/key_bind.rs
@@ -39,7 +39,7 @@ pub fn key_binds(mode: &tab::Mode) -> HashMap<KeyBind, Action> {
     bind!([Ctrl, Shift], Key::Character("n".into()), NewFolder);
     bind!([], Key::Named(Named::Enter), Open);
     bind!([Ctrl], Key::Character(" ".into()), Preview);
-    bind!([], Key::Character(" ".into()), Gallery);
+    bind!([Shift], Key::Character(" ".into()), Gallery);
 
     bind!([Ctrl], Key::Character("h".into()), ToggleShowHidden);
     bind!([Ctrl], Key::Character("a".into()), SelectAll);


### PR DESCRIPTION
Fixes: #1831

When "Type to search" is set to "Selects the first matching file or folder", it's not possible to type out the name of a file that includes a Space character within the filename, as it causes the Gallery to pop up.

Changed the shortcut for the Gallery to pop up from Space to Shift+Space.

AI Usage: Used Gemini to help me figure out how to navigate the code. No code was generated by AI for the commit.

- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

