### PR TITLE
Fix "open archive" button

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -791,23 +791,13 @@ impl App {
         // This allows handling paths as groups if possible, such as launching a single video
         // player that is passed every path.
         let mut groups: FxHashMap<Mime, Vec<PathBuf>> = FxHashMap::default();
-        let mut all_archives = true;
-        let supported_archive_types = crate::archive::SUPPORTED_ARCHIVE_TYPES;
         for (mime, path) in paths.iter().map(|path| {
             (
                 mime_icon::mime_for_path(path, None, false),
                 path.as_ref().to_owned(),
             )
         }) {
-            if all_archives && !supported_archive_types.iter().copied().any(|t| mime == t) {
-                all_archives = false;
-            }
             groups.entry(mime).or_default().push(path);
-        }
-
-        if all_archives {
-            // Use extract to dialog if all selected paths are supported archives
-            return self.extract_to(paths);
         }
 
         'outer: for (mime, paths) in groups {


### PR DESCRIPTION
- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

#be67fd8e This old commit made 'Open' (archive) behave like 'Extract To', which is very strange, duplicates behavior, and is just confusing. Restored the expected behavior
<img width="481" height="583" alt="image" src="https://github.com/user-attachments/assets/173d8a86-d216-4216-86f2-473f7a106f4b" />
