### PR TITLE
Inline file rename (F2) instead of dialog for single selections

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -4285,6 +4285,23 @@ impl Application for App {
             }
             Message::Rename(entity_opt) => {
                 let entity = entity_opt.unwrap_or_else(|| self.tab_model.active());
+                // Rename a single item inline; fall back to dialogs for multiple selections
+                let single_opt = self
+                    .tab_model
+                    .data::<Tab>(entity)
+                    .and_then(|tab| tab.items_opt())
+                    .and_then(|items| {
+                        let mut selected =
+                            items.iter().enumerate().filter(|(_, item)| item.selected);
+                        let (i, item) = selected.next()?;
+                        (selected.next().is_none() && item.path_opt().is_some()).then_some(i)
+                    });
+                if let Some(i) = single_opt {
+                    return self.update(Message::TabMessage(
+                        Some(entity),
+                        tab::Message::EditNameEnable(i),
+                    ));
+                }
                 if let Some(tab) = self.tab_model.data_mut::<Tab>(entity)
                     && let Some(items) = tab.items_opt()
                 {
@@ -4641,6 +4658,9 @@ impl Application for App {
                             }
                         }
                         tab::Command::Delete(paths) => commands.push(self.delete(paths)),
+                        tab::Command::Rename(from, to) => {
+                            commands.push(self.operation(Operation::Rename { from, to }))
+                        }
                         tab::Command::DropFiles(to, from) => {
                             commands.push(self.update(Message::PasteContents(to, from)));
                         }

--- a/src/tab.rs
+++ b/src/tab.rs
@@ -1759,6 +1759,7 @@ pub enum Command {
     OpenInNewWindow(PathBuf),
     OpenTrash,
     Preview(PreviewKind),
+    Rename(PathBuf, PathBuf),
     RunContextAction(usize),
     SetOpenWith(Mime, String),
     SetPermissions(PathBuf, u32),
@@ -1788,6 +1789,10 @@ pub enum Message {
     EditLocationEnable,
     EditLocationSubmit,
     EditLocationTab,
+    EditNameEnable(usize),
+    EditNameInput(String),
+    EditNameSubmit,
+    EditNameCancel,
     OpenInNewTab(PathBuf),
     ClearRecents,
     EmptyTrash,
@@ -2816,6 +2821,8 @@ pub struct Tab {
     pub item_view_size_opt: Cell<Option<Size>>,
     pub edit_location: Option<EditLocation>,
     pub edit_location_id: widget::Id,
+    pub edit_name: Option<(usize, String)>,
+    pub edit_name_id: widget::Id,
     pub history_i: usize,
     pub history: Vec<Location>,
     pub config: TabConfig,
@@ -2963,6 +2970,8 @@ impl Tab {
             item_view_size_opt: Cell::new(None),
             edit_location: None,
             edit_location_id: widget::Id::unique(),
+            edit_name: None,
+            edit_name_id: widget::Id::unique(),
             history_i: 0,
             history,
             config,
@@ -3883,6 +3892,43 @@ impl Tab {
                     widget::text_input::focus(self.edit_location_id.clone()).into(),
                 ));
                 self.edit_location = Some(self.location.clone().into());
+            }
+            Message::EditNameEnable(i) => {
+                if let Some(item) = self.items_opt.as_ref().and_then(|items| items.get(i)) {
+                    let name = item.name.clone();
+                    commands.push(Command::Iced(
+                        widget::text_input::focus(self.edit_name_id.clone()).into(),
+                    ));
+                    commands.push(Command::Iced(
+                        widget::text_input::select_until_last(
+                            self.edit_name_id.clone(),
+                            &name,
+                            '.',
+                        )
+                        .into(),
+                    ));
+                    self.edit_name = Some((i, name));
+                }
+            }
+            Message::EditNameInput(input) => {
+                if let Some((_, name)) = self.edit_name.as_mut() {
+                    *name = input;
+                }
+            }
+            Message::EditNameCancel => {
+                self.edit_name = None;
+            }
+            Message::EditNameSubmit => {
+                if let Some((i, name)) = self.edit_name.take()
+                    && !name.is_empty()
+                    && !name.contains('/')
+                    && let Some(item) = self.items_opt.as_ref().and_then(|items| items.get(i))
+                    && name != item.name
+                    && let Some(from) = item.path_opt().cloned()
+                    && let Some(parent) = from.parent()
+                {
+                    commands.push(Command::Rename(from.clone(), parent.join(name)));
+                }
             }
             Message::EditLocationSubmit => {
                 if let Some(mut edit_location) = self.edit_location.take() {
@@ -5722,6 +5768,24 @@ impl Tab {
         .into()
     }
 
+    fn is_editing_name(&self, i: usize) -> bool {
+        self.edit_name.as_ref().is_some_and(|(idx, _)| *idx == i)
+    }
+
+    fn edit_name_input(&self) -> Element<'static, Message> {
+        let value = self
+            .edit_name
+            .as_ref()
+            .map_or(String::new(), |(_, name)| name.clone());
+        widget::text_input("", value)
+            .id(self.edit_name_id.clone())
+            .on_input(Message::EditNameInput)
+            .on_submit(|_| Message::EditNameSubmit)
+            .on_unfocus(Message::EditNameCancel)
+            .line_height(1.0)
+            .into()
+    }
+
     pub fn grid_view(
         &self,
     ) -> (
@@ -5855,8 +5919,13 @@ impl Tab {
                             false,
                         ))
                         .into(),
-                        widget::tooltip(
-                            widget::button::custom(Item::grid_display_name(&item.display_name))
+                        if self.is_editing_name(i) {
+                            self.edit_name_input()
+                        } else {
+                            widget::tooltip(
+                                widget::button::custom(Item::grid_display_name(
+                                    &item.display_name,
+                                ))
                                 .id(item.button_id.clone())
                                 .padding([0, space_xxxs])
                                 .class(button_style(
@@ -5867,10 +5936,11 @@ impl Tab {
                                     true,
                                     matches!(self.mode, Mode::Desktop),
                                 )),
-                            widget::text::body(&item.name),
-                            widget::tooltip::Position::Bottom,
-                        )
-                        .into(),
+                                widget::text::body(&item.name),
+                                widget::tooltip::Position::Bottom,
+                            )
+                            .into()
+                        },
                     ];
 
                     let mut column = widget::column::with_capacity(buttons.len())
@@ -6237,7 +6307,11 @@ impl Tab {
                                 .size(icon_size)
                                 .into(),
                             widget::column::with_children([
-                                Item::list_display_name(item.display_name.clone()).into(),
+                                if self.is_editing_name(i) {
+                                    self.edit_name_input()
+                                } else {
+                                    Item::list_display_name(item.display_name.clone()).into()
+                                },
                                 //TODO: translate?
                                 widget::text::caption(format!("{modified_text} - {size_text}"))
                                     .into(),
@@ -6254,7 +6328,11 @@ impl Tab {
                                 .size(icon_size)
                                 .into(),
                             widget::column::with_children([
-                                Item::list_display_name(item.display_name.clone()).into(),
+                                if self.is_editing_name(i) {
+                                    self.edit_name_input()
+                                } else {
+                                    Item::list_display_name(item.display_name.clone()).into()
+                                },
                                 widget::text::caption(match item.path_opt() {
                                     Some(path) => path.display().to_string(),
                                     None => String::new(),
@@ -6279,9 +6357,15 @@ impl Tab {
                                 .content_fit(ContentFit::Contain)
                                 .size(icon_size)
                                 .into(),
-                            Item::list_display_name(item.display_name.clone())
-                                .width(Length::Fill)
-                                .into(),
+                            if self.is_editing_name(i) {
+                                widget::container(self.edit_name_input())
+                                    .width(Length::Fill)
+                                    .into()
+                            } else {
+                                Item::list_display_name(item.display_name.clone())
+                                    .width(Length::Fill)
+                                    .into()
+                            },
                             widget::text::body(modified_text.clone())
                                 .width(Length::Fixed(modified_width))
                                 .into(),


### PR DESCRIPTION
Closes #1832

Implements inline file renaming instead of the separate rename dialog.

## What changed

- Pressing F2 / Rename with exactly one item selected replaces the name label with an inline text input, in grid view and all three list layouts (normal, condensed, search).
- The input is pre-focused with the file stem selected (extension preserved), matching the previous dialog behavior.
- Enter submits (tab::Command::Rename -> Operation::Rename); unfocus/click-away cancels.
- Multi-selection rename keeps the existing dialog flow.

## AI/LLM disclosure

This PR was implemented with the assistance of an LLM coding agent (Claude via GitHub Copilot), directed and reviewed by me. I understand the changes in full: the implementation reuses the existing EditLocation inline-edit pattern (new `edit_name` state, `EditNameEnable/Input/Submit/Cancel` messages, a `tab::Command::Rename` routed to the existing `Operation::Rename`), and I have tested it manually. I will respond to review comments myself.

## Testing

`cargo check` clean; manual testing on a scratch folder in grid and all list layouts: F2 inline rename, Enter submit, click-away cancel, extension preservation via stem selection, multi-selection falling back to the dialog.

## Checklist

- [x] I have disclosed use of any AI generated code in my commit messages.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.
