### PR TITLE
fix: handle file mtime overflow

### DIFF
--- a/src/tab.rs
+++ b/src/tab.rs
@@ -1909,7 +1909,7 @@ impl ItemMetadata {
             Self::Path { metadata, .. } => metadata.modified().ok(),
             #[cfg(feature = "gvfs")]
             Self::GvfsPath { mtime, .. } => {
-                Some(SystemTime::UNIX_EPOCH + Duration::from_secs(*mtime))
+                SystemTime::UNIX_EPOCH.checked_add(Duration::from_secs(*mtime))
             }
             _ => None,
         }

--- a/src/tab.rs
+++ b/src/tab.rs
@@ -437,7 +437,9 @@ impl<'a> FormatTime<'a> {
 
 impl Display for FormatTime<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let zoned = jiff::Zoned::try_from(self.time).unwrap();
+        let Ok(zoned) = jiff::Zoned::try_from(self.time) else {
+            return Ok(());
+        };
         let now = jiff::Zoned::now();
         let icu_datetime = DateTime::convert_from(zoned.datetime());
         if zoned.date() == now.date() {


### PR DESCRIPTION
Modification time is doing an unchecked add. Files with bad mtime will overflow and crash the app.

Use a checked add instead, returning None and displaying an empty mtime instead.

This only affects mtimes via GVFS. Viewing local files works because it interprets the mtime directly instead of relying on addition.

Fixes #1886 

- [x] I have disclosed use of any AI generated code in my commit messages.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

