### PR TITLE
fix archive extract crash (#1718)

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -1009,6 +1009,12 @@ impl App {
             .and_then(|first| first.as_ref().parent())
             .map(Path::to_path_buf)
         {
+            let mut tasks = Vec::new();
+            if let Some(old_dialog) = self.file_dialog_opt.take() {
+                let old_id = old_dialog.window_id();
+                self.windows.remove(&old_id);
+                tasks.push(window::close(old_id));
+            }
             let (mut dialog, dialog_task) = Dialog::new(
                 DialogSettings::new()
                     .kind(DialogKind::OpenFolder)
@@ -1025,7 +1031,9 @@ impl App {
                 ))),
             );
             self.file_dialog_opt = Some(dialog);
-            Task::batch([set_title_task, dialog_task])
+            tasks.push(set_title_task);
+            tasks.push(dialog_task);
+            Task::batch(tasks)
         } else {
             Task::none()
         }

--- a/src/archive.rs
+++ b/src/archive.rs
@@ -1,5 +1,5 @@
 use crate::mime_icon::mime_for_path;
-use crate::operation::{Controller, OpReader, OperationError, OperationErrorType, sync_to_disk};
+use crate::operation::{Controller, OpReader, OperationError, OperationErrorType};
 use cosmic::iced::futures;
 use jiff::Zoned;
 use jiff::civil::DateTime;
@@ -45,7 +45,7 @@ pub fn extract(
     new_dir: &Path,
     password: &Option<String>,
     controller: &Controller,
-) -> Result<(), OperationError> {
+) -> Result<(Vec<PathBuf>, HashSet<PathBuf>), OperationError> {
     let mime = mime_for_path(path, None, false);
     let password = password.as_deref();
     match mime.essence_str() {
@@ -55,13 +55,15 @@ pub fn extract(
                 .map(flate2::read::GzDecoder::new)
                 .map(tar::Archive::new)
                 .and_then(|mut archive| archive.unpack(new_dir))
-                .map_err(|e| OperationError::from_err(e, controller))?;
+                .map_err(|e| OperationError::from_err(e, controller))
+                .map(|_| Default::default())
         }
         "application/x-tar" => OpReader::new(path, controller.clone())
             .map(io::BufReader::new)
             .map(tar::Archive::new)
             .and_then(|mut archive| archive.unpack(new_dir))
-            .map_err(|e| OperationError::from_err(e, controller))?,
+            .map_err(|e| OperationError::from_err(e, controller))
+            .map(|_| Default::default()),
         "application/zip" => fs::File::open(path)
             .map(io::BufReader::new)
             .map(zip::ZipArchive::new)
@@ -75,7 +77,7 @@ pub fn extract(
                     OperationError::from_kind(OperationErrorType::PasswordRequired, controller)
                 }
                 _ => OperationError::from_err(e, controller),
-            })?,
+            }),
         #[cfg(feature = "bzip2")]
         "application/x-bzip"
         | "application/x-bzip-compressed-tar"
@@ -85,7 +87,8 @@ pub fn extract(
             .map(bzip2::read::BzDecoder::new)
             .map(tar::Archive::new)
             .and_then(|mut archive| archive.unpack(new_dir))
-            .map_err(|e| OperationError::from_err(e, controller))?,
+            .map_err(|e| OperationError::from_err(e, controller))
+            .map(|_| Default::default()),
         #[cfg(feature = "lzma-rust2")]
         "application/x-xz" | "application/x-xz-compressed-tar" => {
             OpReader::new(path, controller.clone())
@@ -93,14 +96,14 @@ pub fn extract(
                 .map(|reader| lzma_rust2::XzReader::new(reader, true))
                 .map(tar::Archive::new)
                 .and_then(|mut archive| archive.unpack(new_dir))
-                .map_err(|e| OperationError::from_err(e, controller))?;
+                .map_err(|e| OperationError::from_err(e, controller))
+                .map(|_| Default::default())
         }
         _ => Err(OperationError::from_err(
             format!("unsupported mime type {mime:?}"),
             controller,
-        ))?,
+        )),
     }
-    Ok(())
 }
 
 // From https://docs.rs/zip/latest/zip/read/struct.ZipArchive.html#method.extract, with cancellation and progress added
@@ -109,7 +112,7 @@ fn zip_extract<R: io::Read + io::Seek, P: AsRef<Path>>(
     directory: P,
     password: Option<&str>,
     controller: Controller,
-) -> zip::result::ZipResult<()> {
+) -> zip::result::ZipResult<(Vec<PathBuf>, HashSet<PathBuf>)> {
     use std::ffi::OsString;
     use std::fs;
     use zip::result::ZipError;
@@ -282,10 +285,7 @@ fn zip_extract<R: io::Read + io::Seek, P: AsRef<Path>>(
         }
     }
 
-    // Flush files to disk
-    futures::executor::block_on(async { sync_to_disk(written_files, target_dirs).await });
-
-    Ok(())
+    Ok((written_files, target_dirs))
 }
 
 fn zip_date_time_to_system_time(date_time: zip::DateTime) -> Option<SystemTime> {

--- a/src/operation/mod.rs
+++ b/src/operation/mod.rs
@@ -967,11 +967,13 @@ impl Operation {
                 password,
             } => {
                 let controller_clone = controller.clone();
-                compio::runtime::spawn_blocking(
-                    move || -> Result<OperationSelection, OperationError> {
+                compio::runtime::spawn(async move {
+                    let extracted = compio::runtime::spawn_blocking(move || {
                         let controller = controller_clone;
                         let total_paths = paths.len();
                         let mut op_sel = OperationSelection::default();
+                        let mut written_files = Vec::new();
+                        let mut target_dirs = std::collections::HashSet::new();
                         for (i, path) in paths.iter().enumerate() {
                             futures::executor::block_on(async {
                                 controller
@@ -995,16 +997,32 @@ impl Operation {
                                 op_sel.ignored.push(path.clone());
                                 op_sel.selected.push(new_dir.clone());
 
-                                crate::archive::extract(path, &new_dir, &password, &controller)?;
+                                let (files, dirs) = crate::archive::extract(
+                                    path,
+                                    &new_dir,
+                                    &password,
+                                    &controller,
+                                )?;
+                                written_files.extend(files);
+                                target_dirs.extend(dirs);
                             }
                         }
 
-                        Ok(op_sel)
-                    },
-                )
+                        Ok::<_, OperationError>((op_sel, written_files, target_dirs))
+                    })
+                    .await
+                    .map_err(wrap_compio_spawn_error)??;
+
+                    let (op_sel, written_files, target_dirs) = extracted;
+                    if !written_files.is_empty() || !target_dirs.is_empty() {
+                        sync_to_disk(written_files, target_dirs).await;
+                    }
+
+                    Ok::<_, OperationError>(op_sel)
+                })
+                .await
+                .map_err(wrap_compio_spawn_error)?
             }
-            .await
-            .map_err(wrap_compio_spawn_error)?,
             Self::Move {
                 paths,
                 to,


### PR DESCRIPTION
So the archive::extract runs inside spawn_blocking, but sync_to_disk used compio's async fs so it panics "not in a compio runtime" and kills the extract. swapped that flush to plain std::fs since we're already on a blocking thread.
fixes #1718
- [x ] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x ] I understand these changes in full and will be able to respond to review comments.
- [ x] My change is accurately described in the commit message.
- [ x] My contribution is tested and working as described.
- [x ] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

