### PR TITLE
improv: use sort-icons instead of unicode arrow glyphs

### DIFF
--- a/src/menu.rs
+++ b/src/menu.rs
@@ -107,18 +107,25 @@ pub fn context_menu<'a>(
 
     let (sort_name, sort_direction, _) = tab.sort_options();
     let sort_item = |label, variant| {
-        menu_item(
-            format!(
-                "{} {}",
-                label,
-                match (sort_name == variant, sort_direction) {
-                    (true, true) => "\u{2B07}",
-                    (true, false) => "\u{2B06}",
-                    _ => "",
-                }
-            ),
-            Action::ToggleSort(variant),
+        let key = find_key(&Action::ToggleSort(variant));
+        let leading: Element<'a, tab::Message> = if sort_name == variant {
+            let icon_name = if sort_direction {
+                "view-sort-ascending-symbolic"
+            } else {
+                "view-sort-descending-symbolic"
+            };
+            widget::icon::from_name(icon_name).size(14).into()
+        } else {
+            space::horizontal().width(Length::Fixed(14.0)).into()
+        };
+        menu_button!(
+            leading,
+            space::horizontal().width(Length::Fixed(theme::spacing().space_xxs.into())),
+            text::body(label),
+            space::horizontal(),
+            text::body(key).class(theme::Text::Custom(key_style))
         )
+        .on_press(tab::Message::ContextAction(Action::ToggleSort(variant)))
         .into()
     };
 


### PR DESCRIPTION
This replaces the up/down arrow glyphs in the context menu for sort direction with actual sort icons.
This way the icon is not dependent on the user's system font. For example "Adwaita Sans" contains the up arrow but not the down arrow, which means the arrow changes shape (depending on the chosen fallback font) when you switch direction.

<img width="508" height="498" alt="Screenshot_2026-06-09_14-29-58" src="https://github.com/user-attachments/assets/265eada7-d7c2-4f76-b63d-38c1879e6e85" />
<img width="515" height="453" alt="Screenshot_2026-06-09_14-30-09" src="https://github.com/user-attachments/assets/d2634e96-5245-422a-b236-c49d7c65e79c" />

I took the liberty to move the icon from the end of the word to the left side and also preserve an empty space when it's not drawn. It may need UX approval.

Relevant mattermost thread: https://chat.pop-os.org/pop-os/pl/i3nphjm85fbpdfmnd9pt9abs6y

Fixes https://github.com/pop-os/cosmic-files/issues/1844

___
- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

