### PR TITLE
fix: hide apps without declared mimetype support

### DIFF
--- a/src/mime_app.rs
+++ b/src/mime_app.rs
@@ -272,7 +272,9 @@ impl MimeAppCache {
                     }
                 },
                 is_default: Arc::new(AtomicBool::new(false)),
-                no_display: desktop_entry.no_display(),
+                no_display: desktop_entry
+                    .mime_type()
+                    .is_none_or(|supported| supported.is_empty()),
             });
 
             tracing::info!(target: "mime-apps", id = app.id, "detected desktop entry");


### PR DESCRIPTION
This is an alternative to using the NoDisplay property for hiding "other" apps. This will only show apps in the "other" section that declare MimeType support in their desktop entries. This should prevent Steam game launchers from being selectable.

---
- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

