### PR TITLE
fix: embedded thumbnailer field codes

### DIFF
--- a/src/exec.rs
+++ b/src/exec.rs
@@ -1,0 +1,52 @@
+pub(crate) enum Field<'a> {
+    Literal(&'a str),
+    Code(Option<char>),
+}
+
+/// Expand percent field codes in one already shell-split argument.
+///
+/// A trailing `%` is ignored, matching the thumbnailer implementation used
+/// by GNOME. The callback decides how each code is handled.
+pub(crate) fn for_each_field_code(
+    argument: &str,
+    mut visit: impl FnMut(Field<'_>) -> Result<(), ()>,
+) -> Result<(), ()> {
+    let mut rest = argument;
+
+    while let Some(pos) = rest.find('%') {
+        visit(Field::Literal(&rest[..pos]))?;
+        rest = &rest[pos + 1..];
+
+        let Some(code) = rest.chars().next() else {
+            visit(Field::Code(None))?;
+            break;
+        };
+        rest = &rest[code.len_utf8()..];
+        visit(Field::Code(Some(code)))?;
+    }
+
+    visit(Field::Literal(rest))?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Field, for_each_field_code};
+
+    #[test]
+    fn scans_literals_codes_and_trailing_percent() {
+        let mut expanded = String::new();
+        for_each_field_code("left%i-middle%%-right%", |field| {
+            match field {
+                Field::Literal(literal) => expanded.push_str(literal),
+                Field::Code(code) => {
+                    expanded.push_str(&code.map_or("<trailing>".into(), |code| format!("<{code}>")))
+                }
+            }
+            Ok(())
+        })
+        .unwrap();
+
+        assert_eq!(expanded, "left<i>-middle<%>-right<trailing>");
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,7 @@ pub mod clipboard;
 pub mod config;
 mod context_action;
 pub mod dialog;
+mod exec;
 mod key_bind;
 pub(crate) mod large_image;
 pub(crate) mod load_image;

--- a/src/mime_app.rs
+++ b/src/mime_app.rs
@@ -15,6 +15,8 @@ use std::sync::{Arc, RwLock, atomic};
 use std::time::{self, Instant};
 use std::{fs, io, process};
 
+use crate::exec::{Field, for_each_field_code};
+
 #[cfg(feature = "desktop")]
 pub async fn watch(mut emitter: impl FnMut() + 'static + Send) {
     let watcher_result = notify_debouncer_full::new_debouncer(
@@ -96,47 +98,56 @@ pub fn exec_to_command(
 
         for argument in arguments.iter().skip(1) {
             let mut new_argument = BString::new(Vec::with_capacity(argument.capacity()));
-            let mut chars = argument.chars();
-            while let Some(char) = chars.next() {
-                // https://specifications.freedesktop.org/desktop-entry/latest/exec-variables.html
-                if char == '%' {
-                    match chars.next() {
-                        Some('%') => new_argument.push_char(char),
-                        Some('c') => new_argument.push_str(entry_name),
-                        Some('k') => {
-                            if let Some(path) = entry_path {
-                                new_argument.push_str(path.as_os_str().as_bytes());
-                            }
-                        }
-
-                        // %f and %u behave the same in a file manager.
-                        Some('f' | 'u') => {
-                            if let Some(path) = path
-                                && !field_code_used
-                            {
-                                // TODO: files on remote file systems should be copied to a temporary local file.
-                                batch_process = true;
-                                field_code_used = true;
-                                new_argument.push_str(path.as_bytes());
-                            }
-                        }
-
-                        // %F and %U behave the same in a file manager.
-                        Some('F') | Some('U') => {
-                            if !field_code_used && new_argument.is_empty() {
-                                field_code_used = true;
-                                for path in path_opt.iter().map(AsRef::as_ref) {
-                                    args.push(BString::new(path.as_bytes().to_owned()));
-                                }
-                            }
-                        }
-
-                        _ => (),
-                    }
-                } else {
-                    new_argument.push_char(char);
+            // https://specifications.freedesktop.org/desktop-entry/latest/exec-variables.html
+            for_each_field_code(argument, |field| match field {
+                Field::Literal(literal) => {
+                    new_argument.push_str(literal);
+                    Ok(())
                 }
-            }
+                Field::Code(code) => match code {
+                    Some('%') => {
+                        new_argument.push_char('%');
+                        Ok(())
+                    }
+                    Some('c') => {
+                        new_argument.push_str(entry_name);
+                        Ok(())
+                    }
+                    Some('k') => {
+                        if let Some(path) = entry_path {
+                            new_argument.push_str(path.as_os_str().as_bytes());
+                        }
+                        Ok(())
+                    }
+
+                    // %f and %u behave the same in a file manager.
+                    Some('f' | 'u') => {
+                        if let Some(path) = path
+                            && !field_code_used
+                        {
+                            // TODO: files on remote file systems should be copied to a temporary local file.
+                            batch_process = true;
+                            field_code_used = true;
+                            new_argument.push_str(path.as_bytes());
+                        }
+                        Ok(())
+                    }
+
+                    // %F and %U behave the same in a file manager.
+                    Some('F') | Some('U') => {
+                        if !field_code_used && new_argument.is_empty() {
+                            field_code_used = true;
+                            for path in path_opt.iter().map(AsRef::as_ref) {
+                                args.push(BString::new(path.as_bytes().to_owned()));
+                            }
+                        }
+                        Ok(())
+                    }
+
+                    None | Some(_) => Ok(()),
+                },
+            })
+            .ok()?;
 
             if !new_argument.is_empty() {
                 args.push(new_argument);

--- a/src/thumbnailer.rs
+++ b/src/thumbnailer.rs
@@ -10,6 +10,8 @@ use std::sync::{LazyLock, Mutex};
 use std::time::Instant;
 use std::{fs, process};
 
+use crate::exec::{Field, for_each_field_code};
+
 #[derive(Clone, Debug)]
 pub struct Thumbnailer {
     pub exec: String,
@@ -25,30 +27,43 @@ impl Thumbnailer {
         let args_vec: Vec<String> = shlex::split(&self.exec)?;
         let mut args = args_vec.iter();
         let mut command = process::Command::new(args.next()?);
+        let thumbnail_size = thumbnail_size.to_string();
         for arg in args {
-            if arg.starts_with('%') {
-                match arg.as_str() {
-                    "%i" | "%u" => {
-                        command.arg(input);
+            let mut new_arg = std::ffi::OsString::new();
+            for_each_field_code(arg, |field| match field {
+                Field::Literal(literal) => {
+                    new_arg.push(literal);
+                    Ok(())
+                }
+                Field::Code(code) => match code {
+                    None => Ok(()),
+                    Some('%') => {
+                        new_arg.push("%");
+                        Ok(())
                     }
-                    "%o" => {
-                        command.arg(output);
+                    Some('i' | 'u') => {
+                        new_arg.push(input);
+                        Ok(())
                     }
-                    "%s" => {
-                        command.arg(format!("{thumbnail_size}"));
+                    Some('o') => {
+                        new_arg.push(output);
+                        Ok(())
                     }
-                    _ => {
+                    Some('s') => {
+                        new_arg.push(&thumbnail_size);
+                        Ok(())
+                    }
+                    Some(code) => {
                         log::warn!(
-                            "unsupported thumbnailer Exec code {:?} in {:?}",
-                            arg,
+                            "unsupported thumbnailer Exec code '%{code}' in {:?}",
                             self.exec
                         );
-                        return None;
+                        Err(())
                     }
-                }
-            } else {
-                command.arg(arg);
-            }
+                },
+            })
+            .ok()?;
+            command.arg(new_arg);
         }
         Some(command)
     }
@@ -171,4 +186,85 @@ static THUMBNAILER_CACHE: LazyLock<Mutex<ThumbnailerCache>> =
 pub fn thumbnailer(mime: &Mime) -> Vec<Thumbnailer> {
     let thumbnailer_cache = THUMBNAILER_CACHE.lock().unwrap();
     thumbnailer_cache.get(mime)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Thumbnailer;
+    use std::path::{Path, PathBuf};
+
+    fn args_of(exec: &str) -> Vec<String> {
+        let input = PathBuf::from("/home/user/input.stl");
+        let output = PathBuf::from("/home/user/.cache/thumbnails/out.png");
+        let command = Thumbnailer { exec: exec.into() }
+            .command(&input, &output, 512)
+            .expect("should build command");
+        std::iter::once(command.get_program().to_string_lossy().into_owned())
+            .chain(
+                command
+                    .get_args()
+                    .map(|arg| arg.to_string_lossy().into_owned()),
+            )
+            .collect()
+    }
+
+    #[test]
+    fn substitutes_codes_embedded_in_arguments() {
+        // f3d thumbnailer from /usr/share/thumbnailers/f3d-plugin-native.thumbnailer
+        let args = args_of(
+            "f3d --config=thumbnail --load-plugins=native --verbose=quiet --output=%o --resolution=%s,%s %i",
+        );
+        assert_eq!(
+            args,
+            [
+                "f3d",
+                "--config=thumbnail",
+                "--load-plugins=native",
+                "--verbose=quiet",
+                "--output=/home/user/.cache/thumbnails/out.png",
+                "--resolution=512,512",
+                "/home/user/input.stl",
+            ]
+        );
+    }
+
+    #[test]
+    fn substitutes_input_code_with_suffix() {
+        // %i glued to a suffix, e.g. ImageMagick page selector (issue #503)
+        let args = args_of("convert %i[0] -background \"#FFFFFF\" -flatten -thumbnail %s %o");
+        assert_eq!(
+            args,
+            [
+                "convert",
+                "/home/user/input.stl[0]",
+                "-background",
+                "#FFFFFF",
+                "-flatten",
+                "-thumbnail",
+                "512",
+                "/home/user/.cache/thumbnails/out.png",
+            ]
+        );
+    }
+
+    #[test]
+    fn double_percent_is_literal_percent() {
+        let args = args_of("foo --scale=100%% %i");
+        assert_eq!(args, ["foo", "--scale=100%", "/home/user/input.stl"]);
+    }
+
+    #[test]
+    fn trailing_percent_is_ignored() {
+        let args = args_of("foo --label=% %i");
+        assert_eq!(args, ["foo", "--label=", "/home/user/input.stl"]);
+    }
+
+    #[test]
+    fn rejects_unknown_codes_embedded_in_arguments() {
+        let command = Thumbnailer {
+            exec: "foo --output=%o --color=%z %i".into(),
+        }
+        .command(Path::new("/in"), Path::new("/out"), 512);
+        assert!(command.is_none());
+    }
 }


### PR DESCRIPTION
Variables in thumbnailer files were previously rejected unless whitespace-separated. Fedora's f3d-plugin-native.thumbnailer ships:

f3d --config=thumbnail --load-plugins=native --verbose=quiet --output=%o --resolution=%s,%s %i

This was not recognized as a variable and caused writes to ~/%o instead. With this patch, the preview works as expected.
Also includes a minor refactor (shared for_each_field_code function).

Fixes #503

- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

