### PR TITLE
fix: open a network share from the server view

### DIFF
--- a/src/mounter/gvfs.rs
+++ b/src/mounter/gvfs.rs
@@ -128,19 +128,29 @@ fn network_scan(uri: &str, sizes: IconSizes) -> Result<Vec<tab::Item>, String> {
         let name = info.name().to_string_lossy().into_owned();
         let display_name = String::from(info.display_name());
 
-        let uri = String::from(file.child(info.name()).uri());
+        let target_uri = info
+            .attribute_as_string(TARGET_URI_ATTRIBUTE)
+            .map(String::from);
+        let child = match &target_uri {
+            Some(target_uri) => gio::File::for_uri(target_uri),
+            None => file.child(info.name()),
+        };
+        let uri = target_uri
+            .clone()
+            .unwrap_or_else(|| String::from(child.uri()));
 
         //TODO: what is the best way to resolve shortcuts?
-        let location = Location::Network(uri, display_name.clone(), file.child(&name).path());
+        let location = Location::Network(uri, display_name.clone(), child.path());
 
         let metadata = if !force_dir && !info.boolean(gio::FILE_ATTRIBUTE_FILESYSTEM_REMOTE) {
             let mtime = info.attribute_uint64(gio::FILE_ATTRIBUTE_TIME_MODIFIED);
-            let is_dir = matches!(info.file_type(), gio::FileType::Directory);
-            let size_opt = (!is_dir).then_some(info.size() as u64);
+            let is_dir = matches!(info.file_type(), gio::FileType::Directory)
+                || (matches!(info.file_type(), gio::FileType::Mountable) && target_uri.is_some());
+            let size_opt = (!is_dir).then(|| info.size() as u64);
             let mut children_opt = None;
 
             if is_dir {
-                if let Some(path) = file.child(&name).path() {
+                if let Some(path) = child.path() {
                     //TODO: calculate children in the background (and make it cancellable?)
                     match std::fs::read_dir(&path) {
                         Ok(entries) => {


### PR DESCRIPTION
Double clicking a share while browsing `smb://server/` does nothing at all, with no message. This is the "click discovered server, click share, it simply appears empty" report in #657.

### Steps to reproduce

1. Select Networks in the sidebar, enter `smb://user@server/` in the location bar.
2. The shares are listed.
3. Double click one of them. Nothing happens, and the log says `no path for item`.

### Cause

Two things meet here.

gvfs enumerates a share as `gio::FileType::Mountable`, not `Directory`, so `is_dir` is false in `network_scan()`. Activation in `tab.rs` navigates when the item is a directory and otherwise wants a path, so a share takes the branch meant for files.

The item has no usable path or uri to offer either, because the child of a browse root is a backend-internal address that can neither be navigated to nor mounted:

```
$ gio list -a standard::target-uri smb://user@server/
home  0  (mountable)  standard::target-uri=smb://server/home
$ gio list -u smb://user@server/
smb://server/._home
$ gio mount smb://server/home      # mounts
$ gio mount smb://server/._home    # exits 0, mounts nothing
```

The item ends up as `Network("smb://server/._home", "home", None)`, and the click ends in `no path for item`.

### Change

The address that works is `standard::target-uri`, and the enumeration already delivers it — `enumerate_children("*")` includes it, it was simply never read. The item now uses it and takes its path from the resolved file, so a share that is already mounted has its local path right away.

A mountable that resolves to a target is treated as a directory, so activating it navigates instead of giving up. Nothing further is needed to mount it: `Cmd::NetworkScan` already mounts the location it is asked to scan when that location is not mounted yet.

`size_opt` is computed lazily now. `bool::then_some` evaluates its argument eagerly, and a mountable has no `standard::size`, so every share in a listing produced a `g_file_info_get_size: should not be reached` critical on stderr.

### Tested

Pop!_OS 24.04, ThinkPad T490, SMB server with six shares. A release build of this branch compared against the stock 1.5.0 package binary of the same commit, both run against an isolated `XDG_CONFIG_HOME`.

Before, with every share unmounted: double clicking a share does nothing, and the log shows `no path for item Item { name: "home", ... location_opt: Some(Network("smb://server/._home", "home", None)) }`.

After:

- the share list shows folder icons instead of generic file icons
- double click on an unmounted share mounts and opens it, and `no path for item` no longer appears
- back, then double click the same share again while it is mounted, opens it directly
- a subfolder inside the share, and back out again, unchanged
- the mounted share appears in the sidebar and opens from there
- `g_file_info_get_size` criticals per server listing: 6 before, 0 after

Not covered: discovered servers under `network:///`, because that list is empty in my network.

- [x] I have disclosed use of any AI generated code in my commit messages.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.
