### PR TITLE
fix: disable Select All in empty directories

### DIFF
--- a/src/menu.rs
+++ b/src/menu.rs
@@ -106,7 +106,7 @@ pub fn context_menu<'a>(
 
     // Allow paste when clipboard has data and we're in a location that supports it
     let can_paste = clipboard_paste_available && tab.location.supports_paste();
-    let can_select_all = tab.items_opt().is_some_and(|items| !items.is_empty());
+    let can_select_all = tab.can_select_all();
     let select_all_item = || {
         if can_select_all {
             menu_item(fl!("select-all"), Action::SelectAll).into()
@@ -631,9 +631,7 @@ pub fn menu_bar<'a>(
         )
     };
     let in_trash = tab_opt.is_some_and(|tab| tab.location.is_trash());
-    let can_select_all = tab_opt
-        .and_then(Tab::items_opt)
-        .is_some_and(|items| !items.is_empty());
+    let can_select_all = tab_opt.is_some_and(Tab::can_select_all);
 
     let mut selected_dir = 0;
     let mut selected = 0;

--- a/src/menu.rs
+++ b/src/menu.rs
@@ -106,6 +106,14 @@ pub fn context_menu<'a>(
 
     // Allow paste when clipboard has data and we're in a location that supports it
     let can_paste = clipboard_paste_available && tab.location.supports_paste();
+    let can_select_all = tab.items_opt().is_some_and(|items| !items.is_empty());
+    let select_all_item = || {
+        if can_select_all {
+            menu_item(fl!("select-all"), Action::SelectAll).into()
+        } else {
+            menu_item_disabled(fl!("select-all"), Action::SelectAll).into()
+        }
+    };
 
     let (sort_name, sort_direction, _) = tab.sort_options();
     let sort_item = |label, variant| {
@@ -326,7 +334,7 @@ pub fn context_menu<'a>(
                 }
 
                 if tab.mode.multiple() {
-                    children.push(menu_item(fl!("select-all"), Action::SelectAll).into());
+                    children.push(select_all_item());
                 }
                 if can_paste {
                     children.push(menu_item(fl!("paste"), Action::Paste).into());
@@ -386,7 +394,7 @@ pub fn context_menu<'a>(
                     children.push(menu_item(fl!("new-folder"), Action::NewFolder).into());
                 }
                 if tab.mode.multiple() {
-                    children.push(menu_item(fl!("select-all"), Action::SelectAll).into());
+                    children.push(select_all_item());
                 }
                 if !children.is_empty() {
                     children.push(divider::horizontal::light().into());
@@ -403,7 +411,7 @@ pub fn context_menu<'a>(
                 }
             } else {
                 if tab.mode.multiple() {
-                    children.push(menu_item(fl!("select-all"), Action::SelectAll).into());
+                    children.push(select_all_item());
                 }
                 if !children.is_empty() {
                     children.push(divider::horizontal::light().into());
@@ -415,7 +423,7 @@ pub fn context_menu<'a>(
         }
         (_, Location::Trash | Location::Search(SearchLocation::Trash, ..)) => {
             if tab.mode.multiple() {
-                children.push(menu_item(fl!("select-all"), Action::SelectAll).into());
+                children.push(select_all_item());
             }
             if !children.is_empty() {
                 children.push(divider::horizontal::light().into());
@@ -623,6 +631,9 @@ pub fn menu_bar<'a>(
         )
     };
     let in_trash = tab_opt.is_some_and(|tab| tab.location.is_trash());
+    let can_select_all = tab_opt
+        .and_then(Tab::items_opt)
+        .is_some_and(|items| !items.is_empty());
 
     let mut selected_dir = 0;
     let mut selected = 0;
@@ -709,7 +720,7 @@ pub fn menu_bar<'a>(
                         menu_button_optional(fl!("move-to"), Action::MoveTo, selected > 0),
                         menu_button_optional(fl!("copy-to"), Action::CopyTo, selected > 0),
                         menu_button_optional(fl!("paste"), Action::Paste, can_paste),
-                        menu::Item::Button(fl!("select-all"), None, Action::SelectAll),
+                        menu_button_optional(fl!("select-all"), Action::SelectAll, can_select_all),
                         menu::Item::Divider,
                         menu::Item::Button(fl!("history"), None, Action::EditHistory),
                     ],

--- a/src/tab.rs
+++ b/src/tab.rs
@@ -3063,6 +3063,14 @@ impl Tab {
         }
     }
 
+    pub fn can_select_all(&self) -> bool {
+        self.items_opt.as_ref().is_some_and(|items| {
+            items
+                .iter()
+                .any(|item| self.config.show_hidden || !item.hidden)
+        })
+    }
+
     pub fn select_all(&mut self) {
         if let Some(ref mut items) = self.items_opt {
             for item in items.iter_mut() {
@@ -7632,6 +7640,38 @@ mod tests {
         trace!("Tab history: {:?}", tab.history);
 
         Ok((fs, tab, dirs))
+    }
+
+    #[test]
+    fn select_all_ignores_hidden_items_when_hidden_files_are_not_shown() -> io::Result<()> {
+        let fs = TempDir::new()?;
+        let path = fs.path();
+        fs::write(path.join(".hidden"), "hidden")?;
+
+        let mut tab = Tab::new(
+            Location::Path(path.to_owned()),
+            TabConfig::default(),
+            ThumbCfg::default(),
+            None,
+            widget::Id::unique(),
+            None,
+        );
+        let items = scan_path(&path.to_owned(), IconSizes::default());
+        assert_eq!(items.len(), 1);
+        assert!(items[0].hidden);
+        tab.set_items(items);
+
+        assert!(!tab.config.show_hidden);
+        assert!(!tab.can_select_all());
+        tab.select_all();
+        assert!(!tab.items_opt().unwrap()[0].selected);
+
+        tab.config.show_hidden = true;
+        assert!(tab.can_select_all());
+        tab.select_all();
+        assert!(tab.items_opt().unwrap()[0].selected);
+
+        Ok(())
     }
 
     #[test]


### PR DESCRIPTION
Fixes #1025.

## Summary

- disable Select All when the active tab has no visible items
- use one visibility-aware predicate for context and Edit menus
- keep existing Ctrl+A and selection behavior unchanged

## Testing

- `cargo check`
- `cargo build`
- `cargo test` — 44 passed, 0 failed
- hidden-only regression with hidden files off and on
- manual empty → populated → empty menu verification

## Screenshots

| Empty directory | One visible item |
| --- | --- |
| ![Select All disabled in an empty directory](https://github.com/user-attachments/assets/19e842ab-705c-4b02-a274-3670d150c6b6) | ![Select All enabled with one visible item](https://github.com/user-attachments/assets/4fcca04c-fb79-4523-82d2-89ee75279238) |

- [x] I have disclosed use of AI-generated code in my commit messages.
- [x] I understand these changes and can respond to review comments.
- [x] My commit messages accurately describe the changes.
- [x] I tested the contribution and confirmed it works as described.
- [x] I have read the Developer Certificate of Origin and certify this contribution under its conditions.
