### PR TITLE
fix: keep the keyboard focus on the same item across a list rebuild

### DIFF
--- a/src/tab.rs
+++ b/src/tab.rs
@@ -2983,6 +2983,12 @@ impl Tab {
             .and_then(|items| items.iter().enumerate().find(|i| i.1.highlighted))
             .map(|(i, _)| i);
         let selected = self.selected_locations();
+        let focused = self.select_focus.and_then(|i| {
+            self.items_opt
+                .as_ref()
+                .and_then(|items| items.get(i))
+                .and_then(|item| item.location_opt.clone())
+        });
         for item in &mut items {
             item.selected = false;
             if let Some(location) = &item.location_opt
@@ -2992,6 +2998,13 @@ impl Tab {
             }
         }
         self.items_opt = Some(items);
+        if let Some(location) = focused {
+            self.select_focus = self.items_opt.as_ref().and_then(|items| {
+                items
+                    .iter()
+                    .position(|item| item.location_opt.as_ref() == Some(&location))
+            });
+        }
         if let Some(i) = highlighted
             .zip(self.items_opt.as_mut())
             .and_then(|(h, items)| items.get_mut(h))


### PR DESCRIPTION
**Steps to reproduce**

1. Select an item in a folder — the second entry, say.
2. Create a folder that sorts before it (`aaa` will do).
3. Press <kbd>↓</kbd>.

The first arrow-down does nothing visible, and the arrow-up after it looks like it skips an entry.

**Cause**

`Tab::select_focus` is an index into `items_opt`. `set_items` carries the selection over by `location_opt` but never recomputes that index, so it points at the neighbour once an entry is inserted before the focused one. `select_focus_scroll` reads the same stale index, so `ScrollToFocused` scrolls to the wrong row too.

**Fix**

Remember the focused item's location before the swap and look it up again, the way the selection itself already is.

**Testing**

Build of `5bdfffa` with only this patch: select `nnn` among six entries, create `aab` — <kbd>↓</kbd> then moves immediately and <kbd>↑</kbd> returns exactly one entry. In daily use here since.

Rebased onto `3aa55b0` since. The rebase is clean and the inserted lines are unchanged; `set_items`, `select_focus` and `location_opt` are untouched by the commits in between, as are all three call sites of `set_items`. `cargo test` passes with no default features, with defaults, and with all features.

- [x] I have disclosed use of any AI generated code in my commit messages.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

