### PR TITLE
improv: make type-to-select prefix editable and visible

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -2782,6 +2782,12 @@ impl Application for App {
                 return Task::none();
             }
 
+            if !self.type_select_prefix.is_empty() {
+                self.type_select_prefix.clear();
+                self.type_select_last_key = None;
+                return Task::none();
+            }
+
             let had_focused_button = tab.select_focus_id().is_some();
             if tab.select_none() {
                 if had_focused_button {
@@ -3316,44 +3322,32 @@ impl Application for App {
                 if self.core.main_window_id() == Some(window_id) || in_surface_ids {
                     let entity = self.tab_model.active();
 
-                    // When typing-to-select, backspace edits it and escape clears it
+                    // When typing-to-select, backspace edits it
                     if matches!(self.mode, Mode::App)
                         && matches!(self.config.type_to_search, TypeToSearch::SelectByPrefix)
                         && !modifiers.logo()
                         && !modifiers.control()
                         && !modifiers.alt()
                         && !self.type_select_prefix.is_empty()
-                        && self
-                            .type_select_last_key
-                            .is_some_and(|last_key| last_key.elapsed() < tab::TYPE_SELECT_TIMEOUT)
+                        && matches!(key, Key::Named(Named::Backspace))
                     {
-                        match &key {
-                            Key::Named(Named::Backspace) => {
-                                self.type_select_prefix.pop();
-                                self.type_select_last_key = Some(Instant::now());
-                                if !self.type_select_prefix.is_empty()
-                                    && let Some(tab) = self.tab_model.data_mut::<Tab>(entity)
-                                {
-                                    tab.select_by_prefix(&self.type_select_prefix);
-                                    if let Some(offset) = tab.select_focus_scroll() {
-                                        return scrollable::scroll_to(
-                                            tab.scrollable_id.clone(),
-                                            AbsoluteOffset {
-                                                x: Some(offset.x),
-                                                y: Some(offset.y),
-                                            },
-                                        );
-                                    }
-                                }
-                                return Task::none();
+                        self.type_select_prefix.pop();
+                        self.type_select_last_key = Some(Instant::now());
+                        if !self.type_select_prefix.is_empty()
+                            && let Some(tab) = self.tab_model.data_mut::<Tab>(entity)
+                        {
+                            tab.select_by_prefix(&self.type_select_prefix);
+                            if let Some(offset) = tab.select_focus_scroll() {
+                                return scrollable::scroll_to(
+                                    tab.scrollable_id.clone(),
+                                    AbsoluteOffset {
+                                        x: Some(offset.x),
+                                        y: Some(offset.y),
+                                    },
+                                );
                             }
-                            Key::Named(Named::Escape) => {
-                                self.type_select_prefix.clear();
-                                self.type_select_last_key = None;
-                                return Task::none();
-                            }
-                            _ => {}
                         }
+                        return Task::none();
                     }
 
                     for (key_bind, action) in &self.key_binds {

--- a/src/app.rs
+++ b/src/app.rs
@@ -7,7 +7,7 @@ use cosmic::iced::clipboard::dnd::DndAction;
 use cosmic::iced::core::SmolStr;
 use cosmic::iced::core::widget::operation::focusable::unfocus;
 use cosmic::iced::futures::{self, SinkExt};
-use cosmic::iced::keyboard::key::Physical;
+use cosmic::iced::keyboard::key::{Named, Physical};
 use cosmic::iced::keyboard::{Event as KeyEvent, Key, Modifiers};
 #[cfg(all(feature = "wayland", feature = "desktop-applet"))]
 use cosmic::iced::platform_specific::shell::wayland::commands::overlap_notify::overlap_notify;
@@ -432,6 +432,7 @@ pub enum Message {
     SetShowDetails(bool),
     SetShowRecents(bool),
     SetTypeToSearch(TypeToSearch),
+    TypeSelectClear,
     SystemThemeModeChange,
     Size(window::Id, Size),
     TabActivate(Entity),
@@ -3314,6 +3315,47 @@ impl Application for App {
                 let in_surface_ids = false;
                 if self.core.main_window_id() == Some(window_id) || in_surface_ids {
                     let entity = self.tab_model.active();
+
+                    // When typing-to-select, backspace edits it and escape clears it
+                    if matches!(self.mode, Mode::App)
+                        && matches!(self.config.type_to_search, TypeToSearch::SelectByPrefix)
+                        && !modifiers.logo()
+                        && !modifiers.control()
+                        && !modifiers.alt()
+                        && !self.type_select_prefix.is_empty()
+                        && self
+                            .type_select_last_key
+                            .is_some_and(|last_key| last_key.elapsed() < tab::TYPE_SELECT_TIMEOUT)
+                    {
+                        match &key {
+                            Key::Named(Named::Backspace) => {
+                                self.type_select_prefix.pop();
+                                self.type_select_last_key = Some(Instant::now());
+                                if !self.type_select_prefix.is_empty()
+                                    && let Some(tab) = self.tab_model.data_mut::<Tab>(entity)
+                                {
+                                    tab.select_by_prefix(&self.type_select_prefix);
+                                    if let Some(offset) = tab.select_focus_scroll() {
+                                        return scrollable::scroll_to(
+                                            tab.scrollable_id.clone(),
+                                            AbsoluteOffset {
+                                                x: Some(offset.x),
+                                                y: Some(offset.y),
+                                            },
+                                        );
+                                    }
+                                }
+                                return Task::none();
+                            }
+                            Key::Named(Named::Escape) => {
+                                self.type_select_prefix.clear();
+                                self.type_select_last_key = None;
+                                return Task::none();
+                            }
+                            _ => {}
+                        }
+                    }
+
                     for (key_bind, action) in &self.key_binds {
                         if key_bind.matches(modifiers, &key, Some(&physical_key)) {
                             return self.update(action.message(Some(entity)));
@@ -4311,6 +4353,15 @@ impl Application for App {
             Message::SetTypeToSearch(type_to_search) => {
                 config_set!(type_to_search, type_to_search);
                 return self.update_config();
+            }
+            Message::TypeSelectClear => {
+                let expired = self
+                    .type_select_last_key
+                    .is_none_or(|last_key| last_key.elapsed() >= tab::TYPE_SELECT_TIMEOUT);
+                if expired {
+                    self.type_select_prefix.clear();
+                    self.type_select_last_key = None;
+                }
             }
             Message::SystemThemeModeChange => {
                 return self.update_config();
@@ -6465,6 +6516,33 @@ impl Application for App {
 
         let content: Element<_> = tab_column.into();
 
+        // Floating type-ahead indicator anchored to the bottom-right while typing to select.
+        if matches!(self.config.type_to_search, TypeToSearch::SelectByPrefix)
+            && !self.type_select_prefix.is_empty()
+        {
+            let chip = widget::container(
+                widget::row::with_children(vec![
+                    widget::icon::from_name("system-search-symbolic")
+                        .size(16)
+                        .into(),
+                    widget::text::body(self.type_select_prefix.clone()).into(),
+                ])
+                .spacing(space_xxs)
+                .align_y(Alignment::Center),
+            )
+            .padding([space_xxs, space_s])
+            .class(style::Container::Tooltip);
+
+            // A transparent, fill-sized layer pins the chip. It does not capture input.
+            let overlay = widget::container(chip)
+                .align_right(Length::Fill)
+                .align_bottom(Length::Fill)
+                .padding(space_s);
+
+            return cosmic::iced::widget::Stack::with_children(vec![content, overlay.into()])
+                .into();
+        }
+
         // Uncomment to debug layout:
         //content.explain(cosmic::iced::Color::WHITE)
         content
@@ -6892,6 +6970,17 @@ impl Application for App {
                 iced::time::every(time::Duration::from_millis(10))
                     .with(scroll_speed)
                     .map(|(scroll_speed, _)| Message::ScrollTab(scroll_speed)),
+            );
+        }
+
+        // While a type-to-select prefix is active, poll so the buffer (and its indicator)
+        // can be cleared once the timeout elapses.
+        if matches!(self.config.type_to_search, TypeToSearch::SelectByPrefix)
+            && !self.type_select_prefix.is_empty()
+        {
+            subscriptions.push(
+                cosmic::iced::time::every(Duration::from_millis(200))
+                    .map(|_| Message::TypeSelectClear),
             );
         }
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -758,6 +758,8 @@ pub struct App {
     tab_dnd_hover: Option<(Entity, Instant)>,
     type_select_prefix: String,
     type_select_last_key: Option<Instant>,
+    // Focus to restore when each prefix character is removed with Backspace.
+    type_select_focus_stack: Vec<Option<usize>>,
     nav_drag_id: DragId,
     tab_drag_id: DragId,
     auto_scroll_speed: Option<i16>,
@@ -2441,6 +2443,7 @@ impl Application for App {
             tab_dnd_hover: None,
             type_select_prefix: String::new(),
             type_select_last_key: None,
+            type_select_focus_stack: Vec::new(),
             nav_drag_id: DragId::new(),
             tab_drag_id: DragId::new(),
             auto_scroll_speed: None,
@@ -2784,6 +2787,7 @@ impl Application for App {
 
             if !self.type_select_prefix.is_empty() {
                 self.type_select_prefix.clear();
+                self.type_select_focus_stack.clear();
                 self.type_select_last_key = None;
                 return Task::none();
             }
@@ -3332,11 +3336,10 @@ impl Application for App {
                         && matches!(key, Key::Named(Named::Backspace))
                     {
                         self.type_select_prefix.pop();
+                        let restore = self.type_select_focus_stack.pop().flatten();
                         self.type_select_last_key = Some(Instant::now());
-                        if !self.type_select_prefix.is_empty()
-                            && let Some(tab) = self.tab_model.data_mut::<Tab>(entity)
-                        {
-                            tab.select_by_prefix(&self.type_select_prefix);
+                        if let Some(tab) = self.tab_model.data_mut::<Tab>(entity) {
+                            tab.select_focus_set(restore);
                             if let Some(offset) = tab.select_focus_scroll() {
                                 return scrollable::scroll_to(
                                     tab.scrollable_id.clone(),
@@ -3396,13 +3399,14 @@ impl Application for App {
                                     && last_key.elapsed() >= tab::TYPE_SELECT_TIMEOUT
                                 {
                                     self.type_select_prefix.clear();
+                                    self.type_select_focus_stack.clear();
                                 }
 
-                                // Accumulate character and select
-                                self.type_select_prefix.push_str(&text.to_lowercase());
                                 self.type_select_last_key = Some(Instant::now());
 
                                 if let Some(tab) = self.tab_model.data_mut::<Tab>(entity) {
+                                    self.type_select_focus_stack.push(tab.select_focus());
+                                    self.type_select_prefix.push_str(&text.to_lowercase());
                                     tab.select_by_prefix(&self.type_select_prefix);
                                     if let Some(offset) = tab.select_focus_scroll() {
                                         return scrollable::scroll_to(
@@ -4354,6 +4358,7 @@ impl Application for App {
                     .is_none_or(|last_key| last_key.elapsed() >= tab::TYPE_SELECT_TIMEOUT);
                 if expired {
                     self.type_select_prefix.clear();
+                    self.type_select_focus_stack.clear();
                     self.type_select_last_key = None;
                 }
             }
@@ -4500,6 +4505,7 @@ impl Application for App {
                             self.tab_model.text_set(entity, tab_title);
                             // clear the prefix selection buffer when changing location
                             self.type_select_prefix.clear();
+                            self.type_select_focus_stack.clear();
                             commands.push(Task::batch([
                                 self.update_title(),
                                 self.update_watcher(),

--- a/src/dialog.rs
+++ b/src/dialog.rs
@@ -1459,8 +1459,10 @@ impl Application for App {
             }
             Message::Key(modifiers, key, physical_key, text) => {
                 // When typing-to-select, backspace edits it
-                if matches!(self.flags.config.type_to_search, TypeToSearch::SelectByPrefix)
-                    && !modifiers.logo()
+                if matches!(
+                    self.flags.config.type_to_search,
+                    TypeToSearch::SelectByPrefix
+                ) && !modifiers.logo()
                     && !modifiers.control()
                     && !modifiers.alt()
                     && !self.type_select_prefix.is_empty()
@@ -2084,8 +2086,10 @@ impl Application for App {
         let content: Element<_> = col.into();
 
         // Floating type-ahead indicator anchored to the bottom-right while typing to select.
-        if matches!(self.flags.config.type_to_search, TypeToSearch::SelectByPrefix)
-            && !self.type_select_prefix.is_empty()
+        if matches!(
+            self.flags.config.type_to_search,
+            TypeToSearch::SelectByPrefix
+        ) && !self.type_select_prefix.is_empty()
         {
             let chip = widget::container(
                 widget::row::with_children(vec![
@@ -2265,8 +2269,10 @@ impl Application for App {
 
         // While a type-to-select prefix is active, poll so the buffer (and its indicator)
         // can be cleared once the timeout elapses.
-        if matches!(self.flags.config.type_to_search, TypeToSearch::SelectByPrefix)
-            && !self.type_select_prefix.is_empty()
+        if matches!(
+            self.flags.config.type_to_search,
+            TypeToSearch::SelectByPrefix
+        ) && !self.type_select_prefix.is_empty()
         {
             subscriptions.push(
                 iced::time::every(time::Duration::from_millis(200))

--- a/src/dialog.rs
+++ b/src/dialog.rs
@@ -483,6 +483,7 @@ enum Message {
     TimeConfigChange(TimeConfig),
     ToggleFoldersFirst,
     ToggleShowHidden,
+    TypeSelectClear,
     ZoomDefault,
     ZoomIn,
     ZoomOut,
@@ -1451,6 +1452,43 @@ impl Application for App {
                 return self.rescan_tab(None);
             }
             Message::Key(modifiers, key, physical_key, text) => {
+                // When typing-to-select, backspace edits it and escape clears it
+                if matches!(self.flags.config.type_to_search, TypeToSearch::SelectByPrefix)
+                    && !modifiers.logo()
+                    && !modifiers.control()
+                    && !modifiers.alt()
+                    && !self.type_select_prefix.is_empty()
+                    && self
+                        .type_select_last_key
+                        .is_some_and(|last_key| last_key.elapsed() < tab::TYPE_SELECT_TIMEOUT)
+                {
+                    match &key {
+                        Key::Named(Named::Backspace) => {
+                            self.type_select_prefix.pop();
+                            self.type_select_last_key = Some(Instant::now());
+                            if !self.type_select_prefix.is_empty() {
+                                self.tab.select_by_prefix(&self.type_select_prefix);
+                                if let Some(offset) = self.tab.select_focus_scroll() {
+                                    return scrollable::scroll_to(
+                                        self.tab.scrollable_id.clone(),
+                                        AbsoluteOffset {
+                                            x: Some(offset.x),
+                                            y: Some(offset.y),
+                                        },
+                                    );
+                                }
+                            }
+                            return Task::none();
+                        }
+                        Key::Named(Named::Escape) => {
+                            self.type_select_prefix.clear();
+                            self.type_select_last_key = None;
+                            return Task::none();
+                        }
+                        _ => {}
+                    }
+                }
+
                 for (key_bind, action) in &self.key_binds {
                     if key_bind.matches(modifiers, &key, Some(&physical_key)) {
                         return self.update(Message::from(action.message()));
@@ -1984,6 +2022,17 @@ impl Application for App {
                     config.show_hidden = !config.show_hidden;
                 });
             }
+            Message::TypeSelectClear => {
+                // Clear the type-to-select buffer once it has gone idle, which also hides the
+                // type-ahead indicator. A no-op if a newer keystroke re-armed the timer.
+                let expired = self
+                    .type_select_last_key
+                    .is_none_or(|last_key| last_key.elapsed() >= tab::TYPE_SELECT_TIMEOUT);
+                if expired {
+                    self.type_select_prefix.clear();
+                    self.type_select_last_key = None;
+                }
+            }
             Message::ZoomDefault => {
                 return self.with_dialog_config(|config| {
                     zoom_to_default(config.view, &mut config.icon_sizes);
@@ -2011,7 +2060,9 @@ impl Application for App {
 
     /// Creates a view after each update.
     fn view(&self) -> Element<'_, Message> {
-        let cosmic_theme::Spacing { space_xxs, .. } = theme::spacing();
+        let cosmic_theme::Spacing {
+            space_xxs, space_s, ..
+        } = theme::spacing();
 
         let mut col = widget::column::with_capacity(2);
 
@@ -2036,7 +2087,36 @@ impl Application for App {
                 .map(Message::TabMessage),
         );
 
-        col.into()
+        let content: Element<_> = col.into();
+
+        // Floating type-ahead indicator anchored to the bottom-right while typing to select.
+        if matches!(self.flags.config.type_to_search, TypeToSearch::SelectByPrefix)
+            && !self.type_select_prefix.is_empty()
+        {
+            let chip = widget::container(
+                widget::row::with_children(vec![
+                    widget::icon::from_name("system-search-symbolic")
+                        .size(16)
+                        .into(),
+                    widget::text::body(self.type_select_prefix.clone()).into(),
+                ])
+                .spacing(space_xxs)
+                .align_y(Alignment::Center),
+            )
+            .padding([space_xxs, space_s])
+            .class(theme::Container::Tooltip);
+
+            // A transparent, fill-sized layer pins the chip. It does not capture input.
+            let overlay = widget::container(chip)
+                .align_right(Length::Fill)
+                .align_bottom(Length::Fill)
+                .padding(space_s);
+
+            return cosmic::iced::widget::Stack::with_children(vec![content, overlay.into()])
+                .into();
+        }
+
+        content
     }
 
     fn subscription(&self) -> Subscription<Message> {
@@ -2186,6 +2266,17 @@ impl Application for App {
                 iced::time::every(time::Duration::from_millis(10))
                     .with(scroll_speed)
                     .map(|(scroll_speed, _)| Message::ScrollTab(scroll_speed)),
+            );
+        }
+
+        // While a type-to-select prefix is active, poll so the buffer (and its indicator)
+        // can be cleared once the timeout elapses.
+        if matches!(self.flags.config.type_to_search, TypeToSearch::SelectByPrefix)
+            && !self.type_select_prefix.is_empty()
+        {
+            subscriptions.push(
+                iced::time::every(time::Duration::from_millis(200))
+                    .map(|_| Message::TypeSelectClear),
             );
         }
 

--- a/src/dialog.rs
+++ b/src/dialog.rs
@@ -565,6 +565,8 @@ struct App {
     auto_scroll_speed: Option<i16>,
     type_select_prefix: String,
     type_select_last_key: Option<Instant>,
+    // Focus to restore when each prefix character is removed with Backspace.
+    type_select_focus_stack: Vec<Option<usize>>,
 }
 
 impl App {
@@ -1075,6 +1077,7 @@ impl Application for App {
             auto_scroll_speed: None,
             type_select_prefix: String::new(),
             type_select_last_key: None,
+            type_select_focus_stack: Vec::new(),
         };
 
         let commands = Task::batch([
@@ -1350,6 +1353,7 @@ impl Application for App {
 
         if !self.type_select_prefix.is_empty() {
             self.type_select_prefix.clear();
+            self.type_select_focus_stack.clear();
             self.type_select_last_key = None;
             return Task::none();
         }
@@ -1469,18 +1473,17 @@ impl Application for App {
                     && matches!(key, Key::Named(Named::Backspace))
                 {
                     self.type_select_prefix.pop();
+                    let restore = self.type_select_focus_stack.pop().flatten();
                     self.type_select_last_key = Some(Instant::now());
-                    if !self.type_select_prefix.is_empty() {
-                        self.tab.select_by_prefix(&self.type_select_prefix);
-                        if let Some(offset) = self.tab.select_focus_scroll() {
-                            return scrollable::scroll_to(
-                                self.tab.scrollable_id.clone(),
-                                AbsoluteOffset {
-                                    x: Some(offset.x),
-                                    y: Some(offset.y),
-                                },
-                            );
-                        }
+                    self.tab.select_focus_set(restore);
+                    if let Some(offset) = self.tab.select_focus_scroll() {
+                        return scrollable::scroll_to(
+                            self.tab.scrollable_id.clone(),
+                            AbsoluteOffset {
+                                x: Some(offset.x),
+                                y: Some(offset.y),
+                            },
+                        );
                     }
                     return Task::none();
                 }
@@ -1533,9 +1536,10 @@ impl Application for App {
                                 && last_key.elapsed() >= tab::TYPE_SELECT_TIMEOUT
                             {
                                 self.type_select_prefix.clear();
+                                self.type_select_focus_stack.clear();
                             }
 
-                            // Accumulate character and select
+                            self.type_select_focus_stack.push(self.tab.select_focus());
                             self.type_select_prefix.push_str(&text.to_lowercase());
                             self.type_select_last_key = Some(Instant::now());
 
@@ -2026,6 +2030,7 @@ impl Application for App {
                     .is_none_or(|last_key| last_key.elapsed() >= tab::TYPE_SELECT_TIMEOUT);
                 if expired {
                     self.type_select_prefix.clear();
+                    self.type_select_focus_stack.clear();
                     self.type_select_last_key = None;
                 }
             }

--- a/src/dialog.rs
+++ b/src/dialog.rs
@@ -1348,6 +1348,12 @@ impl Application for App {
             return self.search_set(None);
         }
 
+        if !self.type_select_prefix.is_empty() {
+            self.type_select_prefix.clear();
+            self.type_select_last_key = None;
+            return Task::none();
+        }
+
         let had_focused_button = self.tab.select_focus_id().is_some();
         if self.tab.select_none() {
             if had_focused_button {
@@ -1452,41 +1458,29 @@ impl Application for App {
                 return self.rescan_tab(None);
             }
             Message::Key(modifiers, key, physical_key, text) => {
-                // When typing-to-select, backspace edits it and escape clears it
+                // When typing-to-select, backspace edits it
                 if matches!(self.flags.config.type_to_search, TypeToSearch::SelectByPrefix)
                     && !modifiers.logo()
                     && !modifiers.control()
                     && !modifiers.alt()
                     && !self.type_select_prefix.is_empty()
-                    && self
-                        .type_select_last_key
-                        .is_some_and(|last_key| last_key.elapsed() < tab::TYPE_SELECT_TIMEOUT)
+                    && matches!(key, Key::Named(Named::Backspace))
                 {
-                    match &key {
-                        Key::Named(Named::Backspace) => {
-                            self.type_select_prefix.pop();
-                            self.type_select_last_key = Some(Instant::now());
-                            if !self.type_select_prefix.is_empty() {
-                                self.tab.select_by_prefix(&self.type_select_prefix);
-                                if let Some(offset) = self.tab.select_focus_scroll() {
-                                    return scrollable::scroll_to(
-                                        self.tab.scrollable_id.clone(),
-                                        AbsoluteOffset {
-                                            x: Some(offset.x),
-                                            y: Some(offset.y),
-                                        },
-                                    );
-                                }
-                            }
-                            return Task::none();
+                    self.type_select_prefix.pop();
+                    self.type_select_last_key = Some(Instant::now());
+                    if !self.type_select_prefix.is_empty() {
+                        self.tab.select_by_prefix(&self.type_select_prefix);
+                        if let Some(offset) = self.tab.select_focus_scroll() {
+                            return scrollable::scroll_to(
+                                self.tab.scrollable_id.clone(),
+                                AbsoluteOffset {
+                                    x: Some(offset.x),
+                                    y: Some(offset.y),
+                                },
+                            );
                         }
-                        Key::Named(Named::Escape) => {
-                            self.type_select_prefix.clear();
-                            self.type_select_last_key = None;
-                            return Task::none();
-                        }
-                        _ => {}
                     }
+                    return Task::none();
                 }
 
                 for (key_bind, action) in &self.key_binds {

--- a/src/tab.rs
+++ b/src/tab.rs
@@ -3124,6 +3124,20 @@ impl Tab {
         Some(item.button_id.clone())
     }
 
+    pub(crate) fn select_focus(&self) -> Option<usize> {
+        self.select_focus
+    }
+
+    /// Selects exactly the item at the given focus index, deselecting all others.
+    pub(crate) fn select_focus_set(&mut self, focus: Option<usize>) {
+        self.select_focus = focus;
+        if let Some(ref mut items) = self.items_opt {
+            for (i, item) in items.iter_mut().enumerate() {
+                item.selected = Some(i) == focus;
+            }
+        }
+    }
+
     fn select_focus_pos_opt(&self) -> Option<(usize, usize)> {
         let items = self.items_opt.as_ref()?;
         let item = items.get(self.select_focus?)?;


### PR DESCRIPTION
<img width="1780" height="1094" alt="A screenshot preview of the new prefix search chip (bottom right)" src="https://github.com/user-attachments/assets/953cb186-efda-4891-8024-03fab4424f69" />

- Backspace now edits the active prefix and Escape clears it, so fixing a typo or starting a fresh search no longer requires waiting for the timeout.
- Show a bottom-right floating prefix indicator while filtering.
- Auto-clear the buffer (hiding the indicator) once it idle, via a subscription.

Applies to both the main window and the open/save dialog.

- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

