### PR TITLE
fix: fall back to GIO on destination open failure for MTP copies

### DIFF
--- a/src/operation/recursive.rs
+++ b/src/operation/recursive.rs
@@ -479,7 +479,7 @@ impl Op {
             #[cfg(not(feature = "gvfs"))]
             Err(why) => {
                 _ = from_file.close().await;
-                return Err(why).with_context(|| format!("failed to open {} for writing", self.to.display()));
+                return Err(why).with_context(|| format!("failed to open {} for writing", self.to.display())).map_err(Into::into);
             }
             #[cfg(feature = "gvfs")]
             Err(_why) => {

--- a/src/operation/recursive.rs
+++ b/src/operation/recursive.rs
@@ -479,11 +479,7 @@ impl Op {
             #[cfg(not(feature = "gvfs"))]
             Err(why) => {
                 _ = from_file.close().await;
-                return Err(anyhow::anyhow!(
-                    "failed to open {} for writing: {}",
-                    self.to.display(),
-                    why
-                ).into());
+                return Err(why).with_context(|| format!("failed to open {} for writing", self.to.display()));
             }
             #[cfg(feature = "gvfs")]
             Err(_why) => {

--- a/src/operation/recursive.rs
+++ b/src/operation/recursive.rs
@@ -500,7 +500,7 @@ impl Op {
                 return self
                     .gio_file_copy(ctx, progress)
                     .await
-                    .map(|_| true)
+                    .map(|()| true)
                     .map_err(Into::into);
             }
         };

--- a/src/operation/recursive.rs
+++ b/src/operation/recursive.rs
@@ -453,7 +453,11 @@ impl Op {
             }
         }
 
-        let (from_file, metadata, to_file) = cosmic::iced::futures::join!(
+        // Open source and destination files using compio.
+        // If the destination is on a GVfs FUSE mount (e.g., MTP device), compio's
+        // io_uring/IOCP backend may fail to open or write to it. In that case,
+        // we fall back to gio::File which uses the GVfs D-Bus backend directly.
+        let (from_file_open_result, metadata, to_file_open_result) = cosmic::iced::futures::join!(
             async {
                 compio::fs::OpenOptions::new()
                     .read(true)
@@ -469,12 +473,37 @@ impl Op {
                     .write(true)
                     .open(&self.to)
                     .await
-                    .with_context(|| format!("failed to open {} for writing", self.to.display()))
             }
         );
 
-        let from_file = from_file?;
-        let mut to_file = to_file?;
+        let from_file = from_file_open_result?;
+
+        let mut to_file = match to_file_open_result {
+            Ok(file) => file,
+            #[cfg(not(feature = "gvfs"))]
+            Err(why) => {
+                _ = from_file.close().await;
+                return Err(anyhow::anyhow!(
+                    "failed to open {} for writing: {}",
+                    self.to.display(),
+                    why
+                ).into());
+            }
+            #[cfg(feature = "gvfs")]
+            Err(why) => {
+                tracing::warn!(
+                    "compio failed to open {} for writing: {}. Falling back to gio.",
+                    self.to.display(),
+                    why
+                );
+                _ = from_file.close().await;
+                return self
+                    .gio_file_copy(ctx, progress)
+                    .await
+                    .map(|_| true)
+                    .map_err(Into::into);
+            }
+        };
         progress.total_bytes = metadata.as_ref().map(|m| m.len());
         (ctx.on_progress)(self, &progress);
 

--- a/src/operation/recursive.rs
+++ b/src/operation/recursive.rs
@@ -453,10 +453,6 @@ impl Op {
             }
         }
 
-        // Open source and destination files using compio.
-        // If the destination is on a GVfs FUSE mount (e.g., MTP device), compio's
-        // io_uring/IOCP backend may fail to open or write to it. In that case,
-        // we fall back to gio::File which uses the GVfs D-Bus backend directly.
         let (from_file_open_result, metadata, to_file_open_result) = cosmic::iced::futures::join!(
             async {
                 compio::fs::OpenOptions::new()

--- a/src/operation/recursive.rs
+++ b/src/operation/recursive.rs
@@ -486,12 +486,7 @@ impl Op {
                 ).into());
             }
             #[cfg(feature = "gvfs")]
-            Err(why) => {
-                tracing::warn!(
-                    "compio failed to open {} for writing: {}. Falling back to gio.",
-                    self.to.display(),
-                    why
-                );
+            Err(_why) => {
                 _ = from_file.close().await;
                 return self
                     .gio_file_copy(ctx, progress)


### PR DESCRIPTION
When copying files to an MTP device mounted via GVfs FUSE, compio's io_uring backend fails to open the destination file with O_CREAT|O_EXCL. The existing gio_file_copy fallback only triggered on write_at failures, so the error propagated before GIO was ever tried.

Now, if the destination open fails via compio, we fall back to gio_file_copy (which uses POSIX I/O through GIO), matching the same fallback pattern already used for write_at Unsupported errors.

Fixes https://github.com/pop-os/cosmic-files/issues/1782

- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

