### PR TITLE
Honor a per-folder custom icon from .directory (Icon=) — main view + sidebar

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -2650,6 +2650,18 @@ impl Application for App {
     }
 
     fn on_nav_select(&mut self, entity: Entity) -> Task<Self::Message> {
+        // Re-read per-folder `.directory` icons when activating a favorite so the
+        // sidebar picks up icon changes without requiring a new window.
+        if self.nav_model.data::<FavoriteIndex>(entity).is_some()
+            && let Some(Location::Path(path)) = self.nav_model.data::<Location>(entity).cloned()
+            && path.is_dir()
+        {
+            self.nav_model.icon_set(
+                entity,
+                icon::icon(tab::folder_icon_symbolic(&path, 16)).size(16),
+            );
+        }
+
         self.nav_model.activate(entity);
         if let Some(location) = self.nav_model.data::<Location>(entity) {
             let should_open = match location {

--- a/src/app.rs
+++ b/src/app.rs
@@ -1778,14 +1778,16 @@ impl App {
                 };
                 nav_model = nav_model.insert(move |b| {
                     b.text(name.clone())
-                        .icon(
-                            icon::icon(if path.is_dir() {
-                                tab::folder_icon_symbolic(&path, 16)
-                            } else {
-                                icon::from_name("text-x-generic-symbolic").size(16).handle()
-                            })
-                            .size(16),
-                        )
+                        .icon(if path.is_dir() {
+                            tab::folder_nav_icon(&path, 16)
+                        } else {
+                            icon::icon(
+                                icon::from_name("text-x-generic-symbolic")
+                                    .size(16)
+                                    .handle(),
+                            )
+                            .size(16)
+                        })
                         .data(match favorite {
                             Favorite::Network { uri, name, path } => {
                                 Location::Network(uri.clone(), name.clone(), Some(path.to_owned()))
@@ -2656,10 +2658,8 @@ impl Application for App {
             && let Some(Location::Path(path)) = self.nav_model.data::<Location>(entity).cloned()
             && path.is_dir()
         {
-            self.nav_model.icon_set(
-                entity,
-                icon::icon(tab::folder_icon_symbolic(&path, 16)).size(16),
-            );
+            self.nav_model
+                .icon_set(entity, tab::folder_nav_icon(&path, 16));
         }
 
         self.nav_model.activate(entity);

--- a/src/dialog.rs
+++ b/src/dialog.rs
@@ -900,16 +900,16 @@ impl App {
                 };
                 nav_model = nav_model.insert(move |b| {
                     b.text(name.clone())
-                        .icon(
-                            widget::icon::icon(if path.is_dir() {
-                                tab::folder_icon_symbolic(&path, 16)
-                            } else {
+                        .icon(if path.is_dir() {
+                            tab::folder_nav_icon(&path, 16)
+                        } else {
+                            widget::icon::icon(
                                 widget::icon::from_name("text-x-generic-symbolic")
                                     .size(16)
-                                    .handle()
-                            })
-                            .size(16),
-                        )
+                                    .handle(),
+                            )
+                            .size(16)
+                        })
                         .data(Location::Path(path.clone()))
                 });
             }

--- a/src/tab.rs
+++ b/src/tab.rs
@@ -320,6 +320,14 @@ pub fn folder_icon_symbolic(path: &PathBuf, icon_size: u16) -> widget::icon::Han
     .handle()
 }
 
+/// Sidebar/nav folder icon that keeps image aspect ratio (pad, don't squash).
+/// Matches the main view, which uses [`ContentFit::Contain`] for item icons.
+pub fn folder_nav_icon(path: &PathBuf, icon_size: u16) -> widget::icon::Icon {
+    widget::icon::icon(folder_icon_symbolic(path, icon_size))
+        .size(icon_size)
+        .content_fit(ContentFit::Contain)
+}
+
 //TODO: replace with Path::has_trailing_sep when stable
 fn has_trailing_sep(path: &Path) -> bool {
     path.as_os_str()

--- a/src/tab.rs
+++ b/src/tab.rs
@@ -279,7 +279,26 @@ fn button_style(
     }
 }
 
+/// Reads a per-folder custom icon from a `.directory` file's `Icon=` key, if
+/// present. This is the freedesktop convention KDE/Dolphin uses, letting apps
+/// (sync clients, project tools) brand a folder. The value is either a themed
+/// icon name or an absolute path to an image, mirroring `desktop_icon_handle`.
+fn custom_folder_icon(path: &Path, icon_size: u16) -> Option<widget::icon::Handle> {
+    let contents = fs::read_to_string(path.join(".directory")).ok()?;
+    let icon = contents
+        .lines()
+        .find_map(|line| line.strip_prefix("Icon="))?
+        .trim();
+    if icon.is_empty() {
+        return None;
+    }
+    Some(desktop_icon_handle(icon, icon_size))
+}
+
 pub fn folder_icon(path: &PathBuf, icon_size: u16) -> widget::icon::Handle {
+    if let Some(handle) = custom_folder_icon(path, icon_size) {
+        return handle;
+    }
     widget::icon::from_name(SPECIAL_DIRS.get(path).map_or("folder", |x| *x))
         .prefer_svg(true)
         .size(icon_size)
@@ -287,6 +306,12 @@ pub fn folder_icon(path: &PathBuf, icon_size: u16) -> widget::icon::Handle {
 }
 
 pub fn folder_icon_symbolic(path: &PathBuf, icon_size: u16) -> widget::icon::Handle {
+    // A custom `.directory` icon (see `custom_folder_icon`) is a branded image,
+    // not part of the symbolic theme, so honor it directly — this is what makes
+    // a branded folder recognizable in the sidebar too, not just the main view.
+    if let Some(handle) = custom_folder_icon(path, icon_size) {
+        return handle;
+    }
     widget::icon::from_name(format!(
         "{}-symbolic",
         SPECIAL_DIRS.get(path).map_or("folder", |x| *x)

--- a/src/tab.rs
+++ b/src/tab.rs
@@ -619,11 +619,53 @@ fn desktop_icon_handle(icon: &str, size: u16) -> widget::icon::Handle {
     if icon_path.is_absolute() && icon_path.exists() {
         widget::icon::from_path(icon_path.to_path_buf())
     } else {
-        widget::icon::from_name(icon)
-            .prefer_svg(true)
-            .size(size)
-            .handle()
+        themed_icon_handle(icon, size)
     }
+}
+
+fn icon_path_is_cosmic_family(path: &Path) -> bool {
+    path.components().any(|c| {
+        matches!(
+            c.as_os_str().to_str(),
+            Some("Cosmic" | "Pop" | "pop-os-branding")
+        )
+    })
+}
+
+/// Resolve a themed icon name with Cosmic fidelity.
+///
+/// Many Cosmic icons exist only as `*-symbolic`. Looking up the bare name can
+/// inherit a foreign full-color icon (e.g. Humanity) via the theme chain, which
+/// looks wrong next to Cosmic UI. Absolute paths are handled by callers and are
+/// unchanged here.
+fn themed_icon_handle(icon: &str, size: u16) -> widget::icon::Handle {
+    let resolve = |name: &str| {
+        let named = widget::icon::from_name(name).prefer_svg(true).size(size);
+        named.clone().path().map(|path| (path, named))
+    };
+
+    if !icon.ends_with("-symbolic") {
+        let symbolic = format!("{icon}-symbolic");
+        match (resolve(icon), resolve(symbolic.as_str())) {
+            (Some((base_path, base_named)), Some((sym_path, sym_named))) => {
+                if icon_path_is_cosmic_family(&base_path) {
+                    return base_named.handle();
+                }
+                if icon_path_is_cosmic_family(&sym_path) {
+                    return sym_named.handle();
+                }
+                return base_named.handle();
+            }
+            (None, Some((_, sym_named))) => return sym_named.handle(),
+            (Some((_, base_named)), None) => return base_named.handle(),
+            (None, None) => {}
+        }
+    }
+
+    widget::icon::from_name(icon)
+        .prefer_svg(true)
+        .size(size)
+        .handle()
 }
 
 #[cfg(feature = "desktop")]

--- a/src/tab.rs
+++ b/src/tab.rs
@@ -625,10 +625,54 @@ fn get_desktop_file_icon(path: &Path) -> Option<String> {
 fn desktop_icon_handle(icon: &str, size: u16) -> widget::icon::Handle {
     let icon_path = Path::new(icon);
     if icon_path.is_absolute() && icon_path.exists() {
-        widget::icon::from_path(icon_path.to_path_buf())
+        icon_handle_from_image_path(icon_path)
     } else {
         themed_icon_handle(icon, size)
     }
+}
+
+/// Load a raster image path as an icon, padding non-square images to a square
+/// with transparent margins. Nav/segmented-button layouts allocate a square
+/// and historically fill it; without padding a wide logo (e.g. 1920×1201)
+/// gets squashed. SVG and already-square rasters keep the cheap path handle.
+fn icon_handle_from_image_path(path: &Path) -> widget::icon::Handle {
+    if path.extension().is_some_and(|ext| ext == "svg") {
+        return widget::icon::from_path(path.to_path_buf());
+    }
+    padded_square_raster_handle(path)
+        .unwrap_or_else(|| widget::icon::from_path(path.to_path_buf()))
+}
+
+fn padded_square_raster_handle(path: &Path) -> Option<widget::icon::Handle> {
+    let img = ImageReader::open(path)
+        .ok()?
+        .with_guessed_format()
+        .ok()?
+        .decode()
+        .ok()?
+        .into_rgba8();
+    let (w, h) = (img.width(), img.height());
+    if w == 0 || h == 0 || w == h {
+        return None;
+    }
+
+    // Cap work for huge brand assets used as tiny sidebar icons.
+    const MAX_SIDE: u32 = 256;
+    let img = if w.max(h) > MAX_SIDE {
+        let scale = MAX_SIDE as f32 / w.max(h) as f32;
+        let nw = ((w as f32) * scale).round().max(1.0) as u32;
+        let nh = ((h as f32) * scale).round().max(1.0) as u32;
+        image::imageops::resize(&img, nw, nh, image::imageops::FilterType::Triangle)
+    } else {
+        img
+    };
+    let (w, h) = (img.width(), img.height());
+    let side = w.max(h);
+    let mut square = image::RgbaImage::new(side, side);
+    let x = (side - w) / 2;
+    let y = (side - h) / 2;
+    image::imageops::overlay(&mut square, &img, i64::from(x), i64::from(y));
+    Some(widget::icon::from_raster_pixels(side, side, square.into_raw()))
 }
 
 fn icon_path_is_cosmic_family(path: &Path) -> bool {


### PR DESCRIPTION
- [x] I have disclosed use of any AI generated code in my commit messages.
  - **AI disclosure:** this PR was developed with AI assistance (Claude / Cursor). I have reviewed the diff in full, tested it on real hardware (Pop!_OS / COSMIC, running as a patched local install), and I maintain the change and respond to review myself.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

---

Lets an app or user brand a folder — the "this folder looks like *X*" effect
Dropbox/Nextcloud/etc. rely on, and that KDE/Dolphin already supports via the
same file. Today COSMIC Files always shows the generic (or special-dir) folder
icon.

`folder_icon()` and `folder_icon_symbolic()` look for a `.directory` file in
the directory and read its `Icon=` key before falling back to the theme folder
icon, resolved through the existing `desktop_icon_handle()` helper (themed name
*or* absolute path — same handling as `.desktop` icons). Because both functions
read it, one `.directory` file brands the folder in the main view **and** its
sidebar favourite entry.

**Scope:** one private helper + an early return in each function. No new
dependencies, no subprocess. `folder_icon()` is the single point all directory
items (filesystem, gvfs, trash) already route through; the read happens once
per item at construction, where mime guessing already runs.

### Follow-up: non-square image icons in the sidebar

Wide raster `Icon=` paths (common for brand logos, e.g. 1920×1201 PNGs) were
still **horizontally squashed** in sidebar favorites even after using
`ContentFit::Contain` for the nav widget.

**Cause:** the nav/segmented-button layout allocates a square icon slot and
draws into it; a non-square image handle still gets forced into that square.

**Fix (`6d01656`):** for absolute-path raster icons, downscale large assets
(cap longest side at 256), then **pad to a square** with transparent margins
before creating the icon handle. SVG and already-square rasters stay on the
cheap `from_path` path. Combined with sidebar `ContentFit::Contain`, the mark
keeps its aspect ratio in both the main view and the sidebar.

Also in this PR:
- Prefer Cosmic/Pop `*-symbolic` theme icons when resolving bare `Icon=` names
- Re-read favorite sidebar icons when activating a nav entry so `.directory`
  changes show without opening a new window

**Try it:**
```
printf '[Desktop Entry]\nIcon=folder-download\n' > ~/somedir/.directory
```
Reopen the parent → `somedir` shows the download-folder icon. An absolute path
(`Icon=/path/to/wide-logo.png`) works too and should no longer look squashed
in the sidebar.

Built and run on Pop!_OS/COSMIC; the icon renders in both the main view and the
sidebar. Happy to also add the GNOME `gio metadata::custom-icon` source behind
the existing gio/gvfs feature in a follow-up if you'd like GNOME parity.

Closes #1427