### PR TITLE
perf: use fewer synchronisation primitives

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -49,7 +49,7 @@ use std::future::Future;
 use std::num::NonZeroU16;
 use std::path::{Path, PathBuf};
 use std::pin::Pin;
-use std::sync::{Arc, LazyLock, Mutex};
+use std::sync::{Arc, LazyLock};
 use std::time::{self, Duration, Instant};
 use std::{env, fmt, fs, io, process};
 use tokio::sync::mpsc;
@@ -385,7 +385,7 @@ pub enum Message {
     NetworkResult(MounterKey, String, Result<bool, String>),
     NewItem(Option<Entity>, bool),
     #[cfg(feature = "notify")]
-    Notification(Arc<Mutex<notify_rust::NotificationHandle>>),
+    Notification(Arc<notify_rust::NotificationHandle>),
     NotifyEvents(Vec<DebouncedEvent>),
     NotifyWatcher(WatcherWrapper),
     OpenTerminal(Option<Entity>),
@@ -737,7 +737,7 @@ pub struct App {
     network_drive_connecting: Option<(MounterKey, String)>,
     network_drive_input: String,
     #[cfg(feature = "notify")]
-    notification_opt: Option<Arc<Mutex<notify_rust::NotificationHandle>>>,
+    notification_opt: Option<Arc<notify_rust::NotificationHandle>>,
     #[cfg(all(feature = "wayland", feature = "desktop-applet"))]
     overlap: FxHashMap<String, (window::Id, Rectangle)>,
     pending_operation_id: u64,
@@ -1871,8 +1871,7 @@ impl App {
                 return Task::future(async move {
                     tokio::task::spawn_blocking(move || {
                         //TODO: this is nasty
-                        let notification_mutex = Arc::try_unwrap(notification_arc).unwrap();
-                        let notification = notification_mutex.into_inner().unwrap();
+                        let notification = Arc::try_unwrap(notification_arc).unwrap();
                         notification.close();
                     })
                     .await
@@ -7053,7 +7052,7 @@ impl Application for App {
                                                 let _ = futures::executor::block_on(async {
                                                     msg_tx
                                                         .send(Message::Notification(Arc::new(
-                                                            Mutex::new(notification),
+                                                            notification,
                                                         )))
                                                         .await
                                                 });

--- a/src/app.rs
+++ b/src/app.rs
@@ -1272,16 +1272,14 @@ impl App {
             .insert(id, (operation.clone(), controller.clone()));
 
         // Use a task to send operations to the compio runtime thread.
-        cosmic::Task::stream(cosmic::iced::stream::channel(4, move |msg_tx| async move {
+        cosmic::Task::stream(cosmic::iced::stream::channel(4, async move |mut msg_tx| {
             let (tx, rx) = tokio::sync::oneshot::channel();
-
-            let msg_tx = Arc::new(tokio::sync::Mutex::new(msg_tx));
 
             let msg_tx_clone = msg_tx.clone();
 
             _ = compio_tx
                 .send(Box::pin(async move {
-                    let msg = match operation.perform(&msg_tx_clone, controller).await {
+                    let msg = match operation.perform(msg_tx_clone, controller).await {
                         Ok(result_paths) => Message::PendingComplete(id, result_paths),
                         Err(err) => Message::PendingError(id, err),
                     };
@@ -1291,7 +1289,7 @@ impl App {
                 .await;
 
             if let Ok(msg) = rx.await {
-                let _ = msg_tx.lock().await.send(msg).await;
+                let _ = msg_tx.send(msg).await;
             }
         }))
         .map(cosmic::Action::App)

--- a/src/mime_app.rs
+++ b/src/mime_app.rs
@@ -336,7 +336,7 @@ impl MimeAppCache {
         list.load_from_paths(&paths);
         let locales = fde::get_languages_from_env();
         let desktop_entries = fde::Iter::new(fde::default_paths()).entries(Some(&locales));
-        let mime_icon_cache = mime_icon::MIME_ICON_CACHE.lock().unwrap();
+        let mime_icon_cache = &mime_icon::MIME_ICON_CACHE;
         let shared_mime_info = &mime_icon_cache.shared_mime_info;
         let mut aliased_mimes = FxHashMap::default();
 

--- a/src/mime_icon.rs
+++ b/src/mime_icon.rs
@@ -17,7 +17,7 @@ struct MimeIconKey {
 
 #[derive(Default)]
 pub struct MimeIconCache {
-    cache: FxHashMap<MimeIconKey, Option<icon::Handle>>,
+    cache: Mutex<FxHashMap<MimeIconKey, Option<icon::Handle>>>,
     #[cfg(unix)]
     pub shared_mime_info: xdg_mime::SharedMimeInfo,
 }
@@ -29,8 +29,10 @@ impl MimeIconCache {
     }
 
     #[cfg(unix)]
-    fn get(&mut self, key: MimeIconKey) -> Option<icon::Handle> {
+    fn get(&self, key: MimeIconKey) -> Option<icon::Handle> {
         self.cache
+            .lock()
+            .unwrap()
             .entry(key)
             .or_insert_with_key(|key| {
                 let mut icon_names = self.shared_mime_info.lookup_icon_names(&key.mime);
@@ -50,8 +52,7 @@ impl MimeIconCache {
     }
 }
 
-pub static MIME_ICON_CACHE: LazyLock<Mutex<MimeIconCache>> =
-    LazyLock::new(|| Mutex::new(MimeIconCache::default()));
+pub static MIME_ICON_CACHE: LazyLock<MimeIconCache> = LazyLock::new(MimeIconCache::default);
 
 #[cfg(not(unix))]
 pub fn mime_for_path(
@@ -69,9 +70,8 @@ pub fn mime_for_path(
     remote: bool,
 ) -> Mime {
     let path = path.as_ref();
-    let mime_icon_cache = MIME_ICON_CACHE.lock().unwrap();
     // Try the shared mime info cache first
-    let mut gb = mime_icon_cache.shared_mime_info.guess_mime_type();
+    let mut gb = MIME_ICON_CACHE.shared_mime_info.guess_mime_type();
     gb.zero_size(false);
     if remote {
         if let Some(file_name) = path.file_name().and_then(std::ffi::OsStr::to_str) {
@@ -104,8 +104,7 @@ pub fn mime_for_path(
 }
 
 pub fn mime_icon(mime: Mime, size: u16) -> icon::Handle {
-    let mut mime_icon_cache = MIME_ICON_CACHE.lock().unwrap();
-    match mime_icon_cache.get(MimeIconKey { mime, size }) {
+    match MIME_ICON_CACHE.get(MimeIconKey { mime, size }) {
         Some(handle) => handle,
         None => icon::from_name(FALLBACK_MIME_ICON)
             .prefer_svg(true)
@@ -121,14 +120,11 @@ pub fn parent_mime_types(_mime: &Mime) -> Option<Vec<Mime>> {
 
 #[cfg(unix)]
 pub fn parent_mime_types(mime: &Mime) -> Option<Vec<Mime>> {
-    let mime_icon_cache = MIME_ICON_CACHE.lock().unwrap();
-    mime_icon_cache.shared_mime_info.get_parents_aliased(mime)
+    MIME_ICON_CACHE.shared_mime_info.get_parents_aliased(mime)
 }
 
 pub fn is_mime_subclass_of(mime_type: &Mime, base: &Mime) -> bool {
-    let mime_icon_cache = MIME_ICON_CACHE.lock().unwrap();
-
-    mime_icon_cache
+    MIME_ICON_CACHE
         .shared_mime_info
         .mime_type_subclass(mime_type, base)
 }

--- a/src/operation/mod.rs
+++ b/src/operation/mod.rs
@@ -9,8 +9,7 @@ use std::fmt::Formatter;
 use std::fs;
 use std::io::{self, Read, Write};
 use std::path::{Path, PathBuf};
-use std::sync::Arc;
-use tokio::sync::{Mutex as TokioMutex, mpsc};
+use tokio::sync::mpsc;
 use walkdir::WalkDir;
 use zip::AesMode::Aes256;
 
@@ -27,7 +26,7 @@ use self::recursive::{Context, Method};
 pub mod recursive;
 
 async fn handle_replace(
-    msg_tx: Arc<TokioMutex<Sender<Message>>>,
+    mut msg_tx: Sender<Message>,
     file_from: PathBuf,
     file_to: PathBuf,
     multiple: bool,
@@ -51,8 +50,6 @@ async fn handle_replace(
 
     let (tx, mut rx) = mpsc::channel(1);
     let _ = msg_tx
-        .lock()
-        .await
         .send(Message::DialogPush(
             DialogPage::Replace {
                 from: item_from,
@@ -90,7 +87,7 @@ async fn copy_or_move(
     paths: Vec<PathBuf>,
     to: PathBuf,
     method: Method,
-    msg_tx: &Arc<TokioMutex<Sender<Message>>>,
+    msg_tx: Sender<Message>,
     controller: Controller,
 ) -> Result<OperationSelection, OperationError> {
     let msg_tx = msg_tx.clone();
@@ -651,7 +648,7 @@ impl Operation {
     /// Perform the operation
     pub async fn perform(
         self,
-        msg_tx: &Arc<TokioMutex<Sender<Message>>>,
+        msg_tx: Sender<Message>,
         controller: Controller,
     ) -> Result<OperationSelection, OperationError> {
         let controller_clone = controller.clone();
@@ -1280,7 +1277,6 @@ mod tests {
     use cosmic::iced::futures::{StreamExt, future};
     use log::debug;
     use test_log::test;
-    use tokio::sync;
 
     use super::{Controller, Operation, OperationError, OperationSelection, ReplaceResult};
     use crate::app::test_utils::{
@@ -1297,18 +1293,9 @@ mod tests {
     ) -> Result<OperationSelection, OperationError> {
         let id = fastrand::u64(0..u64::MAX);
         let (tx, mut rx) = mpsc::channel(1);
-        let paths_clone = paths.clone();
-        let to_clone = to.clone();
 
         // Wrap this into its own future so that it may be polled concurerntly with the message handler.
-        let handle_copy = async move {
-            Operation::Copy {
-                paths: paths_clone,
-                to: to_clone,
-            }
-            .perform(&sync::Mutex::new(tx).into(), Controller::default())
-            .await
-        };
+        let handle_copy = Operation::Copy { paths, to }.perform(tx, Controller::default());
 
         // Concurrently handling messages will prevent the mpsc channel from blocking when full.
         let handle_messages = async move {

--- a/src/thumbnailer.rs
+++ b/src/thumbnailer.rs
@@ -6,7 +6,7 @@ use cosmic::desktop::fde::GenericEntry;
 use mime_guess::Mime;
 use rustc_hash::FxHashMap;
 use std::path::Path;
-use std::sync::{LazyLock, Mutex};
+use std::sync::LazyLock;
 use std::time::Instant;
 use std::{fs, process};
 
@@ -165,10 +165,8 @@ impl ThumbnailerCache {
     }
 }
 
-static THUMBNAILER_CACHE: LazyLock<Mutex<ThumbnailerCache>> =
-    LazyLock::new(|| Mutex::new(ThumbnailerCache::new()));
+static THUMBNAILER_CACHE: LazyLock<ThumbnailerCache> = LazyLock::new(ThumbnailerCache::new);
 
 pub fn thumbnailer(mime: &Mime) -> Vec<Thumbnailer> {
-    let thumbnailer_cache = THUMBNAILER_CACHE.lock().unwrap();
-    thumbnailer_cache.get(mime)
+    THUMBNAILER_CACHE.get(mime)
 }


### PR DESCRIPTION
Will definitely conflict with #1994. Also extracted from #1751.
Removes a few `Mutex`s where they are not needed, for a little bit of performance. See each individual commit message for more details.

-----------------------------------------------

- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [X] I understand these changes in full and will be able to respond to review comments.
- [X] My change is accurately described in the commit message.
- [X] My contribution is tested and working as described.
- [X] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

