### PR TITLE
feat: added support symlinks in "list view" mode

### DIFF
--- a/src/mounter/gvfs.rs
+++ b/src/mounter/gvfs.rs
@@ -217,6 +217,7 @@ fn network_scan(uri: &str, sizes: IconSizes) -> Result<Vec<tab::Item>, String> {
             dir_size: DirSize::NotDirectory,
             cut: false,
             checksums: ChecksumState::default(),
+            is_symlink: info.boolean(gio::FILE_ATTRIBUTE_STANDARD_IS_SYMLINK),
         });
     }
     Ok(items)

--- a/src/tab.rs
+++ b/src/tab.rs
@@ -16,7 +16,7 @@ use cosmic::iced::{
 };
 use cosmic::widget::menu::action::MenuAction;
 use cosmic::widget::menu::key_bind::KeyBind;
-use cosmic::widget::{self, DndDestination, DndSource, Id, RcElementWrapper, Widget, space};
+use cosmic::widget::{self, DndDestination, DndSource, Id, RcElementWrapper, Widget, space, icon};
 use cosmic::{Apply, Element, cosmic_theme, font, theme};
 use i18n_embed::LanguageLoader;
 use icu::datetime::input::DateTime;
@@ -81,6 +81,9 @@ const THUMBNAIL_SIZE: u32 = (ICON_SIZE_GRID as u32) * (ICON_SCALE_MAX as u32);
 const TEXT_PREVIEW_MAX_BYTES: usize = 256 * 1024; // 256 KiB
 /// Maximum file size (bytes) to attempt text preview; files larger than this are skipped entirely.
 const TEXT_PREVIEW_MAX_FILE_BYTES: u64 = 8 * 1000 * 1000; // 8 MiB
+// TODO: after creating "emblem-symbolic-link" icon in cosmic-icons need change this
+const SYMLINK_ICON_NAME: &str = "mail-forward-symbolic";
+
 
 // Thumbnail generation semaphore - limits parallel thumbnail workers
 // Uses 4 workers for balanced throughput and memory usage
@@ -708,6 +711,7 @@ pub fn item_from_gvfs_info(path: PathBuf, file_info: gio::FileInfo, sizes: IconS
 
     let display_name = display_name_for_file(&path, &file_info.display_name(), false, is_desktop);
     let hidden = file_name.starts_with('.');
+    let symlink = file_info.symlink_target();
 
     Item {
         name: file_name.into(),
@@ -741,6 +745,7 @@ pub fn item_from_gvfs_info(path: PathBuf, file_info: gio::FileInfo, sizes: IconS
         dir_size,
         cut: false,
         checksums: ChecksumState::default(),
+        is_symlink: symlink.is_some(),
     }
 }
 
@@ -749,6 +754,13 @@ pub fn item_from_search_item(search_item: SearchItem, sizes: IconSizes) -> Item 
         SearchItem::Path(path, name, metadata) => item_from_entry(path, name, metadata, sizes),
         SearchItem::Trash(entry, metadata) => item_from_trash_entry(entry, metadata, sizes),
     }
+}
+
+pub fn check_symlink(path: &PathBuf) -> bool {
+    fs::symlink_metadata(path)
+    .ok()
+    .filter(|meta| meta.is_symlink())          
+    .is_some()
 }
 
 pub fn item_from_entry(
@@ -847,6 +859,8 @@ pub fn item_from_entry(
     }
 
     let display_name = display_name_for_file(&path, &name, is_gvfs, is_desktop);
+    let is_symlink = check_symlink(&path); 
+    let location_opt = Some(Location::Path(path));
 
     Item {
         name,
@@ -857,7 +871,7 @@ pub fn item_from_entry(
             children_opt,
         },
         hidden,
-        location_opt: Some(Location::Path(path)),
+        location_opt: location_opt,
         image_dimensions: None,
         mime,
         icon_handle_grid,
@@ -873,6 +887,7 @@ pub fn item_from_entry(
         dir_size,
         cut: false,
         checksums: ChecksumState::default(),
+        is_symlink: is_symlink,
     }
 }
 
@@ -885,7 +900,9 @@ pub fn item_from_trash_entry(
     let name = entry.name.to_string_lossy().into_owned();
     let display_name = Item::display_name(&name);
 
-    let location = crate::trash::trash_item_path(&entry).map(Location::Path);
+    let trash_path = crate::trash::trash_item_path(&entry);
+    let is_symlink = trash_path.as_ref().map_or(false, |p| check_symlink(p));
+    let location = trash_path.map(Location::Path);
 
     let (mime, icon_handle_grid, icon_handle_list, icon_handle_list_condensed) = match metadata.size
     {
@@ -932,6 +949,7 @@ pub fn item_from_trash_entry(
         dir_size: DirSize::NotDirectory,
         cut: false,
         checksums: ChecksumState::default(),
+        is_symlink: is_symlink,
     }
 }
 
@@ -1399,6 +1417,7 @@ pub fn scan_desktop(
             dir_size: DirSize::NotDirectory,
             cut: false,
             checksums: ChecksumState::default(),
+            is_symlink: false,
         });
     }
 
@@ -2319,6 +2338,7 @@ pub struct Item {
     pub overlaps_drag_rect: bool,
     pub dir_size: DirSize,
     pub checksums: ChecksumState,
+    pub is_symlink: bool,
 }
 
 impl Item {
@@ -2774,6 +2794,139 @@ impl fmt::Debug for SearchContextWrapper {
         f.debug_struct("SearchContextWrapper").finish()
     }
 }
+
+pub struct ListViewRowBuilder {
+    icon_size: u16,
+    row_height: u16,
+    modified_width: f32,
+    size_width: f32,
+    space_xxs: u16,
+}
+
+// TODO: Here are all the possible parameters for different list view modes. This is not ideal; it will require some refactoring in the future.
+impl ListViewRowBuilder {
+    pub fn new(
+        icon_size: u16,
+        row_height: u16,
+        modified_width: f32,
+        size_width: f32,
+        space_xxs: u16,
+    ) -> Self {
+        Self {
+            icon_size,
+            row_height,
+            modified_width,
+            size_width,
+            space_xxs,
+        }
+    }
+
+    fn condensed<'b>(
+        &self,
+        display_name: String,
+        icon_handle_list_condensed: widget::icon::Handle,
+        modified_text: String,
+        size_text: String,
+        is_symlink: bool,
+    ) -> widget::Row<'b, Message, cosmic::prelude::Theme> {
+        let row_height = self.row_height;
+        let space_xxs = self.space_xxs;
+        let icon_size = self.icon_size;
+        let link_icon = icon::from_name(SYMLINK_ICON_NAME).size(icon_size).handle();
+        let link_icon_size = icon_size/2;
+
+        let item_name_widget = if is_symlink {
+            widget::row::with_children([
+                    widget::icon::icon(link_icon)
+                        .content_fit(ContentFit::Contain)
+                        .width(Length::Fixed(link_icon_size as f32))
+                        .height(Length::Fixed(link_icon_size as f32))
+                        .size(icon_size)
+                        .into(),
+                    Item::list_display_name(display_name).into(),
+                ])
+        } else {
+            widget::row::with_children([
+                    Item::list_display_name(display_name).into(),
+                ])
+        };
+
+        widget::row::with_children([
+            widget::icon::icon(icon_handle_list_condensed)
+                .content_fit(ContentFit::Contain)
+                .size(icon_size)
+                .into(),
+            widget::column::with_children([
+                item_name_widget
+                .align_y(Alignment::Center)
+                .into(),
+                widget::text::caption(format!("{modified_text} - {size_text}")).into(),
+            ])
+            .into(),
+        ])
+        .height(Length::Fixed(f32::from(row_height)))
+        .align_y(Alignment::Center)
+        .spacing(space_xxs)
+        .into()
+    }
+
+    pub fn wide<'b>(
+        &self,
+        display_name: String,
+        icon_handle_list: widget::icon::Handle,
+        modified_text: String,
+        size_text: String,
+        is_symlink: bool,
+    ) -> widget::Row<'b, Message, cosmic::prelude::Theme> {
+        let icon_size = self.icon_size;
+        let modified_width = self.modified_width;
+        let size_width = self.size_width;
+        let row_height = self.row_height;
+        let space_xxs = self.space_xxs;
+        let link_icon = icon::from_name(SYMLINK_ICON_NAME).size(icon_size).handle();
+        let item_name_widget = if is_symlink {
+            widget::row::with_children([
+                    widget::icon::icon(link_icon)
+                        .content_fit(ContentFit::Contain)
+                        .width(Length::Fixed(icon_size as f32))
+                        .height(Length::Fixed(icon_size as f32))
+                        .size(icon_size)
+                    .into(),
+                    Item::list_display_name(display_name)
+                        .width(Length::Fill)
+                        .into(),
+                ])
+        } else {
+            widget::row::with_children([
+                    Item::list_display_name(display_name)
+                        .width(Length::Fill)
+                        .into(),
+                ])
+        };
+
+        widget::row::with_children([
+            widget::icon::icon(icon_handle_list.clone())
+                .content_fit(ContentFit::Contain)
+                .size(icon_size)
+                .into(),
+                item_name_widget
+                .spacing(self.space_xxs)
+                .align_y(Alignment::Center) 
+                .width(Length::Fill)
+                .into(),
+            widget::text::body(modified_text.clone())
+                .width(Length::Fixed(modified_width))
+                .into(),
+            widget::text::body(size_text.clone())
+                .width(Length::Fixed(size_width))
+                .into(),
+        ])
+        .height(Length::Fixed(f32::from(row_height)))
+        .align_y(Alignment::Center)
+        .spacing(space_xxs)
+    }
+}
+
 
 // TODO when creating items, pass <Arc<SelectedItems>> to each item
 // as a drag data, so that when dnd is initiated, they are all included
@@ -6085,6 +6238,11 @@ impl Tab {
         if let Some(items) = self.column_sort() {
             let mut count = 0;
             let mut hidden = 0;
+            let row_builder = ListViewRowBuilder::new(icon_size.clone(), 
+                row_height.clone(), 
+                modified_width.clone(), 
+                size_width.clone(), 
+                space_xxs.clone());
             for (i, item) in items {
                 if item.hidden && !show_hidden {
                     item.pos_opt.set(None);
@@ -6186,22 +6344,8 @@ impl Tab {
                     };
 
                     let row = if condensed {
-                        widget::row::with_children([
-                            widget::icon::icon(item.icon_handle_list_condensed.clone())
-                                .content_fit(ContentFit::Contain)
-                                .size(icon_size)
-                                .into(),
-                            widget::column::with_children([
-                                Item::list_display_name(item.display_name.clone()).into(),
-                                //TODO: translate?
-                                widget::text::caption(format!("{modified_text} - {size_text}"))
-                                    .into(),
-                            ])
-                            .into(),
-                        ])
-                        .height(Length::Fixed(f32::from(row_height)))
-                        .align_y(Alignment::Center)
-                        .spacing(space_xxs)
+                        row_builder.condensed(item.display_name.clone(), item.icon_handle_list_condensed.clone(), 
+                            modified_text.clone(), size_text.clone(), item.is_symlink)
                     } else if is_search {
                         widget::row::with_children([
                             widget::icon::icon(item.icon_handle_list_condensed.clone())
@@ -6229,24 +6373,11 @@ impl Tab {
                         .align_y(Alignment::Center)
                         .spacing(space_xxs)
                     } else {
-                        widget::row::with_children([
-                            widget::icon::icon(item.icon_handle_list.clone())
-                                .content_fit(ContentFit::Contain)
-                                .size(icon_size)
-                                .into(),
-                            Item::list_display_name(item.display_name.clone())
-                                .width(Length::Fill)
-                                .into(),
-                            widget::text::body(modified_text.clone())
-                                .width(Length::Fixed(modified_width))
-                                .into(),
-                            widget::text::body(size_text.clone())
-                                .width(Length::Fixed(size_width))
-                                .into(),
-                        ])
-                        .height(Length::Fixed(f32::from(row_height)))
-                        .align_y(Alignment::Center)
-                        .spacing(space_xxs)
+                        row_builder.wide(item.display_name.clone(),
+                        item.icon_handle_list.clone(),
+                            modified_text.clone(),
+                            size_text.clone(),
+                        item.is_symlink)
                     };
 
                     let button = |row| {


### PR DESCRIPTION
- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

Added support for symlinks for "list view" mode. Details can be found at the following link: [issue](https://github.com/pop-os/cosmic-files/issues/1981 ).

Due to the absence of the "emblem-symbolic-link" icon, the more suitable of the existing ones was chosen - "mail-forward-symbolic".
I did a little refactoring of the "list_view" function, as it seemed too complicated to me. Some of the string generation methods have been moved to the ListViewRowBuilder abstraction. Refactoring is shallow to reduce the size of the PR.
It works in wide list mode.
<img width="787" height="280" alt="image" src="https://github.com/user-attachments/assets/831379b7-ccba-45f3-a1b8-491c326cffa6" />

It works in the list mode in an brief mode.
<img width="560" height="273" alt="image" src="https://github.com/user-attachments/assets/a14e4aa6-ae10-45d3-b569-e56319090736" />

It works for the trash.
<img width="782" height="420" alt="image" src="https://github.com/user-attachments/assets/3050d4b9-8053-48c6-81fd-e14e6b0e7809" />

