### PR TITLE
fix: handle SFTP host key confirmation

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -672,6 +672,14 @@ impl DialogPages {
         matches!(self.pages.front(), Some(DialogPage::NetworkQuestion { .. }))
     }
 
+    fn pop_front_for_escape(&mut self) -> Option<(DialogPage, Task<Message>)> {
+        if self.front_is_network_question() {
+            None
+        } else {
+            self.pop_front()
+        }
+    }
+
     fn pop_network_question(
         &mut self,
         question_tx: &mpsc::Sender<i32>,
@@ -2825,8 +2833,11 @@ impl Application for App {
         let entity = self.tab_model.active();
 
         // Close dialog if open
-        if let Some((_page, task)) = self.dialog_pages.pop_front() {
-            return task;
+        if self.dialog_pages.front().is_some() {
+            return self
+                .dialog_pages
+                .pop_front_for_escape()
+                .map_or(Task::none(), |(_page, task)| task);
         }
 
         // Close gallery mode if open
@@ -7365,6 +7376,45 @@ mod tests {
         ));
         assert!(pages.front().is_none());
         assert_eq!(pages.pages.len(), 0);
+    }
+
+    #[test]
+    fn network_question_escape_rejects_stale_input() {
+        let (q1_tx, _) = mpsc::channel(1);
+        let (q2_tx, _) = mpsc::channel(1);
+        let q1 = DialogPage::NetworkQuestion {
+            mounter_key: MounterKey("test"),
+            uri: String::from("sftp://q1"),
+            question: MounterQuestion {
+                message: String::from("Q1"),
+                choices: vec![String::from("choice")],
+            },
+            question_tx: q1_tx.clone(),
+        };
+        let q2 = DialogPage::NetworkQuestion {
+            mounter_key: MounterKey("test"),
+            uri: String::from("sftp://q2"),
+            question: MounterQuestion {
+                message: String::from("Q2"),
+                choices: vec![String::from("choice")],
+            },
+            question_tx: q2_tx.clone(),
+        };
+        let mut pages = DialogPages::new();
+        let _ = pages.push_back(q1);
+        let _ = pages.push_back(q2);
+
+        let (_popped, _task) = pages
+            .pop_network_question(&q1_tx)
+            .expect("matching first network question should pop");
+        let page_count = pages.pages.len();
+        assert!(pages.pop_front_for_escape().is_none());
+        assert_eq!(pages.pages.len(), page_count);
+        assert!(matches!(
+            pages.front(),
+            Some(DialogPage::NetworkQuestion { question_tx, .. })
+                if question_tx.same_channel(&q2_tx)
+        ));
     }
 }
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -70,7 +70,7 @@ use crate::key_bind::key_binds;
 use crate::localize::LANGUAGE_SORTER;
 use crate::mime_app::{self, MimeApp, MimeAppCache, MimeAppMatch};
 use crate::mounter::{
-    MOUNTERS, MounterAuth, MounterItem, MounterItems, MounterKey, MounterMessage,
+    MOUNTERS, MounterAuth, MounterItem, MounterItems, MounterKey, MounterMessage, MounterQuestion,
 };
 use crate::operation::{
     Controller, Operation, OperationError, OperationErrorType, OperationSelection, ReplaceResult,
@@ -375,6 +375,9 @@ pub enum Message {
     NavBarContext(Entity),
     NavMenuAction(NavMenuAction),
     NetworkAuth(MounterKey, String, MounterAuth, mpsc::Sender<MounterAuth>),
+    NetworkQuestion(MounterKey, String, MounterQuestion, mpsc::Sender<i32>),
+    NetworkQuestionChoice(mpsc::Sender<i32>, i32),
+    NetworkQuestionCancel(mpsc::Sender<i32>),
     NetworkDriveInput(String),
     NetworkDriveOpenEntityAfterMount {
         entity: Entity,
@@ -549,6 +552,12 @@ pub enum DialogPage {
         auth: MounterAuth,
         auth_tx: mpsc::Sender<MounterAuth>,
     },
+    NetworkQuestion {
+        mounter_key: MounterKey,
+        uri: String,
+        question: MounterQuestion,
+        question_tx: mpsc::Sender<i32>,
+    },
     NetworkError {
         mounter_key: MounterKey,
         uri: String,
@@ -657,6 +666,24 @@ impl DialogPages {
             Task::none()
         };
         Some((page, task))
+    }
+
+    fn front_is_network_question(&self) -> bool {
+        matches!(self.pages.front(), Some(DialogPage::NetworkQuestion { .. }))
+    }
+
+    fn pop_network_question(
+        &mut self,
+        question_tx: &mpsc::Sender<i32>,
+    ) -> Option<(DialogPage, Task<Message>)> {
+        let matches = matches!(
+            self.pages.front(),
+            Some(DialogPage::NetworkQuestion {
+                question_tx: page_tx,
+                ..
+            }) if page_tx.same_channel(question_tx)
+        );
+        if matches { self.pop_front() } else { None }
     }
 
     pub fn update_front(&mut self, page: DialogPage) {
@@ -3144,11 +3171,19 @@ impl Application for App {
                 }
             }
             Message::DialogCancel => {
-                if let Some((_page, task)) = self.dialog_pages.pop_front() {
+                if self.dialog_pages.front_is_network_question() {
+                    log::warn!("tried to cancel a network question with a generic message");
+                    return Task::none();
+                }
+                if let Some((_dialog_page, task)) = self.dialog_pages.pop_front() {
                     return task;
                 }
             }
             Message::DialogComplete => {
+                if self.dialog_pages.front_is_network_question() {
+                    log::warn!("tried to complete a network question with a generic message");
+                    return Task::none();
+                }
                 if let Some((dialog_page, task)) = self.dialog_pages.pop_front() {
                     let mut tasks = vec![task];
                     match dialog_page {
@@ -3210,6 +3245,7 @@ impl Application for App {
                                 cosmic::action::none()
                             }));
                         }
+                        DialogPage::NetworkQuestion { .. } => unreachable!(),
                         DialogPage::NetworkError {
                             mounter_key: _,
                             uri,
@@ -3327,9 +3363,17 @@ impl Application for App {
                 return self.push_dialog(dialog_page, focused_id);
             }
             Message::DialogUpdate(dialog_page) => {
+                if self.dialog_pages.front_is_network_question() {
+                    log::warn!("tried to update a network question with a stale message");
+                    return Task::none();
+                }
                 self.dialog_pages.update_front(dialog_page);
             }
             Message::DialogUpdateComplete(dialog_page) => {
+                if self.dialog_pages.front_is_network_question() {
+                    log::warn!("tried to update a network question with a stale message");
+                    return Task::none();
+                }
                 return Task::batch([
                     self.update(Message::DialogUpdate(dialog_page)),
                     self.update(Message::DialogComplete),
@@ -3625,6 +3669,39 @@ impl Application for App {
                     Some(self.dialog_text_input.clone()),
                 );
             }
+            Message::NetworkQuestion(mounter_key, uri, question, question_tx) => {
+                return self.push_dialog(
+                    DialogPage::NetworkQuestion {
+                        mounter_key,
+                        uri,
+                        question,
+                        question_tx,
+                    },
+                    None,
+                );
+            }
+            Message::NetworkQuestionChoice(question_tx, choice) => {
+                if let Some((_dialog_page, task)) =
+                    self.dialog_pages.pop_network_question(&question_tx)
+                {
+                    return Task::batch([
+                        task,
+                        Task::future(async move {
+                            let _ = question_tx.send(choice).await;
+                            cosmic::action::none()
+                        }),
+                    ]);
+                }
+                log::warn!("tried to send a network question choice to the wrong dialog");
+            }
+            Message::NetworkQuestionCancel(question_tx) => {
+                if let Some((_dialog_page, task)) =
+                    self.dialog_pages.pop_network_question(&question_tx)
+                {
+                    return task;
+                }
+                log::warn!("tried to cancel the wrong network question");
+            }
             Message::NetworkDriveInput(input) => {
                 self.network_drive_input = input;
             }
@@ -3839,6 +3916,9 @@ impl Application for App {
                         .map(|parent| self.open_tab(Location::Path(parent), true, Some(vec![path])))
                 }));
             }
+            Message::OpenWithBrowse if self.dialog_pages.front_is_network_question() => {
+                log::warn!("tried to open with browse while a network question is active");
+            }
             Message::OpenWithBrowse => match self.dialog_pages.pop_front() {
                 Some((
                     DialogPage::OpenWith {
@@ -3870,7 +3950,7 @@ impl Application for App {
                     return Task::batch([task, self.dialog_pages.push_front(dialog_page)]);
                 }
                 None => {}
-            },
+            }
             Message::OpenWithDialog(entity_opt) => {
                 let entity = entity_opt.unwrap_or_else(|| self.tab_model.active());
                 if let Some(tab) = self.tab_model.data::<Tab>(entity)
@@ -4329,6 +4409,10 @@ impl Application for App {
                 }
             }
             Message::ReplaceResult(replace_result) => {
+                if self.dialog_pages.front_is_network_question() {
+                    log::warn!("tried to send replace result while a network question is active");
+                    return Task::none();
+                }
                 if let Some((dialog_page, task)) = self.dialog_pages.pop_front() {
                     match dialog_page {
                         DialogPage::Replace { tx, .. } => {
@@ -5942,6 +6026,32 @@ impl Application for App {
 
                 widget
             }
+            DialogPage::NetworkQuestion {
+                mounter_key: _,
+                uri: _,
+                question,
+                question_tx,
+            } => {
+                let mut parts = question.message.splitn(2, '\n');
+                let title = parts.next().unwrap_or_default();
+                let body = parts.next().unwrap_or_default();
+                let mut choices = widget::column::with_capacity(question.choices.len());
+                for (choice, index) in question.choices.iter().zip(0_i32..) {
+                    choices = choices.push(
+                        widget::button::standard(choice.clone())
+                            .on_press(Message::NetworkQuestionChoice(question_tx.clone(), index)),
+                    );
+                }
+
+                widget::dialog()
+                    .title(title)
+                    .body(body)
+                    .control(choices.spacing(space_s))
+                    .secondary_action(
+                        widget::button::standard(fl!("cancel"))
+                            .on_press(Message::NetworkQuestionCancel(question_tx.clone())),
+                    )
+            }
             DialogPage::NetworkError {
                 mounter_key: _,
                 uri: _,
@@ -7102,6 +7212,9 @@ impl Application for App {
                     MounterMessage::NetworkAuth(uri, auth, auth_tx) => {
                         Message::NetworkAuth(key, uri, auth, auth_tx)
                     }
+                    MounterMessage::NetworkQuestion(uri, question, question_tx) => {
+                        Message::NetworkQuestion(key, uri, question, question_tx)
+                    }
                     MounterMessage::NetworkResult(uri, res) => {
                         Message::NetworkResult(key, uri, res)
                     }
@@ -7202,6 +7315,56 @@ impl Application for App {
         }));
 
         Subscription::batch(subscriptions)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn network_question_sender_identity_rejects_stale_question() {
+        let (q1_tx, _) = mpsc::channel(1);
+        let (q2_tx, _) = mpsc::channel(1);
+        let q2 = DialogPage::NetworkQuestion {
+            mounter_key: MounterKey("test"),
+            uri: String::from("sftp://q2"),
+            question: MounterQuestion {
+                message: String::from("Q2"),
+                choices: vec![String::from("choice")],
+            },
+            question_tx: q2_tx.clone(),
+        };
+        let mut pages = DialogPages::new();
+        let _ = pages.push_front(q2);
+        let page_count = pages.pages.len();
+
+        assert!(pages.front_is_network_question());
+        assert!(pages.pop_network_question(&q1_tx).is_none());
+        assert!(pages.front_is_network_question());
+        assert_eq!(pages.pages.len(), page_count);
+        assert!(matches!(
+            pages.front(),
+            Some(DialogPage::NetworkQuestion { question_tx, .. })
+                if question_tx.same_channel(&q2_tx)
+        ));
+
+        let (popped, _task) = pages
+            .pop_network_question(&q2_tx.clone())
+            .expect("matching network question should pop");
+        assert!(matches!(
+            popped,
+            DialogPage::NetworkQuestion {
+                uri,
+                question,
+                question_tx,
+                ..
+            } if uri == "sftp://q2"
+                && question.message == "Q2"
+                && question_tx.same_channel(&q2_tx)
+        ));
+        assert!(pages.front().is_none());
+        assert_eq!(pages.pages.len(), 0);
     }
 }
 

--- a/src/mounter/gvfs.rs
+++ b/src/mounter/gvfs.rs
@@ -2,16 +2,18 @@ use cosmic::iced::futures::SinkExt;
 use cosmic::iced::{Subscription, stream};
 use cosmic::{Task, widget};
 use gio::glib;
+use gio::glib::translate::*;
 use gio::prelude::*;
 use std::any::TypeId;
 use std::cell::Cell;
+use std::ffi::c_char;
 use std::future::pending;
 use std::hash::Hash;
 use std::path::PathBuf;
 use std::sync::Arc;
 use tokio::sync::mpsc;
 
-use super::{Mounter, MounterAuth, MounterItem, MounterItems, MounterMessage};
+use super::{Mounter, MounterAuth, MounterItem, MounterItems, MounterMessage, MounterQuestion};
 use crate::config::IconSizes;
 use crate::err_str;
 use crate::tab::{self, ChecksumState, DirSize, ItemMetadata, ItemThumbnail, Location};
@@ -263,11 +265,57 @@ fn dir_info(uri: &str) -> Result<(String, String, Option<PathBuf>), glib::Error>
     Ok((resolved_uri, info.display_name().into(), file.path()))
 }
 
+fn connect_ask_question<F>(mount_op: &gio::MountOperation, f: F)
+where
+    F: Fn(&gio::MountOperation, &str, Vec<String>) + 'static,
+{
+    unsafe extern "C" fn trampoline<F>(
+        this: *mut gio::ffi::GMountOperation,
+        message: *const c_char,
+        choices: *mut *const c_char,
+        f: glib::ffi::gpointer,
+    ) where
+        F: Fn(&gio::MountOperation, &str, Vec<String>) + 'static,
+    {
+        let f = unsafe { &*(f as *const F) };
+        let mount_op = unsafe { gio::MountOperation::from_glib_borrow(this) };
+        let mount_op = unsafe { mount_op.unsafe_cast_ref() };
+        let message = unsafe { glib::GString::from_glib_borrow(message) };
+        let mut choices_vec = Vec::new();
+        if !choices.is_null() {
+            let mut index = 0;
+            loop {
+                let choice = unsafe { *choices.add(index) };
+                if choice.is_null() {
+                    break;
+                }
+                choices_vec.push(unsafe { glib::GString::from_glib_borrow(choice) }.to_string());
+                index += 1;
+            }
+        }
+        f(mount_op, message.as_str(), choices_vec);
+    }
+
+    unsafe {
+        let f = Box::new(f);
+        glib::signal::connect_raw(
+            mount_op.as_ptr() as *mut _,
+            c"ask-question".as_ptr() as *const _,
+            Some(std::mem::transmute::<*const (), unsafe extern "C" fn()>(
+                trampoline::<F> as *const (),
+            )),
+            Box::into_raw(f),
+        );
+    }
+}
+
 fn mount_op(
     uri: String,
     event_tx: std::sync::Weak<crate::channel::Sender<Event>>,
 ) -> gio::MountOperation {
     let mount_op = gio::MountOperation::new();
+    let password_uri = uri.clone();
+    let password_event_tx = event_tx.clone();
     mount_op.connect_ask_password(
         move |mount_op, message, default_user, default_domain, flags| {
             let auth = MounterAuth {
@@ -289,8 +337,8 @@ fn mount_op(
                     .then_some(false),
             };
             let (auth_tx, mut auth_rx) = mpsc::channel(1);
-            if let Some(event_tx) = event_tx.upgrade() {
-                event_tx.send(Event::NetworkAuth(uri.clone(), auth, auth_tx));
+            if let Some(event_tx) = password_event_tx.upgrade() {
+                event_tx.send(Event::NetworkAuth(password_uri.clone(), auth, auth_tx));
             }
             //TODO: async recv?
             if let Some(auth) = auth_rx.blocking_recv() {
@@ -310,6 +358,26 @@ fn mount_op(
             }
         },
     );
+    connect_ask_question(&mount_op, move |mount_op, message, choices| {
+        let Some(event_tx) = event_tx.upgrade() else {
+            mount_op.reply(gio::MountOperationResult::Aborted);
+            return;
+        };
+
+        let question = MounterQuestion {
+            message: message.to_string(),
+            choices,
+        };
+        let (question_tx, mut question_rx) = mpsc::channel(1);
+        event_tx.send(Event::NetworkQuestion(uri.clone(), question, question_tx));
+        //TODO: async recv?
+        if let Some(choice) = question_rx.blocking_recv() {
+            mount_op.set_choice(choice);
+            mount_op.reply(gio::MountOperationResult::Handled);
+        } else {
+            mount_op.reply(gio::MountOperationResult::Aborted);
+        }
+    });
     mount_op
 }
 
@@ -338,6 +406,7 @@ enum Event {
     Items(MounterItems),
     MountResult(MounterItem, Result<bool, String>),
     NetworkAuth(String, MounterAuth, mpsc::Sender<MounterAuth>),
+    NetworkQuestion(String, MounterQuestion, mpsc::Sender<i32>),
     NetworkResult(String, Result<bool, String>),
 }
 
@@ -776,6 +845,14 @@ impl Mounter for Gvfs {
                                     .unwrap(),
                                 Event::NetworkAuth(uri, auth, auth_tx) => output
                                     .send(MounterMessage::NetworkAuth(uri, auth, auth_tx))
+                                    .await
+                                    .unwrap(),
+                                Event::NetworkQuestion(uri, question, question_tx) => output
+                                    .send(MounterMessage::NetworkQuestion(
+                                        uri,
+                                        question,
+                                        question_tx,
+                                    ))
                                     .await
                                     .unwrap(),
                                 Event::NetworkResult(uri, res) => output

--- a/src/mounter/mod.rs
+++ b/src/mounter/mod.rs
@@ -22,6 +22,12 @@ pub struct MounterAuth {
     pub anonymous_opt: Option<bool>,
 }
 
+#[derive(Clone, Debug)]
+pub struct MounterQuestion {
+    pub message: String,
+    pub choices: Vec<String>,
+}
+
 // Custom debug for MounterAuth to hide password
 impl fmt::Debug for MounterAuth {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -107,6 +113,7 @@ pub enum MounterMessage {
     Items(MounterItems),
     MountResult(MounterItem, Result<bool, String>),
     NetworkAuth(String, MounterAuth, mpsc::Sender<MounterAuth>),
+    NetworkQuestion(String, MounterQuestion, mpsc::Sender<i32>),
     NetworkResult(String, Result<bool, String>),
 }
 


### PR DESCRIPTION
## Summary

GIO asks the mount operation to confirm an uncached SFTP host key, but COSMIC Files did not handle that question and reported `Login dialog cancelled`.

- forward generic mount-operation questions to the application
- display the backend-provided message and ordered choices
- return the selected choice without interpreting SSH policy
- prevent delayed dialog input from affecting a newer queued question

Fixes #580.

## Testing

- `cargo test --offline --all-features --lib --bins` — 45 passed
- `cargo check --offline --features gvfs`
- `git diff HEAD^ --check`
- first-connection SFTP verification against a disposable server with a fresh host key

Live verification on `c499cb9` was captured across two runs: one confirmed that Escape leaves the first-connection fingerprint question visible, and another confirmed that the same build can open the remote SFTP root. The combined Escape → continued mount sequence was not captured as one run. Automated coverage verifies that Escape preserves the active question and cannot dismiss the next queued question.

- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

