### PR TITLE
fix: accept a URI typed into the location bar from any location

### DIFF
--- a/src/tab.rs
+++ b/src/tab.rs
@@ -3863,6 +3863,28 @@ impl Tab {
             }
             Message::EditLocationSubmit => {
                 if let Some(mut edit_location) = self.edit_location.take() {
+                    let typed_opt = match &edit_location.location {
+                        Location::Path(path) => path.to_str().map(str::to_string),
+                        Location::Network(uri, ..) => Some(uri.clone()),
+                        _ => None,
+                    };
+                    let mut typed_uri = false;
+                    if let Some(typed) = typed_opt {
+                        match typed.trim().parse::<url::Url>() {
+                            Ok(url) if url.scheme() != "file" && url.has_host() => {
+                                let uri = url.as_str().to_string();
+                                edit_location =
+                                    Location::Network(uri.clone(), uri, None).normalize().into();
+                                typed_uri = true;
+                            }
+                            Err(_) if matches!(edit_location.location, Location::Network(..)) => {
+                                edit_location =
+                                    Location::Path(PathBuf::from(typed)).normalize().into();
+                            }
+                            _ => {}
+                        }
+                    }
+
                     // Select first completion if current location does not exist
                     if edit_location.selected.is_none()
                         && edit_location
@@ -3878,6 +3900,9 @@ impl Tab {
                     }
 
                     cd = edit_location.resolve();
+                    if cd.is_none() && typed_uri {
+                        cd = Some(edit_location.location);
+                    }
                 }
             }
             Message::EditLocationTab => {


### PR DESCRIPTION
Typing `smb://server/share` into the location bar only works while the tab is already on a network location. From a normal folder the text is turned into a path and the navigation is dropped:

```
WARN tried to cd to Path("smb://chris@nas/") which is not a directory
```

The bar inherits its type from the tab (`Message::EditLocationEnable`), and the view only has the two branches next to the existing `//TODO: allow editing other locations`. `EditLocationSubmit` now decides by parsing the input instead. The reverse direction — a local path typed while standing in **Networks** — was broken the same way.

Known cosmetic side effect: while the share is not yet mounted the tab shows the raw URI as its name; the proper name appears once the mount completes.

Tested against a real SMB server on a build of `5bdfffa` carrying only this patch, with an isolated `XDG_CONFIG_HOME`. Across the whole run: `failed to connect` 0, `no path for item` 0, `failed to scan` 0.

<details><summary>Eight steps, and two notes that may save a reviewer time</summary>

| # | step | result |
|---|---|---|
| 1 | `smb://user@server/` from a local folder | share list appears |
| 2 | same address with a leading space | same |
| 3 | `/home/…/tmp` from the network location | navigates locally |
| 4 | `foo:bar` from a local folder | no effect (unchanged behaviour) |
| 5 | sidebar → Networks | unchanged |
| 6 | a directory whose name ends in a space | opens, the space is preserved |
| 7 | `smb://server/share`, not mounted | mounts and opens |
| 8 | `foo:bar` from a mounted share | no effect |

* The reliable indicator for "this is a path" is that **parsing fails**, not that the host is missing — `network:///` and `file:///home` both parse with `has_host() == false`. An earlier version keyed on the host and would have broken the Networks view.
* An unmounted share cannot be resolved (`Tab::resolve` → `mounter.dir_info`), so navigating needs a fallback to the typed URI — and navigating is what triggers the mount, since `Cmd::NetworkScan` mounts the location it is asked to scan. The fallback is restricted to input recognised as a URI with a host; applying it to any network location let unparseable text through, and because `with_uri` keeps the previous display name and path, the window looked normal while the listing stayed empty.

</details>

- [x] I have disclosed use of any AI generated code in my commit messages.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.
