### PR TITLE
Clear hover highlights when navigating with keyboard

### DIFF
--- a/src/tab.rs
+++ b/src/tab.rs
@@ -3130,6 +3130,14 @@ impl Tab {
         item.pos_opt.get()
     }
 
+    fn dehighlight_all(&mut self) {
+        if let Some(items) = self.items_opt.as_mut() {
+            for item in items.iter_mut() {
+                item.highlighted = false;
+            }
+        }
+    }
+
     pub(crate) fn select_focus_scroll(&mut self) -> Option<AbsoluteOffset> {
         let items = self.items_opt.as_ref()?;
         let item = items.get(self.select_focus?)?;
@@ -3820,6 +3828,7 @@ impl Tab {
                 }
             }
             Message::ItemDown => {
+                self.dehighlight_all();
                 if let Some(edit_location) = &mut self.edit_location {
                     edit_location.select(true);
                 } else if self.gallery {
@@ -3862,6 +3871,7 @@ impl Tab {
                 }
             }
             Message::ItemLeft => {
+                self.dehighlight_all();
                 if self.gallery {
                     commands.append(&mut self.update(Message::GalleryPrevious, modifiers));
                 } else {
@@ -3920,6 +3930,7 @@ impl Tab {
                 }
             }
             Message::ItemRight => {
+                self.dehighlight_all();
                 if self.gallery {
                     commands.append(&mut self.update(Message::GalleryNext, modifiers));
                 } else {
@@ -3961,6 +3972,7 @@ impl Tab {
                 }
             }
             Message::ItemUp => {
+                self.dehighlight_all();
                 if let Some(edit_location) = &mut self.edit_location {
                     edit_location.select(false);
                 } else if self.gallery {


### PR DESCRIPTION
Keyboard navigation (arrow keys) did not clear item hover state, causing items to retain their grey hover background after the mouse left the window, resulting in multiple items appearing highlighted simultaneously.

Fixes #1865

Here's a video of this change in use : https://youtu.be/VZ_dXxwwauk

- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

