### PR TITLE
feat: show disk usage in sidebar

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -70,7 +70,8 @@ use crate::key_bind::key_binds;
 use crate::localize::LANGUAGE_SORTER;
 use crate::mime_app::{self, MimeApp, MimeAppCache, MimeAppMatch};
 use crate::mounter::{
-    MOUNTERS, MounterAuth, MounterItem, MounterItems, MounterKey, MounterMessage,
+    DiskUsage, DiskUsageLevel, MOUNTERS, MounterAuth, MounterItem, MounterItems, MounterKey,
+    MounterMessage,
 };
 use crate::operation::{
     Controller, Operation, OperationError, OperationErrorType, OperationSelection, ReplaceResult,
@@ -1774,9 +1775,7 @@ impl App {
 
         for (favorite_i, favorite) in self.config.favorites.iter().enumerate() {
             if let Some(path) = favorite.path_opt() {
-                let name = favorite
-                    .display_name()
-                    .unwrap_or_else(|| fl!("filesystem"));
+                let name = favorite.display_name().unwrap_or_else(|| fl!("filesystem"));
                 nav_model = nav_model.insert(move |b| {
                     b.text(name.clone())
                         .icon(
@@ -1846,8 +1845,11 @@ impl App {
                 if let Some(icon) = item.icon(true) {
                     b = b.icon(icon::icon(icon).size(16));
                 }
-                if item.is_mounted() {
+                if item.can_unmount() {
                     b = b.closable();
+                }
+                if let Some(disk_usage) = item.disk_usage() {
+                    b = b.data(disk_usage);
                 }
                 if i == 0 {
                     b = b.divider_above();
@@ -2530,31 +2532,114 @@ impl Application for App {
 
         let nav_model = self.nav_model()?;
 
-        let mut nav = cosmic::widget::nav_bar(nav_model, |entity| {
-            cosmic::Action::Cosmic(cosmic::app::Action::NavBar(entity))
-        })
-        .drag_id(self.nav_drag_id)
-        .on_dnd_enter(|entity, _| cosmic::Action::App(Message::DndEnterNav(entity)))
-        .on_dnd_leave(|_| cosmic::Action::App(Message::DndExitNav))
-        .on_dnd_drop(|entity, data, action| {
-            cosmic::Action::App(Message::DndDropNav(entity, data, action))
-        })
-        .on_context(|entity| cosmic::Action::App(Message::NavBarContext(entity)))
-        .on_close(|entity| cosmic::Action::App(Message::NavBarClose(entity)))
-        .on_middle_press(|entity| {
-            cosmic::Action::App(Message::NavMenuAction(NavMenuAction::OpenInNewTab(entity)))
-        })
-        .context_menu(self.nav_context_menu())
-        .close_icon(icon::from_name("media-eject-symbolic").size(16).icon());
+        let cosmic_theme::Spacing {
+            space_s, space_xxs, ..
+        } = theme::spacing();
+        const BUTTON_HEIGHT: u16 = 40;
+
+        #[allow(unused_mut)]
+        let mut segmented = segmented_button::vertical(nav_model)
+            .on_activate(|entity| cosmic::Action::Cosmic(cosmic::app::Action::NavBar(entity)))
+            .drag_id(self.nav_drag_id)
+            .on_dnd_enter(|entity, _| cosmic::Action::App(Message::DndEnterNav(entity)))
+            .on_dnd_leave(|_| cosmic::Action::App(Message::DndExitNav))
+            .on_dnd_drop(|entity, data, action| {
+                cosmic::Action::App(Message::DndDropNav(entity, data, action))
+            })
+            .on_context(|entity| cosmic::Action::App(Message::NavBarContext(entity)))
+            .on_close(|entity| cosmic::Action::App(Message::NavBarClose(entity)))
+            .on_middle_press(|entity| {
+                cosmic::Action::App(Message::NavMenuAction(NavMenuAction::OpenInNewTab(entity)))
+            })
+            .context_menu(self.nav_context_menu())
+            .close_icon(icon::from_name("media-eject-symbolic").size(16).icon())
+            .button_height(BUTTON_HEIGHT)
+            .button_padding([space_s, space_xxs, space_s, space_xxs])
+            .button_spacing(space_xxs)
+            .spacing(space_xxs)
+            .style(theme::SegmentedButton::NavBar);
 
         #[cfg(feature = "wayland")]
         {
-            nav = nav
+            segmented = segmented
                 .window_id_maybe(self.core().main_window_id())
                 .on_surface_action(|m| cosmic::Action::Cosmic(cosmic::app::Action::Surface(m)))
         }
 
-        let mut nav = nav.into_container();
+        let mut usage_overlay = widget::column::with_capacity(nav_model.len() * 3);
+        for (i, entity) in nav_model.iter().enumerate() {
+            if i > 0 {
+                usage_overlay = usage_overlay
+                    .push(widget::space::vertical().height(Length::Fixed(f32::from(space_xxs))));
+                if nav_model.divider_above(entity).unwrap_or(false) {
+                    usage_overlay = usage_overlay.push(
+                        widget::space::vertical().height(Length::Fixed(1.0 + f32::from(space_xxs))),
+                    );
+                }
+            }
+
+            let usage_row: Element<'_, cosmic::Action<Message>> = if let Some(usage) =
+                nav_model.data::<DiskUsage>(entity)
+            {
+                let horizontal_inset = f32::from(space_s + 16 + space_xxs);
+                widget::column::with_children([
+                        widget::space::vertical().height(Length::Fill).into(),
+                        widget::row::with_children([
+                            widget::space::horizontal()
+                                .width(Length::Fixed(horizontal_inset))
+                                .into(),
+                            iced::widget::progress_bar(0.0..=1.0, usage.fraction())
+                                .girth(3)
+                                .length(Length::Fill)
+                                .class(match usage.level() {
+                                    DiskUsageLevel::Normal => theme::ProgressBar::Primary,
+                                    DiskUsageLevel::Warning => {
+                                        theme::ProgressBar::custom(|app_theme| {
+                                            let mut style = <cosmic::Theme as iced::widget::progress_bar::Catalog>::style(
+                                                app_theme,
+                                                &theme::ProgressBar::Primary,
+                                            );
+                                            style.bar = iced::Color::from(
+                                                app_theme.cosmic().warning_color(),
+                                            )
+                                            .into();
+                                            style
+                                        })
+                                    }
+                                    DiskUsageLevel::Critical => theme::ProgressBar::Danger,
+                                })
+                                .into(),
+                            widget::space::horizontal()
+                                .width(Length::Fixed(horizontal_inset))
+                                .into(),
+                        ])
+                        .into(),
+                        widget::space::vertical().height(Length::Fixed(4.0)).into(),
+                    ])
+                    .height(Length::Fixed(f32::from(BUTTON_HEIGHT)))
+                    .into()
+            } else {
+                widget::space::vertical()
+                    .height(Length::Fixed(f32::from(BUTTON_HEIGHT)))
+                    .into()
+            };
+            usage_overlay = usage_overlay.push(usage_row);
+        }
+
+        let layered_nav = iced::widget::Stack::with_children([
+            Element::from(segmented),
+            Element::from(usage_overlay),
+        ])
+        .width(Length::Fill);
+        let nav = widget::container(layered_nav).padding(space_xxs);
+        let nav = widget::scrollable(nav)
+            .class(cosmic::style::iced::Scrollable::Minimal)
+            .height(Length::Fill);
+        let mut nav = widget::container(nav)
+            .height(Length::Fill)
+            .class(theme::Container::custom(
+                cosmic::widget::nav_bar::nav_bar_style,
+            ));
 
         if !self.core.is_condensed() {
             nav = nav.max_width(280);
@@ -5309,16 +5394,10 @@ impl Application for App {
                 }
 
                 NavMenuAction::ChangeSidebarLabel(entity) => {
-                    if let Some(favorite) = self
-                        .nav_model
-                        .data::<FavoriteIndex>(entity)
-                        .and_then(|FavoriteIndex(favorite_i)| {
-                            self.config.favorites.get(*favorite_i)
-                        })
-                    {
-                        let label = favorite
-                            .display_name()
-                            .unwrap_or_else(|| fl!("filesystem"));
+                    if let Some(favorite) = self.nav_model.data::<FavoriteIndex>(entity).and_then(
+                        |FavoriteIndex(favorite_i)| self.config.favorites.get(*favorite_i),
+                    ) {
+                        let label = favorite.display_name().unwrap_or_else(|| fl!("filesystem"));
                         return Task::batch([
                             self.dialog_pages
                                 .push_back(DialogPage::ChangeSidebarLabel { entity, label }),

--- a/src/dialog.rs
+++ b/src/dialog.rs
@@ -924,7 +924,7 @@ impl App {
                 if let Some(icon) = item.icon(true) {
                     b = b.icon(widget::icon::icon(icon).size(16));
                 }
-                if item.is_mounted() {
+                if item.can_unmount() {
                     b = b.closable();
                 }
                 if i == 0 {

--- a/src/mounter/gvfs.rs
+++ b/src/mounter/gvfs.rs
@@ -11,7 +11,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use tokio::sync::mpsc;
 
-use super::{Mounter, MounterAuth, MounterItem, MounterItems, MounterMessage};
+use super::{DiskUsage, Mounter, MounterAuth, MounterItem, MounterItems, MounterMessage};
 use crate::config::IconSizes;
 use crate::err_str;
 use crate::tab::{self, ChecksumState, DirSize, ItemMetadata, ItemThumbnail, Location};
@@ -57,6 +57,37 @@ fn gio_icon_to_path(icon: &gio::Icon, size: u16) -> Option<PathBuf> {
     None
 }
 
+fn filesystem_details(file: &gio::File) -> (bool, Option<DiskUsage>) {
+    let filesystem_info = file
+        .query_filesystem_info(
+            "filesystem::remote,filesystem::size,filesystem::free",
+            gio::Cancellable::NONE,
+        )
+        .ok();
+    let is_remote = filesystem_info
+        .as_ref()
+        .map(|info| info.boolean(gio::FILE_ATTRIBUTE_FILESYSTEM_REMOTE))
+        .unwrap_or(true); // Default to remote if query fails
+    let disk_usage_opt = if is_remote {
+        None
+    } else {
+        filesystem_info.as_ref().and_then(|info| {
+            let total = info.attribute_uint64(gio::FILE_ATTRIBUTE_FILESYSTEM_SIZE);
+            (total > 0).then(|| DiskUsage {
+                free: info.attribute_uint64(gio::FILE_ATTRIBUTE_FILESYSTEM_FREE),
+                total,
+            })
+        })
+    };
+
+    (is_remote, disk_usage_opt)
+}
+
+#[cfg(unix)]
+fn should_add_system_mount(system_path: &std::path::Path, mounted_paths: &[PathBuf]) -> bool {
+    !mounted_paths.iter().any(|path| path == system_path)
+}
+
 fn items(monitor: &gio::VolumeMonitor, sizes: IconSizes) -> MounterItems {
     let mut items: MounterItems = (monitor.mounts().into_iter())
         .enumerate()
@@ -64,14 +95,7 @@ fn items(monitor: &gio::VolumeMonitor, sizes: IconSizes) -> MounterItems {
         .filter(|(_, mount)| !mount.is_shadowed())
         .map(|(i, mount)| {
             let root = MountExt::root(&mount);
-            let is_remote = root
-                .query_filesystem_info(
-                    gio::FILE_ATTRIBUTE_FILESYSTEM_REMOTE,
-                    gio::Cancellable::NONE,
-                )
-                .ok()
-                .map(|info| info.boolean(gio::FILE_ATTRIBUTE_FILESYSTEM_REMOTE))
-                .unwrap_or(true); // Default to remote if query fails
+            let (is_remote, disk_usage_opt) = filesystem_details(&root);
 
             MounterItem::Gvfs(Item {
                 uri: mount.root().uri().into(),
@@ -83,9 +107,40 @@ fn items(monitor: &gio::VolumeMonitor, sizes: IconSizes) -> MounterItems {
                 icon_opt: gio_icon_to_path(&MountExt::icon(&mount), sizes.grid()),
                 icon_symbolic_opt: gio_icon_to_path(&MountExt::symbolic_icon(&mount), 16),
                 path_opt: root.path(),
+                disk_usage_opt,
             })
         })
         .collect();
+
+    // GVolumeMonitor intentionally omits system-internal mounts such as `/`. Add the root
+    // filesystem explicitly so its capacity is represented in the sidebar, but keep it
+    // non-unmountable.
+    #[cfg(unix)]
+    {
+        let system_path = PathBuf::from("/");
+        let mounted_paths: Vec<_> = items.iter().filter_map(MounterItem::path).collect();
+        if should_add_system_mount(&system_path, &mounted_paths)
+            && let (Some(mount), _) = gio::UnixMountEntry::for_mount_path(&system_path)
+        {
+            let root = gio::File::for_path(&system_path);
+            let (is_remote, disk_usage_opt) = filesystem_details(&root);
+            if !is_remote && disk_usage_opt.is_some() {
+                items.push(MounterItem::Gvfs(Item {
+                    uri: root.uri().into(),
+                    kind: ItemKind::SystemMount,
+                    index: 0,
+                    name: mount.guess_name().into(),
+                    is_mounted: true,
+                    is_remote: false,
+                    icon_opt: gio_icon_to_path(&mount.guess_icon(), sizes.grid()),
+                    icon_symbolic_opt: gio_icon_to_path(&mount.guess_symbolic_icon(), 16),
+                    path_opt: Some(system_path),
+                    disk_usage_opt,
+                }));
+            }
+        }
+    }
+
     items.extend(
         (monitor.volumes().into_iter())
             .enumerate()
@@ -106,6 +161,7 @@ fn items(monitor: &gio::VolumeMonitor, sizes: IconSizes) -> MounterItems {
                     icon_opt: gio_icon_to_path(&VolumeExt::icon(&volume), sizes.grid()),
                     icon_symbolic_opt: gio_icon_to_path(&VolumeExt::symbolic_icon(&volume), 16),
                     path_opt: None,
+                    disk_usage_opt: None,
                 })
             }),
     );
@@ -344,7 +400,14 @@ enum Event {
 #[derive(Clone, Debug)]
 enum ItemKind {
     Mount,
+    SystemMount,
     Volume,
+}
+
+impl ItemKind {
+    const fn can_unmount(&self) -> bool {
+        matches!(self, Self::Mount)
+    }
 }
 
 //TODO: better method of matching items
@@ -359,6 +422,7 @@ pub struct Item {
     icon_opt: Option<PathBuf>,
     icon_symbolic_opt: Option<PathBuf>,
     path_opt: Option<PathBuf>,
+    disk_usage_opt: Option<DiskUsage>,
 }
 
 impl Item {
@@ -389,6 +453,14 @@ impl Item {
 
     pub fn path(&self) -> Option<PathBuf> {
         self.path_opt.clone()
+    }
+
+    pub const fn disk_usage(&self) -> Option<DiskUsage> {
+        self.disk_usage_opt
+    }
+
+    pub const fn can_unmount(&self) -> bool {
+        self.kind.can_unmount()
     }
 }
 

--- a/src/mounter/mod.rs
+++ b/src/mounter/mod.rs
@@ -9,6 +9,46 @@ use tokio::sync::mpsc;
 use crate::config::IconSizes;
 use crate::tab;
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct DiskUsage {
+    pub free: u64,
+    pub total: u64,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum DiskUsageLevel {
+    Normal,
+    Warning,
+    Critical,
+}
+
+impl DiskUsage {
+    #[allow(clippy::cast_precision_loss)]
+    pub fn fraction(self) -> f32 {
+        if self.total == 0 || self.free > self.total {
+            return 0.0;
+        }
+
+        (self.total - self.free) as f32 / self.total as f32
+    }
+
+    pub fn level(self) -> DiskUsageLevel {
+        if self.total == 0 || self.free > self.total {
+            return DiskUsageLevel::Normal;
+        }
+
+        let used = u128::from(self.total - self.free);
+        let total = u128::from(self.total);
+        if used * 100 >= total * 90 {
+            DiskUsageLevel::Critical
+        } else if used * 100 >= total * 80 {
+            DiskUsageLevel::Warning
+        } else {
+            DiskUsageLevel::Normal
+        }
+    }
+}
+
 #[cfg(feature = "gvfs")]
 mod gvfs;
 
@@ -95,6 +135,22 @@ impl MounterItem {
         match self {
             #[cfg(feature = "gvfs")]
             Self::Gvfs(item) => item.is_remote(),
+            Self::None => unreachable!(),
+        }
+    }
+
+    pub fn disk_usage(&self) -> Option<DiskUsage> {
+        match self {
+            #[cfg(feature = "gvfs")]
+            Self::Gvfs(item) => item.disk_usage(),
+            Self::None => unreachable!(),
+        }
+    }
+
+    pub fn can_unmount(&self) -> bool {
+        match self {
+            #[cfg(feature = "gvfs")]
+            Self::Gvfs(item) => item.can_unmount(),
             Self::None => unreachable!(),
         }
     }

--- a/src/operation/recursive.rs
+++ b/src/operation/recursive.rs
@@ -479,7 +479,9 @@ impl Op {
             #[cfg(not(feature = "gvfs"))]
             Err(why) => {
                 _ = from_file.close().await;
-                return Err(why).with_context(|| format!("failed to open {} for writing", self.to.display())).map_err(Into::into);
+                return Err(why)
+                    .with_context(|| format!("failed to open {} for writing", self.to.display()))
+                    .map_err(Into::into);
             }
             #[cfg(feature = "gvfs")]
             Err(_why) => {

--- a/src/tab.rs
+++ b/src/tab.rs
@@ -7156,8 +7156,7 @@ impl Tab {
                                         let path = path.clone();
 
                                         // Acquire semaphore permit
-                                        let _permit =
-                                            THUMB_SEMAPHORE.acquire().await.unwrap();
+                                        let _permit = THUMB_SEMAPHORE.acquire().await.unwrap();
 
                                         tokio::task::spawn_blocking(move || {
                                             let start = Instant::now();


### PR DESCRIPTION
Shows disk usage for mounted drives as a progress bar. Unmounted drives show no usage bar. Also adds the filesystem root to the sidebar with a usage bar as well.

closes #1320
closes #978
closes #166


<img width="948" height="1014" alt="image" src="https://github.com/user-attachments/assets/bb16a214-1e3f-40f0-82aa-eee32f10e2a8" />




- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

