### PR TITLE
fix: retry thumbnails after file changes and stale fail markers

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -3732,7 +3732,10 @@ impl Application for App {
                                                             );
                                                         }
                                                     }
-                                                    //TODO item.thumbnail_opt =
+                                                    // Force the thumbnail to be regenerated, since the
+                                                    // file's data or metadata (mtime/size) changed and any
+                                                    // previous thumbnail or failure marker may be stale.
+                                                    item.thumbnail_opt = None;
                                                 }
                                             }
                                         }

--- a/src/thumbnail_cacher.rs
+++ b/src/thumbnail_cacher.rs
@@ -8,9 +8,16 @@ use std::io::{self, BufReader, BufWriter};
 use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
 use std::sync::LazyLock;
-use std::time::UNIX_EPOCH;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use tempfile::NamedTempFile;
 use url::Url;
+
+/// Fail markers older than this are ignored, so a file that previously failed
+/// to thumbnail (e.g. because a thumbnailer was missing) is retried even when
+/// the source file itself never changed.
+// 24h: long enough to avoid hammering a file that keeps failing, short enough
+// that a fix (e.g. installing a thumbnailer) is picked up the same day.
+const FAIL_MARKER_TTL: Duration = Duration::from_secs(24 * 60 * 60);
 
 /// Implements thumbnail caching based on the freedesktop.org Thumbnail Managing Standard.
 /// <https://specifications.freedesktop.org/thumbnail-spec/latest>/
@@ -80,7 +87,7 @@ impl ThumbnailCacher {
         }
 
         // Check if there is a fail marker from an earlier failure.
-        if self.is_thumbnail_valid(&self.thumbnail_fail_marker_path) {
+        if self.is_fail_marker_valid() {
             return CachedThumbnail::Failed;
         }
 
@@ -287,6 +294,39 @@ impl ThumbnailCacher {
 
         true
     }
+
+    /// Like `is_thumbnail_valid`, but also treats the fail marker as invalid
+    /// once it's older than `FAIL_MARKER_TTL`. This covers failures caused by
+    /// a transient or environmental issue (e.g. a missing thumbnailer that
+    /// gets installed later), where the source file's mtime/size never
+    /// change and so would otherwise never be retried.
+    fn is_fail_marker_valid(&self) -> bool {
+        match fs::metadata(&self.thumbnail_fail_marker_path).and_then(|m| m.modified()) {
+            Ok(marker_mtime) => match SystemTime::now().duration_since(marker_mtime) {
+                Ok(age) if is_fail_marker_expired(age) => return false,
+                // Age within the TTL: fall through to the normal validity check.
+                Ok(_) => {}
+                Err(_) => {
+                    // The marker's mtime is in the future (clock skew, a
+                    // restored backup, etc). Don't trust a clock that's
+                    // wrong: treat the marker as expired so we retry
+                    // instead of getting stuck on it indefinitely.
+                    return false;
+                }
+            },
+            Err(_) => {
+                // No fail marker on disk, or its metadata can't be read.
+                // `is_thumbnail_valid` below will correctly return false
+                // in that case too, causing a retry.
+            }
+        }
+
+        self.is_thumbnail_valid(&self.thumbnail_fail_marker_path)
+    }
+}
+
+fn is_fail_marker_expired(age: Duration) -> bool {
+    age > FAIL_MARKER_TTL
 }
 
 fn thumbnail_uri(path: &Path) -> io::Result<String> {
@@ -367,3 +407,22 @@ static THUMBNAIL_CACHE_BASE_DIR: LazyLock<Option<PathBuf>> = LazyLock::new(|| {
 
     None
 });
+
+#[cfg(test)]
+mod tests {
+    use super::{FAIL_MARKER_TTL, is_fail_marker_expired};
+    use std::time::Duration;
+
+    #[test]
+    fn fail_marker_not_expired_within_ttl() {
+        assert!(!is_fail_marker_expired(Duration::ZERO));
+        assert!(!is_fail_marker_expired(FAIL_MARKER_TTL));
+    }
+
+    #[test]
+    fn fail_marker_expired_past_ttl() {
+        assert!(is_fail_marker_expired(
+            FAIL_MARKER_TTL + Duration::from_secs(1)
+        ));
+    }
+}


### PR DESCRIPTION
- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

AI disclosure: this fix was developed with the assistance of Claude Code (an AI coding assistant). I reviewed the generated diff line by line, understand the mechanism it relies on, and personally ran the manual verification described below on a real build before opening this PR.

Observed behavior

When cosmic-files fails to generate a thumbnail for a video, it never retries that file, even after the root cause is gone (missing codec installed later, file replaced, permissions fixed). The fail marker is effectively permanent.

Root cause

There were two independent bugs.

1. In-memory state never reset (src/app.rs:3735). The filesystem watcher handler for Message::NotifyEvents already refreshed an item's on-disk metadata when the file changed, but left a TODO instead of clearing item.thumbnail_opt. The thumbnail generation loop skips any item where thumbnail_opt.is_some() (src/tab.rs:7065-7067), so once an item was marked NotImage after a failure, it stayed that way for the rest of the session, even though the on-disk fail marker had already become invalid through its own mtime/size check (src/thumbnail_cacher.rs:202-289). The cache was correct, the UI just never asked it again.

2. On-disk fail marker has no expiry for failures unrelated to the file itself. The fail marker follows the freedesktop Thumbnail Managing Standard and stores Thumb::URI, Thumb::MTime and Thumb::Size, invalidating only when the source file changes. A failure caused by something external to the file, such as a missing thumbnailer that gets installed later, never changes the video file, so the marker never expired.

Approach chosen

1. src/app.rs: replace the TODO with item.thumbnail_opt = None when the watcher detects Data or Metadata changes on a file. This alone fixes the case where the file itself changes while the folder is open, with no tradeoff: it just makes the in-memory state match what the disk cache already knew.

2. src/thumbnail_cacher.rs: add a 24 hour TTL on the fail marker (FAIL_MARKER_TTL). is_fail_marker_valid() checks the marker file's own mtime; past the TTL, or if the marker's mtime is in the future (clock skew, a restored backup), it is treated as expired and the thumbnail is retried, regardless of whether the source file changed. This covers failures whose cause was external to the file. The TTL value is intentionally hardcoded and not user configurable for now, to keep the fix minimal; it can be exposed later if there is demand for a different value.

Each retry that fails calls create_fail_marker() again, which rewrites the marker file, so its mtime resets and the 24 hour window restarts. A file that is genuinely and persistently broken is therefore retried at most once per day, not in a tight loop.

These two changes are independent. Item 1 fixes the bug described in the issue title with no downside. Item 2 is the part that involves a judgment call (the TTL value) and can be reviewed or adjusted separately without affecting item 1.

Alternative considered

Relying only on the existing freedesktop mtime/size invalidation, with no TTL. This was rejected because the most common cause of a video thumbnail failure, such as a missing or crashing external thumbnailer, does not change the video file at all. A marker invalidated only by mtime/size would never expire in that case, which is the exact behavior reported in the issue.

Manual verification

To force a thumbnail failure, shadow the thumbnailer's own binary through PATH, rather than editing any .thumbnailer file. Thumbnailer discovery in src/thumbnailer.rs:75-149 collects entries from every XDG data directory into one list per mimetype and tries each in order, with no deduplication by filename or app id. A broken entry placed in $XDG_DATA_HOME/thumbnailers therefore does not shadow the real one in /usr/share/thumbnailers: both get collected, and the working system entry still succeeds after the broken one fails. Overriding XDG_DATA_DIRS entirely to hide the real entry also does not work cleanly: the xdg-mime crate used for mime type detection in this app (src/mime_icon.rs) reads the same XDG_DATA_DIRS and XDG_DATA_HOME variables to locate the shared MIME database, so hiding the thumbnailer this way risks breaking mime detection for the file being tested too. Replacing the thumbnailer's Exec binary on PATH avoids all of this: command resolution by PATH always takes the first match, so it reliably fails, and it can be flipped back to the real binary without restarting anything.

Reproduction A, in-memory state bug:
1. Find the Exec binary of the relevant thumbnailer, for example grep Exec /usr/share/thumbnailers/*.thumbnailer. On this system it is cosmic-player.
2. Create a fake binary ahead of it on PATH:
   mkdir -p /tmp/fakebin
   printf '#!/bin/sh\nexit 1\n' > /tmp/fakebin/cosmic-player
   chmod +x /tmp/fakebin/cosmic-player
3. Launch cosmic-files with that PATH override and open a folder containing a video: PATH="/tmp/fakebin:$PATH" cosmic-files /path/to/folder
   The item shows a generic icon and a fail marker appears under `~/.cache/thumbnails/fail/cosmic-files-<version>/`.
4. Without closing the folder or restarting the app, make the fake binary pass through to the real one: printf '#!/bin/sh\nexec /usr/bin/cosmic-player "$@"\n' > /tmp/fakebin/cosmic-player
   Then overwrite the video file in place with different content (for example cat other_video.mp4 > video.mp4, not mv, so the file keeps the same inode and produces a Modify event instead of a Create/Delete pair).
5. Before this fix: the item keeps showing the generic icon forever, since the only branch that resets thumbnail_opt was a bare TODO. After this fix: within a couple of seconds the real thumbnail appears, without reopening the folder. The debug log (RUST_LOG=cosmic_files=debug) shows a Modify(Data(Any)) event with no accompanying rescan_tab, confirming the fix's own code path handled it rather than a full tab reload.

Reproduction B, TTL for environmental failures:
1. Repeat steps 1 to 3 above to get a fail marker on disk.
2. Restore the real binary on PATH by running only the printf command from step 4 above (the one that makes the fake cosmic-player exec into the real binary). Do not run the video overwrite from that same step 4, and do not touch the video file in any way: this reproduction is specifically testing that the marker expires by age alone, not by a file change.
3. Before this fix: closing and reopening the folder, or restarting the app, still shows the generic icon forever, since the fail marker's Thumb::MTime and Thumb::Size still match the unchanged file.
4. After this fix: age the marker past the TTL without touching the video:
   `touch -d "-25 hours" ~/.cache/thumbnails/fail/cosmic-files-<version>/<hash>.png`
   Reopen the folder or restart the app. The thumbnail is retried and appears correctly, even though the video file's mtime and size never changed.

Both reproductions above were run against a real build of this branch, verified through the debug log and the cache directory contents rather than only by inspection.

Automated tests

cosmic-files has no integration tests that exercise a real thumbnailer or open the UI, so this fix adds unit tests for the pure TTL comparison logic (is_fail_marker_expired), which is deterministic and does not depend on the system clock or filesystem state. The rest is covered by the manual reproduction above.

cargo build --release, cargo fmt and cargo clippy all pass with no new warnings.

Fixes #1997
