### PR TITLE
feat: add ellipsize in search results paths

### DIFF
--- a/src/tab.rs
+++ b/src/tab.rs
@@ -6254,11 +6254,18 @@ impl Tab {
                                 .size(icon_size)
                                 .into(),
                             widget::column::with_children([
-                                Item::list_display_name(item.display_name.clone()).into(),
+                                Item::list_display_name(item.display_name.clone())
+                                .ellipsize(text::Ellipsize::Middle(text::EllipsizeHeightLimit::Lines(
+                                    1,
+                                )))
+                                .into(),
                                 widget::text::caption(match item.path_opt() {
                                     Some(path) => path.display().to_string(),
                                     None => String::new(),
                                 })
+                                .ellipsize(text::Ellipsize::Middle(text::EllipsizeHeightLimit::Lines(
+                                    1,
+                                )))
                                 .into(),
                             ])
                             .width(Length::Fill)
@@ -6366,11 +6373,18 @@ impl Tab {
                                     .size(icon_size)
                                     .into(),
                                 widget::column::with_children([
-                                    Item::list_display_name(item.display_name.clone()).into(),
+                                    Item::list_display_name(item.display_name.clone())
+                                    .ellipsize(text::Ellipsize::Middle(text::EllipsizeHeightLimit::Lines(
+                                        1,
+                                    )))
+                                    .into(),
                                     widget::text::caption(match item.path_opt() {
                                         Some(path) => path.display().to_string(),
                                         None => String::new(),
                                     })
+                                    .ellipsize(text::Ellipsize::Middle(text::EllipsizeHeightLimit::Lines(
+                                        1,
+                                    )))
                                     .into(),
                                 ])
                                 .width(Length::Fill)


### PR DESCRIPTION
- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

Right now, we do not see in the search results whether the path is complete or truncated.
<img width="566" height="537" alt="image" src="https://github.com/user-attachments/assets/758f3a96-6290-4692-8bdd-0f3bc8116cc9" />

Added ellipsize in search path to show path truncating
<img width="598" height="562" alt="image" src="https://github.com/user-attachments/assets/6f5051e3-d968-4d08-b966-88bf46daddaa" />
