### PR TITLE
i18n(fr): add missing French translations

### DIFF
--- a/i18n/fr/cosmic_files.ftl
+++ b/i18n/fr/cosmic_files.ftl
@@ -316,6 +316,9 @@ item-created = Créé : { $created }
 item-modified = Modifié : { $modified }
 item-accessed = Consulté : { $accessed }
 calculating = Calcul en cours...
+checksum = Somme de contrôle { $kind }
+calculate = Calculer
+error = Erreur
 
 ## Settings
 


### PR DESCRIPTION
Adds the three French translations that were missing from `i18n/fr/cosmic_files.ftl`: `checksum`, `calculate` and `error`.

This brings the French locale to full parity with `i18n/en` (244/244 keys). The `{ $kind }` variable is preserved, and the spacing follows the convention already used throughout the French file.