### PR TITLE
fix `show details` desync in context menu

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -4800,8 +4800,15 @@ impl Application for App {
             }
             Message::ToggleContextPage(context_page) => {
                 //TODO: ensure context menus are closed
+
+                //if `Show details` was enabled in the `View` menu, we need to make sure 
+                //we untick it to keep it synchronized
+                if matches!(self.context_page,ContextPage::Preview(_,_)) {
+                    self.core.window.show_context=false;
+                    self.config.show_details=false;
+                    self.update_nav_model();
+                };
                 if self.context_page == context_page
-                    || matches!(self.context_page, ContextPage::Preview(_, _))
                 {
                     self.set_show_context(!self.core.window.show_context);
                 } else {


### PR DESCRIPTION
> - [ x] I have disclosed use of any AI generated code in my commit messages.
>   - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
>   - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
> - [ x] I understand these changes in full and will be able to respond to review comments.
> - [ x] My change is accurately described in the commit message.
> - [ x] My contribution is tested and working as described.
> - [ x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

This PR fixes a bug I encountered. If you have `Show details` enabled in the `View` menu (with the context page opened on the right) and you click either "View->Settings" or "View->About", it will:

* Close the context menu without opening the intended new menu.
* Keep `Show details` checked in the View menu, so the next time you click it, nothing happens. You must click it again to make the context page reappear.


