### PR TITLE
Keep the selection when leaving a folder from the breadcrumb

### DIFF
--- a/src/tab.rs
+++ b/src/tab.rs
@@ -4881,8 +4881,12 @@ impl Tab {
                 if location != self.location || selected_paths.is_some() {
                     if location.path_opt().is_none_or(|path| path.is_dir()) {
                         if selected_paths.is_none() {
-                            selected_paths =
-                                self.location.path_opt().map(|path| vec![path.clone()]);
+                            selected_paths = self.location.path_opt().and_then(|old| {
+                                let new = location.path_opt()?;
+                                old.ancestors()
+                                    .find(|ancestor| ancestor.parent() == Some(new.as_path()))
+                                    .map(|ancestor| vec![ancestor.to_path_buf()])
+                            });
                         }
                         self.change_location(&location, history_i_opt);
                         commands.push(Command::ChangeLocation(


### PR DESCRIPTION
The folder that was left behind is selected by passing the old location to
`select_paths`, which matches the paths it is given against the direct children
of the folder being opened. The old location is only a direct child of that
folder when going up a single level, so jumping several levels at once from the
breadcrumb matched nothing and the selection was lost.

The ancestor of the old location that is a direct child of the folder being
opened is selected instead. Going up one level still selects the same path as
before, and nothing is selected when the two locations are unrelated.

Leaving `/home/u/proy/src/api`:

| opening | before | after |
| --- | --- | --- |
| `/home/u/proy/src` | `api` | `api` |
| `/home/u/proy` | nothing | `src` |
| `/home/u` | nothing | `proy` |
| `/tmp` | nothing | nothing |

Fixes #1890

- [x] I have disclosed use of any AI generated code in my commit messages.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.
