### PR TITLE
fix: freezing of rubber band  selection pause on first frame

### DIFF
--- a/src/tab.rs
+++ b/src/tab.rs
@@ -3847,7 +3847,6 @@ impl Tab {
                 }
             }
             Message::Drag(rect_opt) => {
-                self.watch_drag = false;
                 if let Some(rect) = rect_opt {
                     self.context_menu = None;
                     self.location_context_menu_index = None;

--- a/src/tab.rs
+++ b/src/tab.rs
@@ -3847,6 +3847,7 @@ impl Tab {
                 }
             }
             Message::Drag(rect_opt) => {
+                self.watch_drag = true;
                 if let Some(rect) = rect_opt {
                     self.context_menu = None;
                     self.location_context_menu_index = None;


### PR DESCRIPTION
watch_drag is  false so on the first drag frame , drag watching is disabled.  thats why only one single frame is visible on empty spaces .

- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

