### PR TITLE
Align center for text on items in grid view. fixes #754

### DIFF
--- a/src/tab.rs
+++ b/src/tab.rs
@@ -2355,6 +2355,7 @@ impl Item {
     ) -> widget::Text<'a, cosmic::Theme, cosmic::Renderer> {
         widget::text::body(name)
             .wrapping(text::Wrapping::WordOrGlyph)
+            .align_x(text::Alignment::Center)
             .ellipsize(text::Ellipsize::Middle(text::EllipsizeHeightLimit::Lines(
                 3,
             )))


### PR DESCRIPTION
- [X] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [X] I understand these changes in full and will be able to respond to review comments.
- [X] My change is accurately described in the commit message.
- [X] My contribution is tested and working as described.
- [X] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.


Side by side with Nautilus:

<img width="2076" height="906" alt="Center-aligned-text-grid-view" src="https://github.com/user-attachments/assets/f6507aae-d077-4972-ae5e-cc912a1d2195" />

I think there was an issue with the previous version of iced text Alignment implementation according to this comment: https://github.com/pop-os/cosmic-files/issues/754#issuecomment-3935651897

fixes #754 
Should work for the desktop, although i didn't test the applet.