### PR TITLE
feat: show item count and total file size in file selection footer

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -6590,15 +6590,17 @@ impl Application for App {
 
         let entity = self.tab_model.active();
         if let Some(tab) = self.tab_model.data::<Tab>(entity) {
+            let footer = self.selection_footer();
             let tab_view = tab
                 .view(
                     &self.key_binds,
                     &self.modifiers,
+                    footer.as_ref().map_or(0, |_| 48),
                     self.clipboard_has_content(),
                     &self.config.context_actions,
                 )
                 .map(move |message| Message::TabMessage(Some(entity), message));
-            let tab_view = if let Some(footer) = self.selection_footer() {
+            let tab_view = if let Some(footer) = footer {
                 stack([
                     tab_view,
                     widget::container(footer)
@@ -6655,6 +6657,7 @@ impl Application for App {
                             .view(
                                 &self.key_binds,
                                 &window.modifiers,
+                                0,
                                 self.clipboard_has_content(),
                                 &self.config.context_actions,
                             )

--- a/src/app.rs
+++ b/src/app.rs
@@ -16,6 +16,7 @@ use cosmic::iced::runtime::{clipboard, task};
 use cosmic::iced::widget::button::focus;
 use cosmic::iced::widget::scrollable;
 use cosmic::iced::widget::scrollable::AbsoluteOffset;
+use cosmic::iced::widget::stack;
 use cosmic::iced::window::{self, Event as WindowEvent, Id as WindowId};
 use cosmic::iced::{
     self, Alignment, Event, Length, Rectangle, Size, Subscription, event, mouse, stream,
@@ -772,6 +773,41 @@ pub struct App {
 }
 
 impl App {
+    fn selection_footer(&self) -> Option<Element<'_, Message>> {
+        if self.core.window.show_context
+            && matches!(
+                self.context_page,
+                ContextPage::Preview(_, PreviewKind::Selected)
+            )
+        {
+            return None;
+        }
+        let tab = self.tab_model.active_data::<Tab>()?;
+        if tab.location.is_trash() {
+            return None;
+        }
+        let stats = tab.selection_stats();
+        if stats.items == 0 {
+            return None;
+        }
+
+        let size = if stats.calculating {
+            fl!("calculating")
+        } else if let Some(error) = stats.error.as_deref() {
+            error.to_owned()
+        } else {
+            tab::format_size(stats.size)
+        };
+        let summary = format!("{} | {}", fl!("items", items = stats.items), size);
+        Some(
+            widget::container(widget::text::body(summary))
+            .width(Length::Fill)
+            .padding([theme::spacing().space_xs, theme::spacing().space_s])
+            .class(theme::Container::Background)
+            .into(),
+        )
+    }
+
     /// Returns true if the clipboard cache contains pasteable content
     fn clipboard_has_content(&self) -> bool {
         !matches!(self.clipboard_cache, ClipboardCache::Empty)
@@ -6562,6 +6598,20 @@ impl Application for App {
                     &self.config.context_actions,
                 )
                 .map(move |message| Message::TabMessage(Some(entity), message));
+            let tab_view = if let Some(footer) = self.selection_footer() {
+                stack([
+                    tab_view,
+                    widget::container(footer)
+                        .width(Length::Fill)
+                        .height(Length::Fill)
+                        .align_x(cosmic::iced::alignment::Horizontal::Center)
+                        .align_y(cosmic::iced::alignment::Vertical::Bottom)
+                        .into(),
+                ])
+                .into()
+            } else {
+                tab_view
+            };
             tab_column = tab_column.push(tab_view);
         } else {
             //TODO
@@ -7098,13 +7148,16 @@ impl Application for App {
             }
         }
 
+        let active_entity = self.tab_model.active();
         subscriptions.extend(self.tab_model.iter().filter_map(|entity| {
             let tab = self.tab_model.data::<Tab>(entity)?;
+            let selection_needs_sizes = entity == active_entity && tab.selection_stats().items > 0;
             Some(
                 tab.subscription(
-                    selected_previews
-                        .iter()
-                        .any(|preview| preview.as_ref() == Some(entity).as_ref()),
+                    selection_needs_sizes
+                        || selected_previews
+                            .iter()
+                            .any(|preview| preview.as_ref() == Some(entity).as_ref()),
                 )
                 .with(entity)
                 .map(|(entity, tab_msg)| Message::TabMessage(Some(entity), tab_msg)),

--- a/src/dialog.rs
+++ b/src/dialog.rs
@@ -2051,7 +2051,7 @@ impl Application for App {
 
         col = col.push(
             self.tab
-                .view(&self.key_binds, &self.modifiers, false, &[])
+                .view(&self.key_binds, &self.modifiers, 0, false, &[])
                 .map(Message::TabMessage),
         );
 

--- a/src/tab.rs
+++ b/src/tab.rs
@@ -6469,6 +6469,7 @@ impl Tab {
         &'a self,
         key_binds: &'a HashMap<KeyBind, Action>,
         modifiers: &'a Modifiers,
+        bottom_inset: u16,
         size: Size,
         clipboard_paste_available: bool,
         context_actions: &'a [ContextActionPreset],
@@ -6581,7 +6582,9 @@ impl Tab {
                 // id_container with custom id forces the state to be extracted in a diff
                 // pre-processing step
                 widget::id_container(
-                    widget::scrollable(popover)
+                    widget::scrollable(
+                        widget::container(popover).padding(padding::bottom(bottom_inset)),
+                    )
                         .id(self.scrollable_id.clone())
                         .on_scroll(Message::Scroll)
                         .width(Length::Fill)
@@ -6972,6 +6975,7 @@ impl Tab {
         &'a self,
         key_binds: &'a HashMap<KeyBind, Action>,
         modifiers: &'a Modifiers,
+        bottom_inset: u16,
         clipboard_paste_available: bool,
         context_actions: &'a [ContextActionPreset],
     ) -> Element<'a, Message> {
@@ -6980,6 +6984,7 @@ impl Tab {
                 self.view_responsive(
                     key_binds,
                     modifiers,
+                    bottom_inset,
                     size,
                     clipboard_paste_available,
                     context_actions,

--- a/src/tab.rs
+++ b/src/tab.rs
@@ -346,7 +346,7 @@ fn tab_complete(path: &Path) -> Result<Vec<(String, PathBuf)>, Box<dyn Error>> {
 }
 
 //TODO: translate, add more levels?
-fn format_size(size: u64) -> String {
+pub(crate) fn format_size(size: u64) -> String {
     const KB: u64 = 1000;
     const MB: u64 = 1000 * KB;
     const GB: u64 = 1000 * MB;
@@ -2321,6 +2321,14 @@ pub struct Item {
     pub checksums: ChecksumState,
 }
 
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct SelectionStats {
+    pub items: usize,
+    pub size: u64,
+    pub calculating: bool,
+    pub error: Option<String>,
+}
+
 impl Item {
     fn display_name(name: &str) -> String {
         // In order to wrap at periods and underscores, add a zero width space after each one
@@ -3038,6 +3046,40 @@ impl Tab {
         } else {
             Vec::new()
         }
+    }
+
+    pub fn selection_stats(&self) -> SelectionStats {
+        let Some(items) = self.items_opt.as_ref() else {
+            return SelectionStats::default();
+        };
+
+        items.iter().filter(|item| item.selected).fold(
+            SelectionStats::default(),
+            |mut stats, item| {
+                stats.items += 1;
+                if let Some(size) = item.metadata.file_size() {
+                    stats.size = stats.size.saturating_add(size);
+                } else if let Some(metadata) = item.file_metadata() {
+                    stats.size = stats.size.saturating_add(if metadata.is_dir() {
+                        match &item.dir_size {
+                            DirSize::Directory(size) => *size,
+                            DirSize::Calculating(_) => {
+                                stats.calculating = true;
+                                0
+                            }
+                            DirSize::Error(error) => {
+                                stats.error = Some(error.clone());
+                                0
+                            }
+                            _ => 0,
+                        }
+                    } else {
+                        metadata.len()
+                    });
+                }
+                stats
+            },
+        )
     }
 
     pub fn select_all(&mut self) {
@@ -6555,13 +6597,33 @@ impl Tab {
                 if let Some(items) = self.items_opt()
                     && !items.is_empty()
                 {
+                    let stats = self.selection_stats();
+                    let info = (stats.items > 0).then(|| {
+                        let size = if stats.calculating {
+                            fl!("calculating")
+                        } else if let Some(error) = stats.error.as_deref() {
+                            error.to_owned()
+                        } else {
+                            format_size(stats.size)
+                        };
+                        widget::text::body(format!(
+                            "{} | {}",
+                            fl!("items", items = stats.items),
+                            size
+                        ))
+                    });
                     tab_column = tab_column.push(
-                        widget::layer_container(widget::row::with_children([
-                            widget::space::horizontal().into(),
-                            widget::button::standard(fl!("empty-trash"))
-                                .on_press(Message::EmptyTrash)
-                                .into(),
-                        ]))
+                        widget::layer_container(
+                            widget::row::with_children([
+                                info.map(Into::into)
+                                    .unwrap_or_else(|| widget::space::horizontal().into()),
+                                widget::space::horizontal().into(),
+                                widget::button::standard(fl!("empty-trash"))
+                                    .on_press(Message::EmptyTrash)
+                                    .into(),
+                            ])
+                            .align_y(Alignment::Center),
+                        )
                         .padding([space_xxs, space_xs])
                         .layer(cosmic_theme::Layer::Primary)
                         .apply(widget::container)


### PR DESCRIPTION
When items are selected, the footer displays the selected item count and total size. Regular file sizes are shown immediately, while folder sizes are calculated asynchronously and update when available. If a folder-size calculation fails, the error is displayed instead of reporting an incorrect size.

Related to: #1683

---

- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

