### PR TITLE
Change focus only if selected tab is closed

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -4405,7 +4405,9 @@ impl Application for App {
                     tasks.push(Task::future(async move {
                         cosmic::action::app(Message::WindowClose)
                     }));
-                } else if let Some(position) = self.tab_model.position(entity) {
+                } else if entity == self.tab_model.active()
+                    && let Some(position) = self.tab_model.position(entity)
+                {
                     let new_position = if position > 0 {
                         position - 1
                     } else {


### PR DESCRIPTION
Closes: #1921

Closing a tab other than the focused tab shouldn't change the focus.

- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

---

This bug might exist in the other tabbed COSMIC apps. I'll port the fix over tomorrow if that's the case.
