### PR TITLE
Item text and background colouring

### DIFF
--- a/src/tab.rs
+++ b/src/tab.rs
@@ -157,64 +157,91 @@ fn button_appearance(
     cut: bool,
     focused: bool,
     accent: bool,
-    condensed_radius: bool,
+    hidden: bool,
     desktop: bool,
 ) -> widget::button::Style {
     let cosmic = theme.cosmic();
     let mut appearance = widget::button::Style::new();
-    if selected {
+    let mut background = Color::TRANSPARENT;
+    let mut icon_color = Color::from(cosmic.on_bg_component_color());
+    let mut text_color = Color::from(cosmic.on_bg_component_color());
+
+    // Button is highlighted (hover, etc)
+    if highlighted {
+        background = Color::from(cosmic.bg_component_color());
         if accent {
-            appearance.background = Some(Color::from(cosmic.accent_color()).into());
-            appearance.icon_color = Some(Color::from(cosmic.on_accent_color()));
-            if cut {
-                appearance.text_color = Some(Color::from(cosmic.accent.on_disabled));
-            } else {
-                appearance.text_color = Some(Color::from(cosmic.on_accent_color()));
-            }
-        } else {
-            appearance.background = Some(Color::from(cosmic.bg_component_color()).into());
+            background = Color::from(cosmic.accent_color());
+            icon_color = Color::from(cosmic.on_accent_color());
+            text_color = Color::from(cosmic.on_accent_color());
         }
-    } else if highlighted {
-        if accent {
-            appearance.background = Some(Color::from(cosmic.bg_component_color()).into());
-            appearance.icon_color = Some(Color::from(cosmic.on_bg_component_color()));
-            appearance.text_color = Some(Color::from(cosmic.on_bg_component_color()));
-            if cut {
-                appearance.text_color = Some(Color::from(
-                    cosmic.background(theme.transparent).component.on_disabled,
-                ));
-            } else {
-                appearance.text_color = Some(Color::from(cosmic.on_bg_component_color()));
-            }
-        } else {
-            appearance.background = Some(Color::from(cosmic.bg_component_color()).into());
-        }
-    } else if desktop {
-        appearance.background = Some(Color::from(cosmic.bg_color()).into());
-        appearance.icon_color = Some(Color::from(cosmic.on_bg_color()));
-        if cut {
-            appearance.text_color = Some(Color::from(
-                cosmic.background(theme.transparent).component.disabled,
-            ));
-        } else {
-            appearance.text_color = Some(Color::from(cosmic.on_bg_color()));
-        }
-    } else if cut {
-        appearance.text_color = Some(Color::from(
-            cosmic.background(theme.transparent).component.on_disabled,
-        ));
+        background = background.scale_alpha(0.5);
     }
+
+    // Button is selected
+    else if selected {
+        background = Color::from(cosmic.bg_component_color());
+        if accent {
+            background = Color::from(cosmic.accent_color());
+            icon_color = Color::from(cosmic.on_accent_color());
+            text_color = Color::from(cosmic.on_accent_color());
+        }
+        background = background.scale_alpha(0.4);
+    }
+
+    // Button is an item on the desktop
+    else if desktop {
+        background = Color::from(cosmic.bg_color());
+        icon_color = Color::from(cosmic.on_bg_color());
+        text_color = Color::from(cosmic.on_bg_color());
+    }
+    
+    // Visually indicate cut items
+    if cut {
+        let disabled_color = Color::from(
+            cosmic.background(theme.transparent).component.on_disabled,
+        );
+        icon_color = disabled_color;
+        text_color = disabled_color;
+        appearance.outline_width = 1.0;
+        appearance.outline_color = disabled_color.scale_alpha(0.25);
+    }
+
+    // Visually indicate hidden items
+    if hidden {
+        icon_color = icon_color.scale_alpha(0.85);
+        text_color = icon_color.scale_alpha(0.85);
+    }
+
+    // Ensure legibility of text on the backgrounds
+    if background != Color::TRANSPARENT && !text_color.is_readable_on(background) {
+        if Color::from(cosmic.on_bg_color()).is_readable_on(background) {
+            text_color = Color::from(cosmic.on_bg_color());
+        }
+        else if Color::from(cosmic.on_bg_component_color()).is_readable_on(background) {
+            text_color = Color::from(cosmic.on_bg_component_color());
+        }
+        else if Color::from_rgba(255.0, 255.0, 255.0, 1.0).is_readable_on(background) {
+            text_color = Color::from_rgba(255.0, 255.0, 255.0, 1.0);
+        } else {
+            text_color = Color::from_rgba(0.0, 0.0, 0.0, 1.0);
+        }
+    }
+
+    appearance.background = Some(background.into());
+    appearance.icon_color = Some(icon_color);
+    appearance.text_color = Some(text_color);
+
     if focused && accent {
         appearance.outline_width = 1.0;
         appearance.outline_color = Color::from(cosmic.accent_color());
         appearance.border_width = 2.0;
         appearance.border_color = Color::TRANSPARENT;
+    } else if focused {
+        appearance.border_width = 2.0;
+        appearance.border_color = Color::from(cosmic.accent_color());
     }
-    if condensed_radius {
-        appearance.border_radius = cosmic.radius_xs().into();
-    } else {
-        appearance.border_radius = cosmic.radius_s().into();
-    }
+
+    appearance.border_radius = cosmic.radius_m().into();
     appearance
 }
 
@@ -223,7 +250,7 @@ fn button_style(
     highlighted: bool,
     cut: bool,
     accent: bool,
-    condensed_radius: bool,
+    hidden: bool,
     desktop: bool,
 ) -> theme::Button {
     //TODO: move to libcosmic?
@@ -236,7 +263,7 @@ fn button_style(
                 cut,
                 focused,
                 accent,
-                condensed_radius,
+                hidden,
                 desktop,
             )
         }),
@@ -248,7 +275,7 @@ fn button_style(
                 cut,
                 false,
                 accent,
-                condensed_radius,
+                hidden,
                 desktop,
             )
         }),
@@ -260,7 +287,7 @@ fn button_style(
                 cut,
                 focused,
                 accent,
-                condensed_radius,
+                hidden,
                 desktop,
             )
         }),
@@ -272,7 +299,7 @@ fn button_style(
                 cut,
                 focused,
                 accent,
-                condensed_radius,
+                hidden,
                 desktop,
             )
         }),
@@ -5705,7 +5732,7 @@ impl Tab {
         }
 
         let text_height = 3 * 20; // 3 lines of text
-        let item_width = (3 * space_xxs + icon_sizes.grid() + 3 * space_xxs) as usize;
+        let item_width = (3 * space_xxs + icon_sizes.grid() + 3 * space_xxs).max(80) as usize;
         let item_height =
             (space_xxxs + icon_sizes.grid() + space_xxxs + text_height + space_xxxs) as usize;
 
@@ -5795,66 +5822,67 @@ impl Tab {
 
                 // Only build elements if visible (for performance)
                 if item_rect.intersects(&visible_rect) {
-                    //TODO: one focus group per grid item (needs custom widget)
-                    let buttons: Vec<Element<Message>> = vec![
-                        widget::button::custom(
-                            widget::icon::icon(item.icon_handle_grid.clone())
-                                .content_fit(ContentFit::Contain)
-                                .size(icon_sizes.grid()),
+                    let contents = widget::button::custom(
+                            widget::column::with_children([
+                                Element::from(widget::icon::icon(item.icon_handle_grid.clone())
+                                    .content_fit(ContentFit::Contain)
+                                    .size(icon_sizes.grid())),
+                                Element::from(widget::container(widget::tooltip(
+                                    Item::grid_display_name(&item.display_name),
+                                    widget::text::body(&item.name),
+                                    widget::tooltip::Position::Bottom,
+                                ))),
+                            ])
+                            .align_x(Alignment::Center)
+                            .spacing(space_xxs)
+                            .width(Length::Fill)
                         )
+                        .id(item.button_id.clone())
+                        .width(Length::Fill)
                         .padding(space_xxxs)
                         .class(button_style(
                             item.selected,
                             item.highlighted,
                             item.cut,
-                            false,
-                            false,
-                            false,
-                        ))
-                        .into(),
-                        widget::tooltip(
-                            widget::button::custom(Item::grid_display_name(&item.display_name))
-                                .id(item.button_id.clone())
-                                .padding([0, space_xxxs])
-                                .class(button_style(
-                                    item.selected,
-                                    item.highlighted,
-                                    item.cut,
-                                    true,
-                                    true,
-                                    matches!(self.mode, Mode::Desktop),
-                                )),
-                            widget::text::body(&item.name),
-                            widget::tooltip::Position::Bottom,
-                        )
-                        .into(),
-                    ];
-
-                    let mut column = widget::column::with_capacity(buttons.len())
-                        .align_x(Alignment::Center)
-                        .height(Length::Fixed(item_height as f32))
-                        .width(Length::Fixed(item_width as f32));
-                    for button in buttons {
-                        if self.context_menu.is_some() {
-                            column = column.push(button);
-                        } else {
-                            column = column.push(
-                                mouse_area::MouseArea::new(button)
+                            true,
+                            item.hidden,
+                            matches!(self.mode, Mode::Desktop),
+                        ));
+                    // One focus group per grid item (needs custom widget)
+                    let mouse_area = mouse_area::MouseArea::new(contents)
+                        .on_press(move |_| Message::Click(Some(i)))
+                        .on_double_click(move |_| Message::DoubleClick(Some(i)))
+                        .on_release(move |_| Message::ClickRelease(Some(i)))
+                        .on_middle_press(move |_| Message::MiddleClick(i))
+                        .on_enter(move || Message::HighlightActivate(i))
+                        .on_exit(move || Message::HighlightDeactivate(i));
+                    
+                    let button = Element::from(
+                        widget::container(
+                            if self.context_menu.is_some() {
+                                mouse_area
+                            } else {
+                                mouse_area
                                     .on_right_press_no_capture()
                                     .wayland_on_right_press_window_position()
                                     .on_right_press(move |point_opt| {
                                         Message::RightClick(point_opt, Some(i))
-                                    }),
-                            );
-                        }
-                    }
+                                    })
+                            }
+                        ).width(Length::Fill)
+                    );
 
+                    let column = widget::column::with_children([button])
+                        .align_x(Alignment::Center)
+                        .height(Length::Fixed(item_height as f32))
+                        .width(Length::Fixed(item_width as f32));
                     let column: Element<Message> =
                         if item.metadata.is_dir() && item.location_opt.is_some() {
                             self.dnd_dest(&item.location_opt.clone().unwrap(), column)
                         } else {
                             column.into()
                         };
+                    grid_elements[row].push(column);
 
                     if item.selected {
                         dnd_items.push((i, (row, col), item));
@@ -5863,14 +5891,6 @@ impl Tab {
                         drag_e_i = drag_e_i.max(col);
                         drag_s_i = drag_s_i.max(row);
                     }
-                    let mouse_area = crate::mouse_area::MouseArea::new(column)
-                        .on_press(move |_| Message::Click(Some(i)))
-                        .on_double_click(move |_| Message::DoubleClick(Some(i)))
-                        .on_release(move |_| Message::ClickRelease(Some(i)))
-                        .on_middle_press(move |_| Message::MiddleClick(i))
-                        .on_enter(move || Message::HighlightActivate(i))
-                        .on_exit(move || Message::HighlightDeactivate(i));
-                    grid_elements[row].push(Element::from(mouse_area));
                 } else {
                     // Add a spacer if the row is empty, so scroll works
                     if grid_elements[row].is_empty() {
@@ -5962,40 +5982,42 @@ impl Tab {
                         break;
                     };
                     if *row == r && *col == c {
-                        let buttons = vec![
-                            widget::button::custom(
-                                widget::icon::icon(item.icon_handle_grid.clone())
-                                    .content_fit(ContentFit::Contain)
-                                    .size(icon_sizes.grid()),
+                        let button = Element::from(
+                            widget::container(
+                                widget::tooltip(
+                                    widget::button::custom(
+                                        widget::column::with_children([
+                                            widget::icon::icon(item.icon_handle_grid.clone())
+                                                .content_fit(ContentFit::Contain)
+                                                .size(icon_sizes.grid()).into(),
+                                            Item::grid_display_name(item.display_name.clone()).into(),
+                                        ])
+                                        .align_x(Alignment::Center)
+                                        .spacing(space_xxs)
+                                        .width(Length::Fill)
+                                    )
+                                    .id(item.button_id.clone())
+                                    .on_press(Message::Click(Some(*i)))
+                                    .width(Length::Fill)
+                                    .padding(space_xxxs)
+                                    .class(button_style(
+                                        item.selected,
+                                        item.highlighted,
+                                        item.cut,
+                                        true,
+                                        item.hidden,
+                                        matches!(self.mode, Mode::Desktop),
+                                    )),
+                                    widget::text::body(item.name.clone()),
+                                    widget::tooltip::Position::Bottom,
+                                ),
                             )
-                            .on_press(Message::Click(Some(*i)))
-                            .padding(space_xxxs)
-                            .class(button_style(
-                                item.selected,
-                                item.highlighted,
-                                item.cut,
-                                false,
-                                false,
-                                false,
-                            )),
-                            widget::button::custom(Item::grid_display_name(
-                                item.display_name.clone(),
-                            ))
-                            .id(item.button_id.clone())
-                            .on_press(Message::Click(Some(*i)))
-                            .padding([0, space_xxxs])
-                            .class(button_style(
-                                item.selected,
-                                item.highlighted,
-                                item.cut,
-                                true,
-                                true,
-                                false,
-                            )),
-                        ];
+                            .width(Length::Fill)
+                            .height(Length::Fill)
+                        );
 
                         let column =
-                            widget::column::with_children(buttons.into_iter().map(Element::from))
+                            widget::column::with_children([button])
                                 .align_x(Alignment::Center)
                                 .height(Length::Fixed(item_height as f32))
                                 .width(Length::Fixed(item_width as f32));
@@ -6258,7 +6280,7 @@ impl Tab {
                                     item.highlighted,
                                     item.cut,
                                     true,
-                                    true,
+                                    item.hidden,
                                     false,
                                 )),
                         )

--- a/src/tab.rs
+++ b/src/tab.rs
@@ -162,7 +162,7 @@ fn button_appearance(
 ) -> widget::button::Style {
     let cosmic = theme.cosmic();
     let mut appearance = widget::button::Style::new();
-    let mut background = Color::from(cosmic.bg_color());
+    let mut background = Color::TRANSPARENT;
     let mut icon_color = Color::from(cosmic.on_bg_component_color());
     let mut text_color = Color::from(cosmic.on_bg_component_color());
 
@@ -220,16 +220,21 @@ fn button_appearance(
     }
 
     // Ensure legibility of text on the backgrounds
+    let bg_check = if background == Color::TRANSPARENT {
+            Color::from(cosmic.bg_color())
+        } else {
+            background
+    };
     if !text_color.is_readable_on(background) {
-        if Color::from(cosmic.on_bg_color()).is_readable_on(background) {
+        if Color::from(cosmic.on_bg_color()).is_readable_on(bg_check) {
             icon_color = Color::from(cosmic.on_bg_color());
             text_color = Color::from(cosmic.on_bg_color());
         }
-        else if Color::from(cosmic.on_bg_component_color()).is_readable_on(background) {
+        else if Color::from(cosmic.on_bg_component_color()).is_readable_on(bg_check) {
             icon_color = Color::from(cosmic.on_bg_component_color());
             text_color = Color::from(cosmic.on_bg_component_color());
         }
-        else if Color::WHITE.is_readable_on(background) {
+        else if Color::WHITE.is_readable_on(bg_check) {
             icon_color = Color::WHITE;
             text_color = Color::WHITE;
         } else {
@@ -5757,7 +5762,7 @@ impl Tab {
         };
 
         let (cols, column_spacing) = {
-            let width_m1 = width.saturating_sub(item_width + 2 * space_xxs as usize);
+            let width_m1 = width.saturating_sub(item_width + space_xxs as usize);
             let cols_m1 = width_m1 / (item_width + grid_spacing as usize);
             let cols = cols_m1 + 1;
             let spacing = width_m1
@@ -5848,7 +5853,7 @@ impl Tab {
                             // TODO: Merge with button_style()
                             let mut a = widget::container::Style::default();
                             let c = t.cosmic();
-                            let mut background = Color::from(c.bg_color());
+                            let mut background = Color::TRANSPARENT;
                             let mut icon_color = Color::from(c.on_bg_component_color());
                             let mut text_color = Color::from(c.on_bg_component_color());
 
@@ -5898,16 +5903,21 @@ impl Tab {
                             }
 
                             // Ensure legibility of text on the backgrounds
-                            if !text_color.is_readable_on(background) {
-                                if Color::from(c.on_bg_color()).is_readable_on(background) {
+                            let bg_check = if background == Color::TRANSPARENT {
+                                    Color::from(c.bg_color())
+                                } else {
+                                    background
+                            };
+                            if !text_color.is_readable_on(bg_check) {
+                                if Color::from(c.on_bg_color()).is_readable_on(bg_check) {
                                     icon_color = Color::from(c.on_bg_color());
                                     text_color = Color::from(c.on_bg_color());
                                 }
-                                else if Color::from(c.on_bg_component_color()).is_readable_on(background) {
+                                else if Color::from(c.on_bg_component_color()).is_readable_on(bg_check) {
                                     icon_color = Color::from(c.on_bg_component_color());
                                     text_color = Color::from(c.on_bg_component_color());
                                 }
-                                else if Color::WHITE.is_readable_on(background) {
+                                else if Color::WHITE.is_readable_on(bg_check) {
                                     icon_color = Color::WHITE;
                                     text_color = Color::WHITE;
                                 } else {
@@ -5922,15 +5932,13 @@ impl Tab {
                     ])
                     .height(Length::Fill)
                     .width(width as f32)
-                    .align_x(Alignment::Center)
-                    .spacing(space_xxs);
+                    .align_x(Alignment::Center);
 
                     let button = |contents| {
                         let mouse_area = crate::mouse_area::MouseArea::new(
                             widget::button::custom(contents)
                                 .width(Length::Fill)
                                 .id(item.button_id.clone())
-                                .padding(space_xxs)
                                 .class(button_style(
                                     item.selected,
                                     item.highlighted,

--- a/src/tab.rs
+++ b/src/tab.rs
@@ -162,7 +162,7 @@ fn button_appearance(
 ) -> widget::button::Style {
     let cosmic = theme.cosmic();
     let mut appearance = widget::button::Style::new();
-    let mut background = Color::TRANSPARENT;
+    let mut background = Color::from(cosmic.bg_color());
     let mut icon_color = Color::from(cosmic.on_bg_component_color());
     let mut text_color = Color::from(cosmic.on_bg_component_color());
 
@@ -174,7 +174,7 @@ fn button_appearance(
             icon_color = Color::from(cosmic.on_accent_color());
             text_color = Color::from(cosmic.on_accent_color());
         }
-        background = background.scale_alpha(0.5);
+        background = background.scale_alpha(0.85);
     }
 
     // Button is selected
@@ -185,7 +185,7 @@ fn button_appearance(
             icon_color = Color::from(cosmic.on_accent_color());
             text_color = Color::from(cosmic.on_accent_color());
         }
-        background = background.scale_alpha(0.4);
+        background = background.scale_alpha(0.75);
     }
 
     // Button is an item on the desktop
@@ -200,30 +200,41 @@ fn button_appearance(
         let disabled_color = Color::from(
             cosmic.background(theme.transparent).component.on_disabled,
         );
-        icon_color = disabled_color;
-        text_color = disabled_color;
+        if !accent {
+            background = Color::from(
+                cosmic.background(theme.transparent).component.disabled,
+            ).scale_alpha(0.1);
+            icon_color = disabled_color;
+            text_color = disabled_color;
+        }
+        icon_color = icon_color.scale_alpha(0.8);
+        text_color = text_color.scale_alpha(0.8);
         appearance.outline_width = 1.0;
         appearance.outline_color = disabled_color.scale_alpha(0.25);
     }
 
     // Visually indicate hidden items
     if hidden {
-        icon_color = icon_color.scale_alpha(0.85);
-        text_color = icon_color.scale_alpha(0.85);
+        icon_color = icon_color.scale_alpha(0.8);
+        text_color = text_color.scale_alpha(0.8);
     }
 
     // Ensure legibility of text on the backgrounds
-    if background != Color::TRANSPARENT && !text_color.is_readable_on(background) {
+    if !text_color.is_readable_on(background) {
         if Color::from(cosmic.on_bg_color()).is_readable_on(background) {
+            icon_color = Color::from(cosmic.on_bg_color());
             text_color = Color::from(cosmic.on_bg_color());
         }
         else if Color::from(cosmic.on_bg_component_color()).is_readable_on(background) {
+            icon_color = Color::from(cosmic.on_bg_component_color());
             text_color = Color::from(cosmic.on_bg_component_color());
         }
-        else if Color::from_rgba(255.0, 255.0, 255.0, 1.0).is_readable_on(background) {
-            text_color = Color::from_rgba(255.0, 255.0, 255.0, 1.0);
+        else if Color::WHITE.is_readable_on(background) {
+            icon_color = Color::WHITE;
+            text_color = Color::WHITE;
         } else {
-            text_color = Color::from_rgba(0.0, 0.0, 0.0, 1.0);
+            icon_color = Color::BLACK;
+            text_color = Color::BLACK;
         }
     }
 
@@ -5294,10 +5305,9 @@ impl Tab {
             .height(Length::Fill)
             .style(|theme| {
                 let cosmic = theme.cosmic();
-                let mut bg = cosmic.bg_color();
-                bg.alpha = 0.75;
+                let bg = cosmic.bg_color();
                 widget::container::Style {
-                    background: Some(Color::from(bg).into()),
+                    background: Some(Color::from(bg).scale_alpha(0.85).into()),
                     ..Default::default()
                 }
             })
@@ -5747,7 +5757,7 @@ impl Tab {
         };
 
         let (cols, column_spacing) = {
-            let width_m1 = width.saturating_sub(item_width);
+            let width_m1 = width.saturating_sub(item_width + 2 * space_xxs as usize);
             let cols_m1 = width_m1 / (item_width + grid_spacing as usize);
             let cols = cols_m1 + 1;
             let spacing = width_m1
@@ -5822,57 +5832,118 @@ impl Tab {
 
                 // Only build elements if visible (for performance)
                 if item_rect.intersects(&visible_rect) {
-                    let contents = widget::button::custom(
-                            widget::column::with_children([
-                                Element::from(widget::icon::icon(item.icon_handle_grid.clone())
-                                    .content_fit(ContentFit::Contain)
-                                    .size(icon_sizes.grid())),
-                                Element::from(widget::container(widget::tooltip(
-                                    Item::grid_display_name(&item.display_name),
-                                    widget::text::body(&item.name),
-                                    widget::tooltip::Position::Bottom,
-                                ))),
-                            ])
-                            .align_x(Alignment::Center)
-                            .spacing(space_xxs)
-                            .width(Length::Fill)
+                    let contents = widget::column::with_children([
+                        Element::from(widget::container(
+                            widget::icon::icon(item.icon_handle_grid.clone())
+                                .content_fit(ContentFit::Contain)
+                                .size(icon_sizes.grid())
+                        )),
+                        Element::from(widget::container(
+                            widget::tooltip(
+                                Item::grid_display_name(&item.display_name),
+                                widget::text::body(&item.name),
+                                widget::tooltip::Position::Bottom,
+                            )
+                        ).style(|t| {
+                            // TODO: Merge with button_style()
+                            let mut a = widget::container::Style::default();
+                            let c = t.cosmic();
+                            let mut background = Color::from(c.bg_color());
+                            let mut icon_color = Color::from(c.on_bg_component_color());
+                            let mut text_color = Color::from(c.on_bg_component_color());
+
+                            // Button is highlighted (hover, etc)
+                            if item.highlighted {
+                                background = Color::from(c.accent_color());
+                                icon_color = Color::from(c.on_accent_color());
+                                text_color = Color::from(c.on_accent_color());
+                                background = background.scale_alpha(0.75);
+                            }
+
+                            // Button is selected
+                            else if item.selected {
+                                background = Color::from(c.accent_color());
+                                icon_color = Color::from(c.on_accent_color());
+                                text_color = Color::from(c.on_accent_color());
+                                background = background.scale_alpha(0.66);
+                            }
+
+                            // Button is an item on the desktop
+                            else if matches!(self.mode, Mode::Desktop) {
+                                background = Color::from(c.bg_color());
+                                icon_color = Color::from(c.on_bg_color());
+                                text_color = Color::from(c.on_bg_color());
+                            }
+
+                            // Visually indicate hidden items
+                            if item.hidden {
+                                icon_color = icon_color.scale_alpha(0.8);
+                                text_color = text_color.scale_alpha(0.8);
+                            }
+
+                            // Ensure legibility of text on the backgrounds
+                            if !text_color.is_readable_on(background) {
+                                if Color::from(c.on_bg_color()).is_readable_on(background) {
+                                    icon_color = Color::from(c.on_bg_color());
+                                    text_color = Color::from(c.on_bg_color());
+                                }
+                                else if Color::from(c.on_bg_component_color()).is_readable_on(background) {
+                                    icon_color = Color::from(c.on_bg_component_color());
+                                    text_color = Color::from(c.on_bg_component_color());
+                                }
+                                else if Color::WHITE.is_readable_on(background) {
+                                    icon_color = Color::WHITE;
+                                    text_color = Color::WHITE;
+                                } else {
+                                    icon_color = Color::BLACK;
+                                    text_color = Color::BLACK;
+                                }
+                            }
+                            a.icon_color = Some(icon_color);
+                            a.text_color = Some(text_color);
+                            a
+                        })),
+                    ])
+                    .height(Length::Fill)
+                    .width(width as f32)
+                    .align_x(Alignment::Center)
+                    .spacing(space_xxs);
+
+                    let button = |contents| {
+                        let mouse_area = crate::mouse_area::MouseArea::new(
+                            widget::button::custom(contents)
+                                .width(Length::Fill)
+                                .id(item.button_id.clone())
+                                .padding(space_xxs)
+                                .class(button_style(
+                                    item.selected,
+                                    item.highlighted,
+                                    item.cut,
+                                    true,
+                                    item.hidden,
+                                    false,
+                                )),
                         )
-                        .id(item.button_id.clone())
-                        .width(Length::Fill)
-                        .padding(space_xxxs)
-                        .class(button_style(
-                            item.selected,
-                            item.highlighted,
-                            item.cut,
-                            true,
-                            item.hidden,
-                            matches!(self.mode, Mode::Desktop),
-                        ));
-                    // One focus group per grid item (needs custom widget)
-                    let mouse_area = mouse_area::MouseArea::new(contents)
                         .on_press(move |_| Message::Click(Some(i)))
                         .on_double_click(move |_| Message::DoubleClick(Some(i)))
                         .on_release(move |_| Message::ClickRelease(Some(i)))
                         .on_middle_press(move |_| Message::MiddleClick(i))
                         .on_enter(move || Message::HighlightActivate(i))
                         .on_exit(move || Message::HighlightDeactivate(i));
-                    
-                    let button = Element::from(
-                        widget::container(
-                            if self.context_menu.is_some() {
-                                mouse_area
-                            } else {
-                                mouse_area
-                                    .on_right_press_no_capture()
-                                    .wayland_on_right_press_window_position()
-                                    .on_right_press(move |point_opt| {
-                                        Message::RightClick(point_opt, Some(i))
-                                    })
-                            }
-                        ).width(Length::Fill)
-                    );
 
-                    let column = widget::column::with_children([button])
+                        if self.context_menu.is_some() {
+                            mouse_area
+                        } else {
+                            mouse_area
+                                .on_right_press_no_capture()
+                                .wayland_on_right_press_window_position()
+                                .on_right_press(move |point_opt| {
+                                    Message::RightClick(point_opt, Some(i))
+                                })
+                        }
+                    };
+
+                    let column = widget::column::with_children([button(contents).into()])
                         .align_x(Alignment::Center)
                         .height(Length::Fixed(item_height as f32))
                         .width(Length::Fixed(item_width as f32));
@@ -6207,9 +6278,12 @@ impl Tab {
 
                     let row = if condensed {
                         widget::row::with_children([
-                            widget::icon::icon(item.icon_handle_list_condensed.clone())
-                                .content_fit(ContentFit::Contain)
-                                .size(icon_size)
+                            widget::container(
+                                widget::icon::icon(item.icon_handle_list_condensed.clone())
+                                    .content_fit(ContentFit::Contain)
+                                    .size(icon_size)
+                                )
+                                .padding([0, 0, 0, space_xxs])
                                 .into(),
                             widget::column::with_children([
                                 Item::list_display_name(item.display_name.clone()).into(),
@@ -6224,9 +6298,12 @@ impl Tab {
                         .spacing(space_xxs)
                     } else if is_search {
                         widget::row::with_children([
-                            widget::icon::icon(item.icon_handle_list_condensed.clone())
-                                .content_fit(ContentFit::Contain)
-                                .size(icon_size)
+                            widget::container(
+                                widget::icon::icon(item.icon_handle_list_condensed.clone())
+                                    .content_fit(ContentFit::Contain)
+                                    .size(icon_size)
+                                )
+                                .padding([0, 0, 0, space_xxs])
                                 .into(),
                             widget::column::with_children([
                                 Item::list_display_name(item.display_name.clone()).into(),
@@ -6250,9 +6327,12 @@ impl Tab {
                         .spacing(space_xxs)
                     } else {
                         widget::row::with_children([
-                            widget::icon::icon(item.icon_handle_list.clone())
-                                .content_fit(ContentFit::Contain)
-                                .size(icon_size)
+                            widget::container(
+                                widget::icon::icon(item.icon_handle_list.clone())
+                                    .content_fit(ContentFit::Contain)
+                                    .size(icon_size)
+                                )
+                                .padding([0, 0, 0, space_xxs])
                                 .into(),
                             Item::list_display_name(item.display_name.clone())
                                 .width(Length::Fill)

--- a/src/tab.rs
+++ b/src/tab.rs
@@ -5875,6 +5875,22 @@ impl Tab {
                                 text_color = Color::from(c.on_bg_color());
                             }
 
+                            // Visually indicate cut items
+                            if item.cut {
+                                let disabled_color = Color::from(
+                                    c.background(t.transparent).component.on_disabled,
+                                );
+                                if !item.highlighted && !item.selected {
+                                    background = Color::from(
+                                        c.background(t.transparent).component.disabled,
+                                    ).scale_alpha(0.1);
+                                    icon_color = disabled_color;
+                                    text_color = disabled_color;
+                                }
+                                icon_color = icon_color.scale_alpha(0.8);
+                                text_color = text_color.scale_alpha(0.8);
+                            }
+
                             // Visually indicate hidden items
                             if item.hidden {
                                 icon_color = icon_color.scale_alpha(0.8);
@@ -6022,7 +6038,8 @@ impl Tab {
                 // Cache content height for scroll clamping on next frame
                 self.content_height_opt.set(Some(max_bottom as f32));
 
-                let top_deduct = 7 * (space_xxs as usize);
+                // TODO: Don't have 'magic' number (10) here
+                let top_deduct = 10 * (space_xxs as usize);
 
                 self.item_view_size_opt
                     .set(self.size_opt.get().map(|s| Size {
@@ -6480,7 +6497,7 @@ impl Tab {
                 };
 
                 count += 1;
-                y += f32::from(row_height);
+                y += f32::from(row_height + space_xxs);
                 column = column.push(button_row);
             }
 

--- a/src/tab.rs
+++ b/src/tab.rs
@@ -6505,7 +6505,7 @@ impl Tab {
                 };
 
                 count += 1;
-                y += f32::from(row_height + space_xxs);
+                y += f32::from(row_height);
                 column = column.push(button_row);
             }
 


### PR DESCRIPTION
Improved the item background and text colouring to be cleaner, smarter, more legible and to work better with Frosted Glass.

In refactoring the Grid View item structure and colouring it looks like I have also fixed several other issues ( listed below ). I'm happy for those fixes to be pulled out individually if desired.


### Text Legibility ( https://github.com/pop-os/cosmic-files/issues/1989 )
Item label text now checks for legibility and switches colour if necessary, both in list view and Grid View.  This is far more noticeable when using extreme custom accent colours like ( #000000 ).

_screenshot: this branch (top) compared to original 1.5.0 (old)_
<img width="960" height="719" alt="image" src="https://github.com/user-attachments/assets/ab53bafe-b6eb-448e-9dc8-2f0f48cce3c3" />


### Grid View Highlights
Highlighted and selected items in Grid View now use the accent colour for the background, with partial transparency for those using Frosted Glass.
<img width="951" height="340" alt="image" src="https://github.com/user-attachments/assets/940e4f8d-647c-4834-a92f-adc9742d770c" />



### Hidden Items ( https://github.com/pop-os/cosmic-files/issues/299 )
Hidden items now have a mild opacity on the text and icon colour (the latter not applied) to have a visual difference.  This is very mild for readability concerns, but it's an easily changed `alpha_scale()` value now.
<img width="748" height="320" alt="image" src="https://github.com/user-attachments/assets/775da5de-1350-46b2-8a68-aed8e3dc3957" />


### Cut Items
Items that have been cut now have additional mild opacity applied and show a mild outline to make them stand out more.
<img width="445" height="312" alt="image" src="https://github.com/user-attachments/assets/d5d385c4-94d9-4a95-a834-8ec8da5a6a08" />


### List View corners
The corners of List View items now respect the user's Style choice, matching other elements like the sidebar items. ( see screenshots above )


### Frosted Glass ( https://github.com/pop-os/cosmic-files/issues/1914 )
The highlighting for both Grid View and List View is now partially transparent, which also propagates into the Search Results.  This allows those who like less frosting (not me) to see through the list results like other UI elements like the sidebar.
<img width="962" height="352" alt="image" src="https://github.com/user-attachments/assets/3b6b36e9-af0d-4935-b6ba-02e651f5cc26" />


### Grid View Drag to Select ( https://github.com/pop-os/cosmic-files/issues/1808 )
The effective mouse areas for Grid View items has been updated:
 - Drag to move will now only happen within the coloured background area
 - The Drop Target for each item is still the larger area to handle the preferred action
 - The Drag to select can now occur in the 'empty' areas between the visible list items (that are actually inside the grid cell), giving more room for that action
<img width="960" height="350" alt="image" src="https://github.com/user-attachments/assets/c3c2a0bc-f05e-47fd-bd7b-9e1e7d2808bb" />
<img width="960" height="350" alt="image" src="https://github.com/user-attachments/assets/c9cec481-4f0f-49e0-a4c1-197c7924f732" />


### Icons
Although the icon colouring has been updated in code, the visible icons will remain the same until SVG Icons and Icon::opacity come in future updates ( see: https://github.com/pop-os/cosmic-files/pull/1936 )


Relates to: 
- https://github.com/pop-os/cosmic-files/issues/1989
- https://github.com/pop-os/cosmic-files/issues/299
- https://github.com/pop-os/cosmic-files/issues/1808
- https://github.com/pop-os/cosmic-files/issues/1914


----

- [ ☑️ ] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [ ☑️ ] I understand these changes in full and will be able to respond to review comments.
- [ ☑️ ] My change is accurately described in the commit message.
- [ ☑️ ] My contribution is tested and working as described.
- [ ☑️ ] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

