### PR TITLE
chore: minor cleanup around futures usage

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -1277,7 +1277,7 @@ impl App {
             .insert(id, (operation.clone(), controller.clone()));
 
         // Use a task to send operations to the compio runtime thread.
-        cosmic::Task::stream(cosmic::iced::stream::channel(4, move |msg_tx| async move {
+        cosmic::Task::stream(cosmic::iced::stream::channel(4, async move |msg_tx| {
             let (tx, rx) = tokio::sync::oneshot::channel();
 
             let msg_tx = Arc::new(tokio::sync::Mutex::new(msg_tx));
@@ -6854,7 +6854,7 @@ impl Application for App {
             Subscription::run_with(TypeId::of::<WatcherSubscription>(), |_| {
                 stream::channel(
                     100,
-                    |mut output: futures::channel::mpsc::Sender<Message>| async move {
+                    async |mut output| {
                         let watcher_res = {
                             let mut output = output.clone();
                             new_debouncer(
@@ -6885,9 +6885,9 @@ impl Application for App {
                                         });
 
                                             if !events.is_empty() {
-                                                match futures::executor::block_on(async {
-                                                    output.send(Message::NotifyEvents(events)).await
-                                                }) {
+                                                match futures::executor::block_on(
+                                                    output.send(Message::NotifyEvents(events)),
+                                                ) {
                                                     Ok(()) => {}
                                                     Err(err) => {
                                                         log::warn!(
@@ -6932,11 +6932,11 @@ impl Application for App {
             Subscription::run(|| {
                 stream::channel(
                     1,
-                    |mut output: futures::channel::mpsc::Sender<Message>| async move {
+                    async |mut output| {
                         mime_app::watch(move || {
-                            futures::executor::block_on(async {
-                                _ = output.send(Message::ReloadMimeAppCache).await;
-                            })
+                            _ = futures::executor::block_on(
+                                output.send(Message::ReloadMimeAppCache),
+                            );
                         })
                         .await;
 
@@ -6947,7 +6947,7 @@ impl Application for App {
             Subscription::run_with(TypeId::of::<TrashWatcherSubscription>(), |_| {
                 stream::channel(
                     1,
-                    |mut output: futures::channel::mpsc::Sender<Message>| async move {
+                    async |mut output| {
                         let watcher_res = new_debouncer(
                             time::Duration::from_millis(250),
                             Some(time::Duration::from_millis(250)),
@@ -6961,9 +6961,9 @@ impl Application for App {
                                             events.iter().any(|event| !event.kind.is_access());
 
                                         if should_rescan
-                                            && let Err(e) = futures::executor::block_on(async {
-                                                output.send(Message::RescanTrash).await
-                                            })
+                                            && let Err(e) = futures::executor::block_on(
+                                                output.send(Message::RescanTrash),
+                                            )
                                         {
                                             log::warn!(
                                                 "trash needs to be rescanned but sending message failed: {e:?}"
@@ -7019,7 +7019,7 @@ impl Application for App {
             Subscription::run_with(TypeId::of::<RecentsWatcherSubscription>(), |_| {
                 stream::channel(
                     1,
-                    |mut output: futures::channel::mpsc::Sender<Message>| async move {
+                    async |mut output| {
                         let Some(recents_path) = recently_used_xbel::dir() else {
                             log::warn!(
                                 "failed to watch recents changes: .recently_used.xbel does not exist"
@@ -7041,9 +7041,9 @@ impl Application for App {
                                                 || kind.is_modify()
                                                 || kind.is_remove()
                                                 || kind.is_other()
-                                        }) && let Err(e) = futures::executor::block_on(async {
-                                            output.send(Message::RescanRecents).await
-                                        }) {
+                                        }) && let Err(e) = futures::executor::block_on(
+                                            output.send(Message::RescanRecents),
+                                        ) {
                                             log::warn!(
                                                 "open recents tabs need to be updated but sending message failed: {e:?}"
                                             );
@@ -7134,7 +7134,7 @@ impl Application for App {
                         |_| {
                             stream::channel(
                                 1,
-                                move |mut msg_tx: futures::channel::mpsc::Sender<_>| async move {
+                                async |mut msg_tx| {
                                     tokio::task::spawn_blocking(move || {
                                         match notify_rust::Notification::new()
                                             .summary(&fl!("notification-in-progress"))
@@ -7142,13 +7142,12 @@ impl Application for App {
                                             .show()
                                         {
                                             Ok(notification) => {
-                                                let _ = futures::executor::block_on(async {
+                                                let _ = futures::executor::block_on(
                                                     msg_tx
                                                         .send(Message::Notification(Arc::new(
                                                             Mutex::new(notification),
-                                                        )))
-                                                        .await
-                                                });
+                                                        ))),
+                                                );
                                             }
                                             Err(err) => {
                                                 log::warn!("failed to create notification: {err}");

--- a/src/archive.rs
+++ b/src/archive.rs
@@ -150,12 +150,8 @@ fn zip_extract<R: io::Read + io::Seek, P: AsRef<Path>>(
     let mut files_by_last_modified = Vec::with_capacity(total_files);
 
     for i in 0..total_files {
-        futures::executor::block_on(async {
-            controller
-                .check()
-                .await
-                .map_err(|s| io::Error::other(OperationError::from_state(s, &controller)))
-        })?;
+        futures::executor::block_on(controller.check())
+            .map_err(|s| io::Error::other(OperationError::from_state(s, &controller)))?;
 
         controller.set_progress(i as f32 / total_files as f32);
 
@@ -235,12 +231,8 @@ fn zip_extract<R: io::Read + io::Seek, P: AsRef<Path>>(
         let mut outfile = fs::File::create(&outpath)?;
         let mut current = 0;
         loop {
-            futures::executor::block_on(async {
-                controller
-                    .check()
-                    .await
-                    .map_err(|s| io::Error::other(OperationError::from_state(s, &controller)))
-            })?;
+            futures::executor::block_on(controller.check())
+                .map_err(|s| io::Error::other(OperationError::from_state(s, &controller)))?;
 
             let count = file.read(&mut buffer)?;
             if count == 0 {

--- a/src/dialog.rs
+++ b/src/dialog.rs
@@ -2109,7 +2109,7 @@ impl Application for App {
             }),
             Subscription::run_with(TypeId::of::<WatcherSubscription>(), |_| {
                 stream::channel(100, {
-                    |mut output: futures::channel::mpsc::Sender<_>| async move {
+                    async |mut output| {
                         let watcher_res = {
                             let mut output = output.clone();
                             new_debouncer(
@@ -2138,9 +2138,9 @@ impl Application for App {
                                         });
 
                                             if !events.is_empty() {
-                                                match futures::executor::block_on(async {
-                                                    output.send(Message::NotifyEvents(events)).await
-                                                }) {
+                                                match futures::executor::block_on(
+                                                    output.send(Message::NotifyEvents(events)),
+                                                ) {
                                                     Ok(()) => {}
                                                     Err(err) => {
                                                         log::warn!(

--- a/src/mounter/gvfs.rs
+++ b/src/mounter/gvfs.rs
@@ -730,9 +730,7 @@ impl Mounter for Gvfs {
                 let event_rx = event_rx.clone();
                 stream::channel(
                     1,
-                    move |mut output: cosmic::iced::futures::channel::mpsc::Sender<
-                        MounterMessage,
-                    >| async move {
+                    async move |mut output| {
                         command_tx.send(Cmd::Rescan).unwrap();
                         while let Some(event) = event_rx.recv().await {
                             match event {

--- a/src/operation/mod.rs
+++ b/src/operation/mod.rs
@@ -134,7 +134,7 @@ async fn copy_or_move(
 
         let from_to_pairs: Vec<(PathBuf, PathBuf)> = if matches!(method, Method::Move { .. }) {
             from_to_pairs_iter
-                .map(|(from, to)| async move {
+                .map(async |(from, to)| {
                     //TODO: show replace dialog here?
                     if to.exists() {
                         return Some((from, to));
@@ -157,7 +157,7 @@ async fn copy_or_move(
                     }
                 })
                 .collect::<cosmic::iced::futures::stream::FuturesOrdered<_>>()
-                .fold(Vec::new(), |mut pairs, pair| async move {
+                .fold(Vec::new(), async |mut pairs, pair| {
                     if let Some(pair) = pair {
                         pairs.push(pair);
                     }
@@ -218,7 +218,7 @@ pub async fn sync_to_disk(
     target_dirs: std::collections::HashSet<PathBuf>,
 ) {
     // Sync files to disk
-    stream::iter(written_files.into_iter().map(|path| async move {
+    stream::iter(written_files.into_iter().map(async |path| {
         if let Ok(file) = compio::fs::OpenOptions::new().write(true).open(&path).await {
             let _ = file.sync_all().await;
         }
@@ -228,7 +228,7 @@ pub async fn sync_to_disk(
     .await;
 
     // Sync directories to disk
-    stream::iter(target_dirs.into_iter().map(|path| async move {
+    stream::iter(target_dirs.into_iter().map(async |path| {
         if let Ok(dir) = compio::fs::OpenOptions::new().read(true).open(&path).await {
             let _ = dir.sync_all().await;
         }
@@ -707,12 +707,8 @@ impl Operation {
 
                                 let total_paths = paths.len();
                                 for (i, path) in paths.iter().enumerate() {
-                                    futures::executor::block_on(async {
-                                        controller
-                                            .check()
-                                            .await
-                                            .map_err(|e| OperationError::from_state(e, &controller))
-                                    })?;
+                                    futures::executor::block_on(controller.check())
+                                        .map_err(|e| OperationError::from_state(e, &controller))?;
 
                                     controller.set_progress((i as f32) / total_paths as f32);
 
@@ -742,12 +738,8 @@ impl Operation {
                                 let total_paths = paths.len();
                                 let mut buffer = vec![0; 4 * 1024 * 1024];
                                 for (i, path) in paths.iter().enumerate() {
-                                    futures::executor::block_on(async {
-                                        controller
-                                            .check()
-                                            .await
-                                            .map_err(|s| OperationError::from_state(s, &controller))
-                                    })?;
+                                    futures::executor::block_on(controller.check())
+                                        .map_err(|e| OperationError::from_state(e, &controller))?;
 
                                     controller.set_progress((i as f32) / total_paths as f32);
 
@@ -798,11 +790,8 @@ impl Operation {
                                                 })?;
                                             let mut current = 0;
                                             loop {
-                                                futures::executor::block_on(async {
-                                                    controller.check().await.map_err(|s| {
-                                                        OperationError::from_state(s, &controller)
-                                                    })
-                                                })?;
+                                                futures::executor::block_on(controller.check())
+                                                    .map_err(|e| OperationError::from_state(e, &controller))?;
 
                                                 let count =
                                                     file.read(&mut buffer).map_err(|e| {
@@ -849,12 +838,8 @@ impl Operation {
             Self::Delete { paths } => {
                 let total = paths.len();
                 for (i, path) in paths.into_iter().enumerate() {
-                    futures::executor::block_on(async {
-                        controller
-                            .check()
-                            .await
-                            .map_err(|s| OperationError::from_state(s, &controller))
-                    })?;
+                    futures::executor::block_on(controller.check())
+                        .map_err(|e| OperationError::from_state(e, &controller))?;
 
                     controller.set_progress((i as f32) / (total as f32));
 
@@ -881,12 +866,8 @@ impl Operation {
                         let controller = controller_clone;
                         let count = items.len();
                         for (i, item) in items.into_iter().enumerate() {
-                            futures::executor::block_on(async {
-                                controller
-                                    .check()
-                                    .await
-                                    .map_err(|s| OperationError::from_state(s, &controller))
-                            })?;
+                            futures::executor::block_on(controller.check())
+                                .map_err(|e| OperationError::from_state(e, &controller))?;
 
                             controller.set_progress(i as f32 / count as f32);
 
@@ -921,12 +902,8 @@ impl Operation {
                         let mut errors: Vec<trash::Error> = Vec::new();
 
                         for (i, item) in items.into_iter().enumerate() {
-                            futures::executor::block_on(async {
-                                controller
-                                    .check()
-                                    .await
-                                    .map_err(|s| OperationError::from_state(s, &controller))
-                            })?;
+                            futures::executor::block_on(controller.check())
+                                .map_err(|e| OperationError::from_state(e, &controller))?;
 
                             if let Err(e) = trash::os_limited::purge_all([item]) {
                                 errors.push(e);
@@ -975,12 +952,8 @@ impl Operation {
                         let mut written_files = Vec::new();
                         let mut target_dirs = std::collections::HashSet::new();
                         for (i, path) in paths.iter().enumerate() {
-                            futures::executor::block_on(async {
-                                controller
-                                    .check()
-                                    .await
-                                    .map_err(|s| OperationError::from_state(s, &controller))
-                            })?;
+                            futures::executor::block_on(controller.check())
+                                .map_err(|e| OperationError::from_state(e, &controller))?;
 
                             controller.set_progress((i as f32) / total_paths as f32);
 

--- a/src/operation/reader.rs
+++ b/src/operation/reader.rs
@@ -28,12 +28,8 @@ impl OpReader {
 
 impl io::Read for OpReader {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-        cosmic::iced::futures::executor::block_on(async {
-            self.controller
-                .check()
-                .await
-                .map_err(|s| io::Error::other(OperationError::from_state(s, &self.controller)))
-        })?;
+        cosmic::iced::futures::executor::block_on(self.controller.check())
+            .map_err(|s| io::Error::other(OperationError::from_state(s, &self.controller)))?;
 
         let count = self.file.read(buf)?;
         self.current += count as u64;

--- a/src/tab.rs
+++ b/src/tab.rs
@@ -6,7 +6,7 @@ use cosmic::iced::alignment::Vertical;
 use cosmic::iced::clipboard::dnd::DndAction;
 use cosmic::iced::core::mouse::ScrollDelta;
 use cosmic::iced::core::widget::tree;
-use cosmic::iced::futures::{self, SinkExt};
+use cosmic::iced::futures::SinkExt;
 use cosmic::iced::keyboard::Modifiers;
 use cosmic::iced::widget::scrollable::{self, AbsoluteOffset, Viewport};
 use cosmic::iced::widget::{rule, stack};
@@ -7034,7 +7034,7 @@ impl Tab {
                             } = wrapper.clone();
                             stream::channel(
                                 1,
-                                move |mut output: futures::channel::mpsc::Sender<_>| async move {
+                                async move |mut output| {
                                     while crate::operation::is_actively_writing_to(&path) {
                                         crate::operation::actively_writing_tick().await;
                                     }
@@ -7121,7 +7121,7 @@ impl Tab {
                                 |Wrapper { path, controller }| {
                                     let path = path.clone();
                                     let controller = controller.clone();
-                                    stream::channel(1, |mut output: futures::channel::mpsc::Sender<_>| async move {
+                                    stream::channel(1, async move |mut output| {
                                         let message = {
                                             let start = Instant::now();
                                             match calculate_dir_size(&path, controller).await {
@@ -7199,7 +7199,7 @@ impl Tab {
                     let wrapper = wrapper.clone();
                     stream::channel(
                         2,
-                        move |mut output: futures::channel::mpsc::Sender<Message>| async move {
+                        async move |mut output| {
                             let Wrapper {
                                 location,
                                 search_location,
@@ -7296,7 +7296,7 @@ impl Tab {
                     let path = path.clone();
                     stream::channel(
                         1,
-                        |mut output: futures::channel::mpsc::Sender<_>| async move {
+                        async move |mut output| {
                             let message = {
                                 let path = path.clone();
                                 tokio::task::spawn_blocking(move || {


### PR DESCRIPTION
Small style patch extracted from #1751.
 - Use async closures instead of closures that return futures, which is more consise and helps with type inference
 - Remove some wrapping of futures with `async {}` and `.await`
 
----------------------------------------

- [X] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [X] I understand these changes in full and will be able to respond to review comments.
- [X] My change is accurately described in the commit message.
- [X] My contribution is tested and working as described.
- [X] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

