### PR TITLE
fix: treat an already mounted location as reached, not as an error

### DIFF
--- a/src/mounter/gvfs.rs
+++ b/src/mounter/gvfs.rs
@@ -533,6 +533,13 @@ impl Gvfs {
                                         Ok(()) => {
                                             _ = result_tx.send(Ok(()));
                                             Ok(true)},
+                                        Err(err) if matches!(
+                                            err.kind::<gio::IOErrorEnum>(),
+                                            Some(gio::IOErrorEnum::AlreadyMounted)
+                                        ) => {
+                                            _ = result_tx.send(Ok(()));
+                                            Ok(true)
+                                        }
                                         Err(err) => {
                                             _ = result_tx.send(Err(anyhow::anyhow!("{err:?}")));
                                             match err.kind::<gio::IOErrorEnum>() {
@@ -572,6 +579,7 @@ impl Gvfs {
                                             },
                                             Err(err) => match err.kind::<gio::IOErrorEnum>() {
                                                 Some(gio::IOErrorEnum::FailedHandled) => Ok(false),
+                                                Some(gio::IOErrorEnum::AlreadyMounted) => Ok(true),
                                                 _ => Err(format!("{err}"))
                                             }
                                         }));


### PR DESCRIPTION
Connecting to a location that is already mounted ends in a dialog with no way forward. This is the "claims mounted, shows nothing, retry says already mounted" part of #657, and it is the follow-up I offered while reviewing #1956.

### Steps to reproduce

1. Mount a network share, for example `smb://server/home`.
2. Add network drive, enter the same address, connect.
3. "Unable to access network drive — Location is already mounted", with Cancel and Retry.
4. Retry produces the same message, every time.

### Cause

In `Cmd::NetworkDrive` every error except `FailedHandled` is reported as a failure. `AlreadyMounted` is not a failure: what was asked for — reach that location — is already true, so there is nothing left to do and nothing to report.

Since #1956 the classification has a second consequence, because a failure now also means "do not navigate". A bookmark whose stored path no longer exists while its location is already mounted goes through `network_drive()` and therefore stops instead of opening. I could not construct that combination by hand, so this part is read from the code rather than measured, and it is not what the change is tested against.

### Change

`AlreadyMounted` is treated as success at both call sites in `src/mounter/gvfs.rs`. The match is on `err.kind::<gio::IOErrorEnum>()`, not on the message text, so it does not depend on the locale.

The second site, in `Cmd::NetworkScan`, has the same misclassification, but there the condition can only be reached by a race between the not-mounted check and the mount itself. I could not construct a case that reaches it; it is changed for consistency, and I am happy to drop that hunk if you would rather keep the PR to what is covered by a test.

### Tested

Pop!_OS 24.04, ThinkPad T490, SMB share. Two release builds of `5bdfffa`, with and without this patch, run against an isolated `XDG_CONFIG_HOME`.

Before, with `smb://server/home` mounted: connecting to it again gives the dialog, and Retry gives it again. The log shows

```
network drive smb://server/home: result Err(Error { domain: g-io-error-quark, code: 17, ... })
```

with 4 x `failed to connect` over 5 attempts. Code 17 is `G_IO_ERROR_ALREADY_MOUNTED`.

After:

```
network drive smb://server/home:   result Err(...)  ->  connected to "smb://server/home"
network drive smb://server/backup: result Ok(())    ->  connected to "smb://server/backup"
```

- already mounted: no dialog, and the Add network drive panel closes by itself
- 0 x `failed to connect`
- an unmounted share over the same dialog still mounts normally, so the ordinary path is unaffected

Not covered: the bookmark case described above, and the `Cmd::NetworkScan` race.

- [x] I have disclosed use of any AI generated code in my commit messages.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.
