### PR TITLE
fix: prevent long delay on startup (~1min) and freeze for (~12s) after deleting files by keeping filesystem I/O off the GUI thread

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -345,6 +345,10 @@ pub enum Message {
     CosmicSettings(&'static str),
     Cut(Option<Entity>),
     Delete(Option<Entity>),
+    DeleteClassified {
+        trash_paths: Vec<PathBuf>,
+        dialog_paths: Vec<PathBuf>,
+    },
     DesktopConfig(DesktopConfig),
     DesktopViewOptions,
     DesktopDialogs(bool),
@@ -424,6 +428,7 @@ pub enum Message {
     ReorderTab(ReorderEvent),
     RescanRecents,
     RescanTrash,
+    TrashEmpty,
     RemoveFromRecents(Option<Entity>),
     Rename(Option<Entity>),
     ReplaceResult(ReplaceResult),
@@ -1214,25 +1219,51 @@ impl App {
 
     // This wrapper ensures that local folders use trash and remote folders permanently delete with a dialog
     fn delete(&mut self, paths: impl IntoIterator<Item = PathBuf>) -> Task<Message> {
-        let mut dialog_paths = Vec::new();
-        let mut trash_paths = Vec::new();
-
-        for path in paths {
-            //TODO: is there a smarter way to check this? (like checking for trash folders)
-            let can_trash = match path.metadata() {
-                Ok(metadata) => matches!(tab::fs_kind(&metadata), tab::FsKind::Local),
-                Err(err) => {
-                    log::warn!("failed to get metadata for {}: {}", path.display(), err);
-                    false
+        let paths: Vec<PathBuf> = paths.into_iter().collect();
+        // Classifying trash vs permanent-delete stats each path, which blocks on slow mounts;
+        // do it off-thread and finish in Message::DeleteClassified.
+        Task::future(async move {
+            let (trash_paths, dialog_paths) = tokio::task::spawn_blocking(move || {
+                let mut trash_paths = Vec::new();
+                let mut dialog_paths = Vec::new();
+                for path in paths {
+                    //TODO: is there a smarter way to check this? (like checking for trash folders)
+                    let can_trash = match path.metadata() {
+                        Ok(metadata) => matches!(tab::fs_kind(&metadata), tab::FsKind::Local),
+                        Err(err) => {
+                            log::warn!("failed to get metadata for {}: {}", path.display(), err);
+                            false
+                        }
+                    };
+                    if can_trash {
+                        trash_paths.push(path);
+                    } else {
+                        dialog_paths.push(path);
+                    }
                 }
-            };
-            if can_trash {
-                trash_paths.push(path);
-            } else {
-                dialog_paths.push(path);
-            }
-        }
+                (trash_paths, dialog_paths)
+            })
+            .await
+            .unwrap_or_else(|err| {
+                // Surface a panic in the classification task rather than silently dropping
+                // the delete; fall back to deleting nothing.
+                log::warn!("failed to classify paths for deletion: {err}");
+                (Vec::new(), Vec::new())
+            });
+            cosmic::action::app(Message::DeleteClassified {
+                trash_paths,
+                dialog_paths,
+            })
+        })
+    }
 
+    // Trash the local paths and/or open the permanent-delete dialog, once `delete` has
+    // classified them off-thread.
+    fn delete_classified(
+        &mut self,
+        trash_paths: Vec<PathBuf>,
+        dialog_paths: Vec<PathBuf>,
+    ) -> Task<Message> {
         let mut tasks = Vec::new();
         if !dialog_paths.is_empty() {
             tasks.push(self.update(Message::DialogPush(
@@ -1389,6 +1420,8 @@ impl App {
         commands.push(self.rescan_operation_selection(op_sel));
         // Manually rescan any trash tabs after any operation is completed
         commands.push(self.rescan_trash());
+        // An operation may have changed the trash; refresh its cached state off-thread.
+        commands.push(self.refresh_trash_state());
 
         Task::batch(commands)
     }
@@ -1556,6 +1589,17 @@ impl App {
             .map(|(entity, location)| self.update_tab(entity, location, None));
 
         Task::batch(commands)
+    }
+
+    /// Recompute the cached trash empty/full state off-thread. Walking the trash blocks on
+    /// slow mounts, so it must never run inline in `update`/`view`. [`Message::TrashEmpty`]
+    /// then repaints the nav icon from the refreshed cache.
+    fn refresh_trash_state(&self) -> Task<Message> {
+        Task::future(async move {
+            // Discard the returned value: the handler repaints from the cache, not from here.
+            let _ = tokio::task::spawn_blocking(Trash::refresh_is_empty).await;
+            cosmic::action::app(Message::TrashEmpty)
+        })
     }
 
     fn rescan_recents(&mut self) -> Task<Message> {
@@ -1768,15 +1812,10 @@ impl App {
                     fl!("filesystem")
                 };
                 nav_model = nav_model.insert(move |b| {
+                    // Favorites are directories; use the folder icon without stat-ing the
+                    // path, which would block the GUI thread on slow/network mounts.
                     b.text(name.clone())
-                        .icon(
-                            icon::icon(if path.is_dir() {
-                                tab::folder_icon_symbolic(&path, 16)
-                            } else {
-                                icon::from_name("text-x-generic-symbolic").size(16).handle()
-                            })
-                            .size(16),
-                        )
+                        .icon(icon::icon(tab::folder_icon_symbolic(&path, 16)).size(16))
                         .data(match favorite {
                             Favorite::Network { uri, name, path } => {
                                 Location::Network(uri.clone(), name.clone(), Some(path.to_owned()))
@@ -2453,7 +2492,12 @@ impl Application for App {
             layer_sizes: FxHashMap::default(),
         };
 
-        let mut commands = vec![app.update_config(), app.update(Message::CheckClipboard)];
+        let mut commands = vec![
+            app.update_config(),
+            app.update(Message::CheckClipboard),
+            // Compute the trash empty/full state off-thread so the nav icon never blocks init.
+            app.refresh_trash_state(),
+        ];
 
         for location in flags.locations {
             if let Some(path) = location.path_opt()
@@ -2608,7 +2652,7 @@ impl Application for App {
             ));
         }
 
-        if matches!(location_opt, Some(Location::Trash)) && !Trash::is_empty() {
+        if matches!(location_opt, Some(Location::Trash)) && !Trash::is_empty_cached() {
             items.push(cosmic::widget::menu::Item::Button(
                 fl!("empty-trash"),
                 None,
@@ -3025,6 +3069,12 @@ impl Application for App {
                         }
                     }
                 }
+            }
+            Message::DeleteClassified {
+                trash_paths,
+                dialog_paths,
+            } => {
+                return self.delete_classified(trash_paths, dialog_paths);
             }
             Message::DesktopConfig(config) => {
                 if config != self.config.desktop {
@@ -3620,58 +3670,21 @@ impl Application for App {
             Message::NotifyEvents(events) => {
                 log::debug!("{events:?}");
 
+                // Reload any tab whose directory an event touched, via update_tab so the I/O
+                // runs in a background task — reading metadata here, on the GUI thread, would
+                // block on slow mounts.
                 let mut needs_reload = Vec::new();
                 let entities: Box<[_]> = self.tab_model.iter().collect();
                 for entity in entities {
-                    if let Some(tab) = self.tab_model.data_mut::<Tab>(entity)
+                    if let Some(tab) = self.tab_model.data::<Tab>(entity)
                         && let Some(path) = tab.location.path_opt()
                     {
-                        let mut contains_change = false;
-                        for event in &events {
-                            for event_path in &event.paths {
-                                if event_path.starts_with(path) {
-                                    if let notify::EventKind::Modify(
-                                        notify::event::ModifyKind::Metadata(_)
-                                        | notify::event::ModifyKind::Data(_),
-                                    ) = event.kind
-                                    {
-                                        // If metadata or data changed, find the matching item and reload it
-                                        //TODO: this could be further optimized by looking at what exactly changed
-                                        if let Some(items) = &mut tab.items_opt {
-                                            for item in items.iter_mut() {
-                                                if item.path_opt() == Some(event_path) {
-                                                    //TODO: reload more, like mime types?
-                                                    match fs::metadata(event_path) {
-                                                        Ok(new_metadata) => {
-                                                            if let ItemMetadata::Path {
-                                                                metadata,
-                                                                ..
-                                                            } = &mut item.metadata
-                                                            {
-                                                                *metadata = new_metadata;
-                                                            }
-                                                        }
-
-                                                        Err(err) => {
-                                                            log::warn!(
-                                                                "failed to reload metadata for {}: {}",
-                                                                path.display(),
-                                                                err
-                                                            );
-                                                        }
-                                                    }
-                                                    //TODO item.thumbnail_opt =
-                                                }
-                                            }
-                                        }
-                                    } else {
-                                        // Any other events reload the whole tab
-                                        contains_change = true;
-                                        break;
-                                    }
-                                }
-                            }
-                        }
+                        let contains_change = events.iter().any(|event| {
+                            event
+                                .paths
+                                .iter()
+                                .any(|event_path| event_path.starts_with(path))
+                        });
                         if contains_change {
                             needs_reload.push((entity, tab.location.clone()));
                         }
@@ -4186,7 +4199,16 @@ impl Application for App {
                 return self.rescan_recents();
             }
             Message::RescanTrash => {
-                // Update trash icon if empty/full
+                // Refresh the cached state off-thread (Message::TrashEmpty repaints the icon)
+                // and rescan tabs.
+                return Task::batch([
+                    self.refresh_trash_state(),
+                    self.rescan_trash(),
+                    self.update_desktop(),
+                ]);
+            }
+            Message::TrashEmpty => {
+                // Cache was refreshed off-thread; repaint the nav-bar trash icon from it.
                 let maybe_entity = self.nav_model.iter().find(|&entity| {
                     self.nav_model
                         .data::<Location>(entity)
@@ -4196,8 +4218,6 @@ impl Application for App {
                     self.nav_model
                         .icon_set(entity, icon::icon(Trash::icon_symbolic(16)));
                 }
-
-                return Task::batch([self.rescan_trash(), self.update_desktop()]);
             }
             Message::Rename(entity_opt) => {
                 let entity = entity_opt.unwrap_or_else(|| self.tab_model.active());

--- a/src/app.rs
+++ b/src/app.rs
@@ -346,6 +346,10 @@ pub enum Message {
     CosmicSettings(&'static str),
     Cut(Option<Entity>),
     Delete(Option<Entity>),
+    DeleteClassified {
+        trash_paths: Vec<PathBuf>,
+        dialog_paths: Vec<PathBuf>,
+    },
     DesktopConfig(DesktopConfig),
     DesktopViewOptions,
     DesktopDialogs(bool),
@@ -425,6 +429,7 @@ pub enum Message {
     ReorderTab(ReorderEvent),
     RescanRecents,
     RescanTrash,
+    TrashEmpty,
     RemoveFromRecents(Option<Entity>),
     Rename(Option<Entity>),
     ReplaceResult(ReplaceResult),
@@ -1223,25 +1228,51 @@ impl App {
 
     // This wrapper ensures that local folders use trash and remote folders permanently delete with a dialog
     fn delete(&mut self, paths: impl IntoIterator<Item = PathBuf>) -> Task<Message> {
-        let mut dialog_paths = Vec::new();
-        let mut trash_paths = Vec::new();
-
-        for path in paths {
-            //TODO: is there a smarter way to check this? (like checking for trash folders)
-            let can_trash = match path.metadata() {
-                Ok(metadata) => matches!(tab::fs_kind(&metadata), tab::FsKind::Local),
-                Err(err) => {
-                    log::warn!("failed to get metadata for {}: {}", path.display(), err);
-                    false
+        let paths: Vec<PathBuf> = paths.into_iter().collect();
+        // Classifying trash vs permanent-delete stats each path, which blocks on slow mounts;
+        // do it off-thread and finish in Message::DeleteClassified.
+        Task::future(async move {
+            let (trash_paths, dialog_paths) = tokio::task::spawn_blocking(move || {
+                let mut trash_paths = Vec::new();
+                let mut dialog_paths = Vec::new();
+                for path in paths {
+                    //TODO: is there a smarter way to check this? (like checking for trash folders)
+                    let can_trash = match path.metadata() {
+                        Ok(metadata) => matches!(tab::fs_kind(&metadata), tab::FsKind::Local),
+                        Err(err) => {
+                            log::warn!("failed to get metadata for {}: {}", path.display(), err);
+                            false
+                        }
+                    };
+                    if can_trash {
+                        trash_paths.push(path);
+                    } else {
+                        dialog_paths.push(path);
+                    }
                 }
-            };
-            if can_trash {
-                trash_paths.push(path);
-            } else {
-                dialog_paths.push(path);
-            }
-        }
+                (trash_paths, dialog_paths)
+            })
+            .await
+            .unwrap_or_else(|err| {
+                // Surface a panic in the classification task rather than silently dropping
+                // the delete; fall back to deleting nothing.
+                log::warn!("failed to classify paths for deletion: {err}");
+                (Vec::new(), Vec::new())
+            });
+            cosmic::action::app(Message::DeleteClassified {
+                trash_paths,
+                dialog_paths,
+            })
+        })
+    }
 
+    // Trash the local paths and/or open the permanent-delete dialog, once `delete` has
+    // classified them off-thread.
+    fn delete_classified(
+        &mut self,
+        trash_paths: Vec<PathBuf>,
+        dialog_paths: Vec<PathBuf>,
+    ) -> Task<Message> {
         let mut tasks = Vec::new();
         if !dialog_paths.is_empty() {
             tasks.push(self.update(Message::DialogPush(
@@ -1398,6 +1429,8 @@ impl App {
         commands.push(self.rescan_operation_selection(op_sel));
         // Manually rescan any trash tabs after any operation is completed
         commands.push(self.rescan_trash());
+        // An operation may have changed the trash; refresh its cached state off-thread.
+        commands.push(self.refresh_trash_state());
 
         Task::batch(commands)
     }
@@ -1565,6 +1598,17 @@ impl App {
             .map(|(entity, location)| self.update_tab(entity, location, None));
 
         Task::batch(commands)
+    }
+
+    /// Recompute the cached trash empty/full state off-thread. Walking the trash blocks on
+    /// slow mounts, so it must never run inline in `update`/`view`. [`Message::TrashEmpty`]
+    /// then repaints the nav icon from the refreshed cache.
+    fn refresh_trash_state(&self) -> Task<Message> {
+        Task::future(async move {
+            // Discard the returned value: the handler repaints from the cache, not from here.
+            let _ = tokio::task::spawn_blocking(Trash::refresh_is_empty).await;
+            cosmic::action::app(Message::TrashEmpty)
+        })
     }
 
     fn rescan_recents(&mut self) -> Task<Message> {
@@ -1777,15 +1821,10 @@ impl App {
                     fl!("filesystem")
                 };
                 nav_model = nav_model.insert(move |b| {
+                    // Favorites are directories; use the folder icon without stat-ing the
+                    // path, which would block the GUI thread on slow/network mounts.
                     b.text(name.clone())
-                        .icon(
-                            icon::icon(if path.is_dir() {
-                                tab::folder_icon_symbolic(&path, 16)
-                            } else {
-                                icon::from_name("text-x-generic-symbolic").size(16).handle()
-                            })
-                            .size(16),
-                        )
+                        .icon(icon::icon(tab::folder_icon_symbolic(&path, 16)).size(16))
                         .data(match favorite {
                             Favorite::Network { uri, name, path } => {
                                 Location::Network(uri.clone(), name.clone(), Some(path.to_owned()))
@@ -2465,7 +2504,12 @@ impl Application for App {
             layer_sizes: FxHashMap::default(),
         };
 
-        let mut commands = vec![app.update_config(), app.update(Message::CheckClipboard)];
+        let mut commands = vec![
+            app.update_config(),
+            app.update(Message::CheckClipboard),
+            // Compute the trash empty/full state off-thread so the nav icon never blocks init.
+            app.refresh_trash_state(),
+        ];
 
         for location in flags.locations {
             if let Some(path) = location.path_opt()
@@ -2626,7 +2670,7 @@ impl Application for App {
                 ));
             }
 
-            if matches!(location_opt, Some(Location::Trash)) && !Trash::is_empty() {
+            if matches!(location_opt, Some(Location::Trash)) && !Trash::is_empty_cached() {
                 items.push(cosmic::widget::menu::Item::Button(
                     fl!("empty-trash"),
                     None,
@@ -3048,6 +3092,12 @@ impl Application for App {
                         }
                     }
                 }
+            }
+            Message::DeleteClassified {
+                trash_paths,
+                dialog_paths,
+            } => {
+                return self.delete_classified(trash_paths, dialog_paths);
             }
             Message::DesktopConfig(config) => {
                 if config != self.config.desktop {
@@ -3643,58 +3693,21 @@ impl Application for App {
             Message::NotifyEvents(events) => {
                 log::debug!("{events:?}");
 
+                // Reload any tab whose directory an event touched, via update_tab so the I/O
+                // runs in a background task — reading metadata here, on the GUI thread, would
+                // block on slow mounts.
                 let mut needs_reload = Vec::new();
                 let entities: Box<[_]> = self.tab_model.iter().collect();
                 for entity in entities {
-                    if let Some(tab) = self.tab_model.data_mut::<Tab>(entity)
+                    if let Some(tab) = self.tab_model.data::<Tab>(entity)
                         && let Some(path) = tab.location.path_opt()
                     {
-                        let mut contains_change = false;
-                        for event in &events {
-                            for event_path in &event.paths {
-                                if event_path.starts_with(path) {
-                                    if let notify::EventKind::Modify(
-                                        notify::event::ModifyKind::Metadata(_)
-                                        | notify::event::ModifyKind::Data(_),
-                                    ) = event.kind
-                                    {
-                                        // If metadata or data changed, find the matching item and reload it
-                                        //TODO: this could be further optimized by looking at what exactly changed
-                                        if let Some(items) = &mut tab.items_opt {
-                                            for item in items.iter_mut() {
-                                                if item.path_opt() == Some(event_path) {
-                                                    //TODO: reload more, like mime types?
-                                                    match fs::metadata(event_path) {
-                                                        Ok(new_metadata) => {
-                                                            if let ItemMetadata::Path {
-                                                                metadata,
-                                                                ..
-                                                            } = &mut item.metadata
-                                                            {
-                                                                *metadata = new_metadata;
-                                                            }
-                                                        }
-
-                                                        Err(err) => {
-                                                            log::warn!(
-                                                                "failed to reload metadata for {}: {}",
-                                                                path.display(),
-                                                                err
-                                                            );
-                                                        }
-                                                    }
-                                                    //TODO item.thumbnail_opt =
-                                                }
-                                            }
-                                        }
-                                    } else {
-                                        // Any other events reload the whole tab
-                                        contains_change = true;
-                                        break;
-                                    }
-                                }
-                            }
-                        }
+                        let contains_change = events.iter().any(|event| {
+                            event
+                                .paths
+                                .iter()
+                                .any(|event_path| event_path.starts_with(path))
+                        });
                         if contains_change {
                             needs_reload.push((entity, tab.location.clone()));
                         }
@@ -4209,7 +4222,16 @@ impl Application for App {
                 return self.rescan_recents();
             }
             Message::RescanTrash => {
-                // Update trash icon if empty/full
+                // Refresh the cached state off-thread (Message::TrashEmpty repaints the icon)
+                // and rescan tabs.
+                return Task::batch([
+                    self.refresh_trash_state(),
+                    self.rescan_trash(),
+                    self.update_desktop(),
+                ]);
+            }
+            Message::TrashEmpty => {
+                // Cache was refreshed off-thread; repaint the nav-bar trash icon from it.
                 let maybe_entity = self.nav_model.iter().find(|&entity| {
                     self.nav_model
                         .data::<Location>(entity)
@@ -4219,8 +4241,6 @@ impl Application for App {
                     self.nav_model
                         .icon_set(entity, icon::icon(Trash::icon_symbolic(16)));
                 }
-
-                return Task::batch([self.rescan_trash(), self.update_desktop()]);
             }
             Message::Rename(entity_opt) => {
                 let entity = entity_opt.unwrap_or_else(|| self.tab_model.active());

--- a/src/menu.rs
+++ b/src/menu.rs
@@ -196,7 +196,7 @@ pub fn context_menu<'a>(
         ) => {
             if selected_trash_only {
                 children.push(menu_item(fl!("open"), Action::Open).into());
-                if !Trash::is_empty() {
+                if !Trash::is_empty_cached() {
                     children.push(menu_item(fl!("empty-trash"), Action::EmptyTrash).into());
                 }
             } else if let Some(entry) = selected_desktop_entry {

--- a/src/menu.rs
+++ b/src/menu.rs
@@ -202,7 +202,7 @@ pub fn context_menu<'a>(
         ) => {
             if selected_trash_only {
                 children.push(menu_item(fl!("open"), Action::Open).into());
-                if !Trash::is_empty() {
+                if !Trash::is_empty_cached() {
                     children.push(menu_item(fl!("empty-trash"), Action::EmptyTrash).into());
                 }
             } else if let Some(entry) = selected_desktop_entry {

--- a/src/tab.rs
+++ b/src/tab.rs
@@ -2722,12 +2722,12 @@ fn folder_name<P: AsRef<Path>>(path: P) -> (String, bool) {
                 found_home = true;
                 fl!("home")
             } else {
-                match (get_filename_from_path(path), fs::metadata(path)) {
-                    (Ok(name), Ok(metadata)) => {
-                        let is_gvfs = fs_kind(&metadata) == FsKind::Gvfs;
-                        display_name_for_file(path, &name, is_gvfs, false)
-                    }
-                    _ => name.to_string_lossy().into_owned(),
+                // Name from the path component only. folder_name runs on the GUI thread for
+                // every tab title and breadcrumb, so it must not stat (which a gvfs friendly-
+                // name lookup would do, blocking on slow mounts).
+                match get_filename_from_path(path) {
+                    Ok(name) => display_name_for_file(path, &name, false, false),
+                    Err(_) => name.to_string_lossy().into_owned(),
                 }
             }
         }
@@ -7204,7 +7204,7 @@ fn text_editor_class(
 
 #[cfg(test)]
 mod tests {
-    use std::path::PathBuf;
+    use std::path::{Path, PathBuf};
     use std::{fs, io};
 
     use cosmic::iced::mouse::ScrollDelta;
@@ -7216,7 +7216,8 @@ mod tests {
     use test_log::test;
 
     use super::{
-        ItemMetadata, ItemThumbnail, Location, Message, Tab, respond_to_scroll_direction, scan_path,
+        ItemMetadata, ItemThumbnail, Location, Message, Tab, folder_name,
+        respond_to_scroll_direction, scan_path,
     };
     use crate::app::test_utils::{
         NAME_LEN, NUM_DIRS, NUM_FILES, NUM_HIDDEN, NUM_NESTED, assert_eq_tab_path, empty_fs,
@@ -7359,6 +7360,37 @@ mod tests {
         assert!(actual.is_empty());
 
         Ok(())
+    }
+
+    #[test]
+    fn folder_name_derives_last_path_component() {
+        // No '.' or '_' in the component, so Item::display_name leaves it untouched.
+        let (name, found_home) = folder_name("/srv/data/Projects");
+        assert_eq!(name, "Projects");
+        assert!(!found_home);
+    }
+
+    #[test]
+    fn folder_name_does_not_stat_the_path() {
+        // A non-existent path still yields its final component: the name comes from the path
+        // alone, with no stat (which is what keeps folder_name safe on the GUI thread).
+        let missing = "/this/path/does/not/exist/Documents";
+        assert!(!Path::new(missing).exists());
+
+        let (name, found_home) = folder_name(missing);
+        assert_eq!(name, "Documents");
+        assert!(!found_home);
+    }
+
+    #[test]
+    fn folder_name_flags_the_home_directory() {
+        let home = crate::home_dir();
+        // The "/" fallback (no resolvable home) has no final component to match; only assert
+        // the flag when home resolves to a named directory.
+        if home.file_name().is_some() {
+            let (_name, found_home) = folder_name(&home);
+            assert!(found_home);
+        }
     }
 
     #[test]

--- a/src/tab.rs
+++ b/src/tab.rs
@@ -2861,12 +2861,12 @@ fn folder_name<P: AsRef<Path>>(path: P) -> (String, bool) {
                 found_home = true;
                 fl!("home")
             } else {
-                match (get_filename_from_path(path), fs::metadata(path)) {
-                    (Ok(name), Ok(metadata)) => {
-                        let is_gvfs = fs_kind(&metadata) == FsKind::Gvfs;
-                        display_name_for_file(path, &name, is_gvfs, false)
-                    }
-                    _ => name.to_string_lossy().into_owned(),
+                // Name from the path component only. folder_name runs on the GUI thread for
+                // every tab title and breadcrumb, so it must not stat (which a gvfs friendly-
+                // name lookup would do, blocking on slow mounts).
+                match get_filename_from_path(path) {
+                    Ok(name) => display_name_for_file(path, &name, false, false),
+                    Err(_) => name.to_string_lossy().into_owned(),
                 }
             }
         }
@@ -7379,7 +7379,7 @@ fn text_editor_class(
 
 #[cfg(test)]
 mod tests {
-    use std::path::PathBuf;
+    use std::path::{Path, PathBuf};
     use std::{fs, io};
 
     use cosmic::iced::mouse::ScrollDelta;
@@ -7391,7 +7391,8 @@ mod tests {
     use test_log::test;
 
     use super::{
-        ItemMetadata, ItemThumbnail, Location, Message, Tab, respond_to_scroll_direction, scan_path,
+        ItemMetadata, ItemThumbnail, Location, Message, Tab, folder_name,
+        respond_to_scroll_direction, scan_path,
     };
     use crate::app::test_utils::{
         NAME_LEN, NUM_DIRS, NUM_FILES, NUM_HIDDEN, NUM_NESTED, assert_eq_tab_path, empty_fs,
@@ -7534,6 +7535,37 @@ mod tests {
         assert!(actual.is_empty());
 
         Ok(())
+    }
+
+    #[test]
+    fn folder_name_derives_last_path_component() {
+        // No '.' or '_' in the component, so Item::display_name leaves it untouched.
+        let (name, found_home) = folder_name("/srv/data/Projects");
+        assert_eq!(name, "Projects");
+        assert!(!found_home);
+    }
+
+    #[test]
+    fn folder_name_does_not_stat_the_path() {
+        // A non-existent path still yields its final component: the name comes from the path
+        // alone, with no stat (which is what keeps folder_name safe on the GUI thread).
+        let missing = "/this/path/does/not/exist/Documents";
+        assert!(!Path::new(missing).exists());
+
+        let (name, found_home) = folder_name(missing);
+        assert_eq!(name, "Documents");
+        assert!(!found_home);
+    }
+
+    #[test]
+    fn folder_name_flags_the_home_directory() {
+        let home = crate::home_dir();
+        // The "/" fallback (no resolvable home) has no final component to match; only assert
+        // the flag when home resolves to a named directory.
+        if home.file_name().is_some() {
+            let (_name, found_home) = folder_name(&home);
+            assert!(found_home);
+        }
     }
 
     #[test]

--- a/src/trash.rs
+++ b/src/trash.rs
@@ -2,12 +2,30 @@ use cosmic::widget;
 use regex::Regex;
 use std::collections::HashSet;
 use std::path::PathBuf;
+use std::sync::atomic::{AtomicBool, Ordering};
 
 use crate::config::IconSizes;
 use crate::tab::{Item, SearchItem};
 
+/// Cached trash empty/full state. The real check walks every mount and blocks on slow ones,
+/// so it runs off-thread via [`TrashExt::refresh_is_empty`]; GUI code reads the cache via
+/// [`TrashExt::is_empty_cached`].
+static TRASH_IS_EMPTY: AtomicBool = AtomicBool::new(true);
+
 pub trait TrashExt {
     fn is_empty() -> bool {
+        true
+    }
+
+    /// Last known empty state, read without touching the filesystem. Safe on the GUI thread.
+    fn is_empty_cached() -> bool {
+        TRASH_IS_EMPTY.load(Ordering::Relaxed)
+    }
+
+    /// Recompute and cache the state, returning the fresh value. Blocks on I/O across every
+    /// mount — call only from a background thread.
+    fn refresh_is_empty() -> bool {
+        TRASH_IS_EMPTY.store(true, Ordering::Relaxed);
         true
     }
 
@@ -28,8 +46,9 @@ pub trait TrashExt {
 
     fn scan_search<F: Fn(SearchItem) -> bool + Sync>(_callback: F, _regex: &Regex) {}
 
+    // Icons read the cached empty state so they are safe to build on the GUI thread.
     fn icon(icon_size: u16) -> widget::icon::Handle {
-        widget::icon::from_name(if Self::is_empty() {
+        widget::icon::from_name(if Self::is_empty_cached() {
             "user-trash"
         } else {
             "user-trash-full"
@@ -39,7 +58,7 @@ pub trait TrashExt {
     }
 
     fn icon_symbolic(icon_size: u16) -> widget::icon::Handle {
-        widget::icon::from_name(if Self::is_empty() {
+        widget::icon::from_name(if Self::is_empty_cached() {
             "user-trash-symbolic"
         } else {
             "user-trash-full-symbolic"
@@ -62,8 +81,15 @@ pub struct Trash;
     )
 ))]
 impl TrashExt for Trash {
+    // Walks the trash dir on every mount and blocks on slow ones; never call on the GUI thread.
     fn is_empty() -> bool {
         trash::os_limited::is_empty().unwrap_or(true)
+    }
+
+    fn refresh_is_empty() -> bool {
+        let is_empty = Self::is_empty();
+        TRASH_IS_EMPTY.store(is_empty, Ordering::Relaxed);
+        is_empty
     }
 
     fn entries() -> usize {

--- a/src/trash.rs
+++ b/src/trash.rs
@@ -2,6 +2,7 @@ use cosmic::widget;
 use regex::Regex;
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicBool, Ordering};
 
 use crate::config::IconSizes;
 use crate::tab::{Item, SearchItem};
@@ -25,8 +26,25 @@ fn percent_decode(s: &str) -> Option<String> {
     Some(r)
 }
 
+/// Cached trash empty/full state. The real check walks every mount and blocks on slow ones,
+/// so it runs off-thread via [`TrashExt::refresh_is_empty`]; GUI code reads the cache via
+/// [`TrashExt::is_empty_cached`].
+static TRASH_IS_EMPTY: AtomicBool = AtomicBool::new(true);
+
 pub trait TrashExt {
     fn is_empty() -> bool {
+        true
+    }
+
+    /// Last known empty state, read without touching the filesystem. Safe on the GUI thread.
+    fn is_empty_cached() -> bool {
+        TRASH_IS_EMPTY.load(Ordering::Relaxed)
+    }
+
+    /// Recompute and cache the state, returning the fresh value. Blocks on I/O across every
+    /// mount — call only from a background thread.
+    fn refresh_is_empty() -> bool {
+        TRASH_IS_EMPTY.store(true, Ordering::Relaxed);
         true
     }
 
@@ -47,8 +65,9 @@ pub trait TrashExt {
 
     fn scan_search<F: Fn(SearchItem) -> bool + Sync>(_callback: F, _regex: &Regex) {}
 
+    // Icons read the cached empty state so they are safe to build on the GUI thread.
     fn icon(icon_size: u16) -> widget::icon::Handle {
-        widget::icon::from_name(if Self::is_empty() {
+        widget::icon::from_name(if Self::is_empty_cached() {
             "user-trash"
         } else {
             "user-trash-full"
@@ -58,7 +77,7 @@ pub trait TrashExt {
     }
 
     fn icon_symbolic(icon_size: u16) -> widget::icon::Handle {
-        widget::icon::from_name(if Self::is_empty() {
+        widget::icon::from_name(if Self::is_empty_cached() {
             "user-trash-symbolic"
         } else {
             "user-trash-full-symbolic"
@@ -121,8 +140,15 @@ pub struct Trash;
     )
 ))]
 impl TrashExt for Trash {
+    // Walks the trash dir on every mount and blocks on slow ones; never call on the GUI thread.
     fn is_empty() -> bool {
         trash::os_limited::is_empty().unwrap_or(true)
+    }
+
+    fn refresh_is_empty() -> bool {
+        let is_empty = Self::is_empty();
+        TRASH_IS_EMPTY.store(is_empty, Ordering::Relaxed);
+        is_empty
     }
 
     fn entries() -> usize {


### PR DESCRIPTION
## Summary

On systems with slow or network-backed mounts (NTFS via `ntfs-3g`, CIFS/NFS
automounts), cosmic-files could freeze for many seconds — **over a minute at
startup**, and **~12 s after deleting a file**. The freezes were synchronous
filesystem calls made directly on the GUI (`update`/`view`/`init`) thread,
which block until the slow or cold mount responds.

## Root cause

The Elm/iced architecture requires `update`/`view`/`init` to stay non-blocking
— all I/O belongs in `Task`s. A handful of "convenience" synchronous calls
bypassed that and blocked the UI thread:

- **Trash empty/full check (the main culprit).** `Trash::is_empty`/`list` walk
  the trash directory on **every mounted filesystem**. This ran while building
  the nav bar, both context menus, and the post-operation trash rescan. On a
  cold network mount each call blocks ~12 s; at startup the nav bar is rebuilt
  several times in a row, turning into a minute-plus freeze.
- Nav favorites were `is_dir`-stat'd to pick an icon.
- `folder_name` (tab titles + breadcrumbs) stat'd the path.
- `delete()` stat'd each path to choose trash vs permanent-delete.
- `NotifyEvents` stat'd changed paths inline.

## Changes

- Trash empty/full state is cached (`Trash::is_empty_cached()`) and refreshed
  off-thread (`spawn_blocking`) at startup, on the trash watcher, and after
  operations. The nav bar, menus, and post-delete handler read the cache.
- Nav favorites use the folder icon directly (no `is_dir` stat).
- `folder_name` derives the name from the path with no stat / GIO query.
- `delete()` classifies trash-vs-permanent-delete in a background task.
- `NotifyEvents` reloads through the existing off-thread rescan instead of an
  inline `fs::metadata`.

## Behavior notes / trade-offs

- Favorites always show the folder icon (a file bookmark would no longer show a
  file icon).
- gvfs mounts show their path-component name in titles/breadcrumbs rather than
  the GIO "friendly" display name.
- A metadata-only change in the current directory now triggers a background
  rescan rather than an in-place item update — consistent with how
  create/remove/rename watcher events already behaved.

## Testing

- Reproduced and confirmed fixed on a machine with NTFS (`ntfs-3g`) drives and a
  CIFS automount: startup is instant and deletes no longer freeze.
- `cargo test` (42 passing, including new `folder_name` no-stat regression
  tests), `cargo clippy` clean, release build succeeds.

## AI assistance

This change was developed with AI assistance (Claude Code); it is disclosed in
the commit message per the contribution guidelines. All changes have been
reviewed and are understood by the author.

## Checklist

- [x] I have disclosed use of any AI generated code in my commit messages.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.
