### PR TITLE
Fix folder named `files` being shown as empty

### DIFF
--- a/src/trash.rs
+++ b/src/trash.rs
@@ -105,7 +105,15 @@ pub fn original_path_for_trash_child(p: &Path) -> Option<PathBuf> {
 
 /// Check whether a path is inside any trash `files/` directory.
 pub fn is_trash_path(path: &Path) -> bool {
-    path.ancestors().any(|a| a.ends_with("files"))
+    path.ancestors().any(is_trash_files_dir)
+}
+
+/// Whether `dir` is the `files/` directory of an XDG trash bin: it is named
+/// `files` and has the sibling `info/` directory that the FreeDesktop trash
+/// specification requires. This distinguishes a real trash bin from an ordinary
+/// user folder that merely happens to be named `files`.
+fn is_trash_files_dir(dir: &Path) -> bool {
+    dir.ends_with("files") && dir.parent().is_some_and(|bin| bin.join("info").is_dir())
 }
 
 pub struct Trash;
@@ -202,3 +210,45 @@ impl TrashExt for Trash {
     )
 )))]
 impl TrashExt for Trash {}
+
+#[cfg(test)]
+mod tests {
+    use super::is_trash_path;
+    use std::fs;
+    use tempfile::tempdir;
+
+    #[test]
+    fn plain_folder_named_files_is_not_trash() {
+        let tmp = tempdir().unwrap();
+        let files = tmp.path().join("files");
+        let child = files.join("child.txt");
+        fs::create_dir(&files).unwrap();
+        fs::write(&child, b"").unwrap();
+
+        assert!(!is_trash_path(&files));
+        assert!(!is_trash_path(&child));
+    }
+
+    #[test]
+    fn trash_files_dir_with_sibling_info_is_trash() {
+        let tmp = tempdir().unwrap();
+        let bin = tmp.path().join("Trash");
+        let files = bin.join("files");
+        fs::create_dir_all(&files).unwrap();
+        fs::create_dir_all(bin.join("info")).unwrap();
+
+        assert!(is_trash_path(&files));
+        assert!(is_trash_path(&files.join("deleted.txt")));
+        assert!(is_trash_path(&files.join("dir/nested.txt")));
+    }
+
+    #[test]
+    fn files_dir_without_info_dir_is_not_trash() {
+        let tmp = tempdir().unwrap();
+        let files = tmp.path().join("files");
+        fs::create_dir(&files).unwrap();
+        fs::write(tmp.path().join("info"), b"").unwrap();
+
+        assert!(!is_trash_path(&files));
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #1903.

A folder literally named `files` was displayed as **"Empty folder"** in COSMIC Files, even when it had contents (the parent view still showed the correct item count). `is_trash_path` treated any path with an ancestor component named `files` as being inside the Trash, so every child of such a folder was routed through the trash-item reconstruction path (`item_from_trash_child` → `original_path_for_trash_child`), which returns `None` for entries that have no `.trashinfo` metadata — emptying the listing.

This affects any directory named exactly `files` and all of its descendants (e.g. `/var/www/html/files`), not just top-level folders. Introduced by 4910718 ("feat: view folder's content in trash").

The fix restricts `is_trash_path` to a `files/` directory that also has the sibling `info/` directory mandated by the [FreeDesktop trash specification](https://specifications.freedesktop.org/trash-spec/latest/), so an ordinary folder named `files` is no longer mistaken for the Trash while the real Trash (which always has both `files/` and `info/`) still is.

**Testing:** added unit tests in `src/trash.rs` covering the regression (a plain folder named `files` is not trash), a real trash layout (`files/` + `info/` is trash, including nested paths), and the guard where a sibling `info` is a regular file. `cargo test --lib trash::` passes.

---

- [x] I have disclosed use of any AI generated code in my commit messages.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.
