### PR TITLE
Add binary-based size format and make it default

### DIFF
--- a/i18n/en/cosmic_files.ftl
+++ b/i18n/en/cosmic_files.ftl
@@ -310,6 +310,7 @@ error = Error
 ## Settings
 settings = Settings
 single-click = Single click to open
+use-binary-units = Use binary file size units (KiB, MiB, GiB)
 show-recents = Recents folder in the sidebar
 
 ### Appearance

--- a/i18n/ru/cosmic_files.ftl
+++ b/i18n/ru/cosmic_files.ftl
@@ -314,6 +314,7 @@ item-modified = Дата изменения: { $modified }
 item-accessed = Дата доступа: { $accessed }
 calculating = Вычисление…
 single-click = Открывать одним нажатием
+use-binary-units = Двоичные единицы размера файлов (КиБ, МиБ, ГиБ)
 type-to-search = Поле поиска
 type-to-search-recursive = Поиск в текущей папке и подпапках
 type-to-search-enter-path = Ввод пути к каталогу или файлу

--- a/src/app.rs
+++ b/src/app.rs
@@ -2149,9 +2149,14 @@ impl App {
         let mut children = Vec::with_capacity(1);
         let entity = entity_opt.unwrap_or_else(|| self.tab_model.active());
         let military_time = self.config.tab.military_time;
+        let use_binary_units = self.config.tab.use_binary_units;
         match kind {
             PreviewKind::Custom(PreviewItem(item)) => {
-                children.push(item.preview_view(Some(&self.mime_app_cache), military_time));
+                children.push(item.preview_view(
+                    Some(&self.mime_app_cache),
+                    military_time,
+                    use_binary_units,
+                ));
             }
             PreviewKind::Location(location) => {
                 if let Some(tab) = self.tab_model.data::<Tab>(entity)
@@ -2159,8 +2164,11 @@ impl App {
                 {
                     for item in items {
                         if item.location_opt.as_ref() == Some(location) {
-                            children
-                                .push(item.preview_view(Some(&self.mime_app_cache), military_time));
+                            children.push(item.preview_view(
+                                Some(&self.mime_app_cache),
+                                military_time,
+                                use_binary_units,
+                            ));
                             // Only show one property view to avoid issues like hangs when generating
                             // preview images on thousands of files
                             break;
@@ -2181,9 +2189,11 @@ impl App {
                                 Some(tab.multi_preview_view(Some(&self.mime_app_cache)))
                             }
                             // Exactly one selected item
-                            (Some(item), None) => {
-                                Some(item.preview_view(Some(&self.mime_app_cache), military_time))
-                            }
+                            (Some(item), None) => Some(item.preview_view(
+                                Some(&self.mime_app_cache),
+                                military_time,
+                                use_binary_units,
+                            )),
                             // No selected items
                             _ => None,
                         }
@@ -2196,7 +2206,11 @@ impl App {
                     if children.is_empty()
                         && let Some(item) = &tab.parent_item_opt
                     {
-                        children.push(item.preview_view(Some(&self.mime_app_cache), military_time));
+                        children.push(item.preview_view(
+                            Some(&self.mime_app_cache),
+                            military_time,
+                            use_binary_units,
+                        ));
                     }
                 }
             }
@@ -2266,6 +2280,17 @@ impl App {
                         move |single_click| {
                             Message::TabConfig(TabConfig {
                                 single_click,
+                                ..tab_config
+                            })
+                        },
+                    )
+                })
+                .add({
+                    settings::item::builder(fl!("use-binary-units")).toggler(
+                        tab_config.use_binary_units,
+                        move |use_binary_units| {
+                            Message::TabConfig(TabConfig {
+                                use_binary_units,
                                 ..tab_config
                             })
                         },
@@ -6197,15 +6222,16 @@ impl Application for App {
                 tx,
             } => {
                 let military_time = self.config.tab.military_time;
+                let use_binary_units = self.config.tab.use_binary_units;
                 let dialog = widget::dialog()
                     .title(fl!("replace-title", filename = to.name.as_str()))
                     .body(fl!("replace-warning-operation"))
                     .control(
-                        to.replace_view(fl!("original-file"), military_time)
+                        to.replace_view(fl!("original-file"), military_time, use_binary_units)
                             .map(|x| Message::TabMessage(None, x)),
                     )
                     .control(
-                        from.replace_view(fl!("replace-with"), military_time)
+                        from.replace_view(fl!("replace-with"), military_time, use_binary_units)
                             .map(|x| Message::TabMessage(None, x)),
                     )
                     .primary_action(

--- a/src/config.rs
+++ b/src/config.rs
@@ -346,7 +346,7 @@ impl Default for TabConfig {
             military_time: false,
             show_hidden: false,
             single_click: false,
-            use_binary_units: true,
+            use_binary_units: false,
             view: View::List,
         }
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -210,6 +210,7 @@ impl Config {
             military_time: self.tab.military_time,
             show_hidden: self.dialog.show_hidden,
             single_click: false,
+            use_binary_units: self.tab.use_binary_units,
             view: self.dialog.view,
         }
     }
@@ -331,6 +332,8 @@ pub struct TabConfig {
     pub show_hidden: bool,
     /// Single click to open
     pub single_click: bool,
+    /// Format file sizes using binary units such as KiB and MiB
+    pub use_binary_units: bool,
     /// Selected view, grid or list
     pub view: View,
 }
@@ -343,6 +346,7 @@ impl Default for TabConfig {
             military_time: false,
             show_hidden: false,
             single_click: false,
+            use_binary_units: true,
             view: View::List,
         }
     }

--- a/src/dialog.rs
+++ b/src/dialog.rs
@@ -682,16 +682,17 @@ impl App {
 
     fn preview<'a>(&'a self, kind: &'a PreviewKind) -> Element<'a, tab::Message> {
         let military_time = self.tab.config.military_time;
+        let use_binary_units = self.tab.config.use_binary_units;
         let mut children = Vec::with_capacity(1);
         match kind {
             PreviewKind::Custom(PreviewItem(item)) => {
-                children.push(item.preview_view(None, military_time));
+                children.push(item.preview_view(None, military_time, use_binary_units));
             }
             PreviewKind::Location(location) => {
                 if let Some(items) = self.tab.items_opt() {
                     for item in items {
                         if item.location_opt.as_ref() == Some(location) {
-                            children.push(item.preview_view(None, military_time));
+                            children.push(item.preview_view(None, military_time, use_binary_units));
                             // Only show one property view to avoid issues like hangs when generating
                             // preview images on thousands of files
                             break;
@@ -708,7 +709,9 @@ impl App {
                             // At least two selected items
                             (Some(_), Some(_)) => Some(self.tab.multi_preview_view(None)),
                             // Exactly one selected item
-                            (Some(item), None) => Some(item.preview_view(None, military_time)),
+                            (Some(item), None) => {
+                                Some(item.preview_view(None, military_time, use_binary_units))
+                            }
                             // No selected items
                             _ => None,
                         }
@@ -721,7 +724,7 @@ impl App {
                     if children.is_empty()
                         && let Some(item) = &self.tab.parent_item_opt
                     {
-                        children.push(item.preview_view(None, military_time));
+                        children.push(item.preview_view(None, military_time, use_binary_units));
                     }
                 }
             }

--- a/src/tab.rs
+++ b/src/tab.rs
@@ -345,24 +345,21 @@ fn tab_complete(path: &Path) -> Result<Vec<(String, PathBuf)>, Box<dyn Error>> {
     Ok(completions)
 }
 
-//TODO: translate, add more levels?
-fn format_size(size: u64) -> String {
-    const KB: u64 = 1000;
-    const MB: u64 = 1000 * KB;
-    const GB: u64 = 1000 * MB;
-    const TB: u64 = 1000 * GB;
-
-    if size >= TB {
-        format!("{:.1} TB", size as f64 / TB as f64)
-    } else if size >= GB {
-        format!("{:.1} GB", size as f64 / GB as f64)
-    } else if size >= MB {
-        format!("{:.1} MB", size as f64 / MB as f64)
-    } else if size >= KB {
-        format!("{:.1} KB", size as f64 / KB as f64)
+fn format_size(size: u64, use_binary_units: bool) -> String {
+    let (base, units): (u64, [&str; 4]) = if use_binary_units {
+        (1024, ["KiB", "MiB", "GiB", "TiB"])
     } else {
-        format!("{size} B")
+        (1000, ["KB", "MB", "GB", "TB"])
+    };
+
+    for (index, unit) in units.iter().enumerate().rev() {
+        let divisor = base.pow((index + 1) as u32);
+        if size >= divisor {
+            return format!("{:.1} {unit}", size as f64 / divisor as f64);
+        }
     }
+
+    format!("{size} B")
 }
 
 const MODE_SHIFT_USER: u32 = 6;
@@ -2001,8 +1998,8 @@ impl ItemThumbnail {
                     "skipping internal {} thumbnailer for {}: file size {} is larger than {}",
                     thumbnailer,
                     path.display(),
-                    format_size(size),
-                    format_size(max_size)
+                    format_size(size, true),
+                    format_size(max_size, true)
                 );
                 false
             }
@@ -2411,6 +2408,7 @@ impl Item {
         &'a self,
         mime_app_cache_opt: Option<&'a mime_app::MimeAppCache>,
         military_time: bool,
+        use_binary_units: bool,
     ) -> Element<'a, Message> {
         let cosmic_theme::Spacing {
             space_xxxs,
@@ -2466,7 +2464,7 @@ impl Item {
                 }
                 let size = match &self.dir_size {
                     DirSize::Calculating(_) => fl!("calculating"),
-                    DirSize::Directory(size) => format_size(*size),
+                    DirSize::Directory(size) => format_size(*size, use_binary_units),
                     DirSize::NotDirectory => String::new(),
                     DirSize::Error(err) => err.clone(),
                 };
@@ -2476,7 +2474,7 @@ impl Item {
             } else {
                 details = details.push(widget::text::body(fl!(
                     "item-size",
-                    size = format_size(metadata.len())
+                    size = format_size(metadata.len(), use_binary_units)
                 )));
             }
 
@@ -2646,7 +2644,12 @@ impl Item {
         column.into()
     }
 
-    pub fn replace_view(&self, heading: String, military_time: bool) -> Element<'_, Message> {
+    pub fn replace_view(
+        &self,
+        heading: String,
+        military_time: bool,
+        use_binary_units: bool,
+    ) -> Element<'_, Message> {
         let cosmic_theme::Spacing { space_xxxs, .. } = theme::spacing();
 
         let mut row = widget::row::with_capacity(2).spacing(space_xxxs);
@@ -2669,7 +2672,7 @@ impl Item {
             } else {
                 column = column.push(widget::text::body(format!(
                     "Size: {}",
-                    format_size(metadata.len())
+                    format_size(metadata.len(), use_binary_units)
                 )));
             }
             if let Ok(time) = metadata.modified() {
@@ -6002,6 +6005,7 @@ impl Tab {
         let TabConfig {
             show_hidden,
             icon_sizes,
+            use_binary_units,
             ..
         } = self.config;
 
@@ -6105,7 +6109,7 @@ impl Tab {
                                     String::new()
                                 }
                             } else {
-                                format_size(metadata.len())
+                                format_size(metadata.len(), use_binary_units)
                             }
                         }
                         ItemMetadata::Trash { metadata, .. } => match metadata.size {
@@ -6117,7 +6121,9 @@ impl Tab {
                                     format!("{entries} items")
                                 }
                             }
-                            trash::TrashItemSize::Bytes(bytes) => format_size(bytes),
+                            trash::TrashItemSize::Bytes(bytes) => {
+                                format_size(bytes, use_binary_units)
+                            }
                         },
                         ItemMetadata::SimpleDir { entries } => {
                             //TODO: translate
@@ -6127,7 +6133,7 @@ impl Tab {
                                 format!("{entries} items")
                             }
                         }
-                        ItemMetadata::SimpleFile { size } => format_size(*size),
+                        ItemMetadata::SimpleFile { size } => format_size(*size, use_binary_units),
                         #[cfg(feature = "gvfs")]
                         ItemMetadata::GvfsPath {
                             size_opt,
@@ -6141,7 +6147,7 @@ impl Tab {
                                     format!("{child_count} items")
                                 }
                             }
-                            None => format_size(size_opt.unwrap_or_default()),
+                            None => format_size(size_opt.unwrap_or_default(), use_binary_units),
                         },
                     };
 
@@ -6734,7 +6740,7 @@ impl Tab {
             } else if let Some(error) = dir_size_error {
                 error
             } else {
-                format_size(total_size)
+                format_size(total_size, self.config.use_binary_units)
             }
         };
 


### PR DESCRIPTION
Introduce binary size units as the default display format. Add a settings preference to allow switching back to decimal prefixes.

- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.


<img width="646" height="753" alt="image" src="https://github.com/user-attachments/assets/2d378b6d-1fd6-4beb-adc2-63177d6d0a96" />
<img width="646" height="753" alt="image" src="https://github.com/user-attachments/assets/aff4ca64-4671-421a-8654-68b1277c7f31" />

