### PR TITLE
fix: trim whitespace around a server address before connecting

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -3629,13 +3629,11 @@ impl Application for App {
                 self.network_drive_input = input;
             }
             Message::NetworkDriveSubmit => {
+                let uri = self.network_drive_input.trim().to_string();
                 //TODO: know which mounter to use for network drives
                 if let Some((mounter_key, mounter)) = MOUNTERS.iter().next() {
-                    self.network_drive_connecting =
-                        Some((*mounter_key, self.network_drive_input.clone()));
-                    return mounter
-                        .network_drive(self.network_drive_input.clone())
-                        .map(|_| cosmic::action::none());
+                    self.network_drive_connecting = Some((*mounter_key, uri.clone()));
+                    return mounter.network_drive(uri).map(|_| cosmic::action::none());
                 }
                 log::warn!(
                     "no mounter found for connecting to {:?}",


### PR DESCRIPTION
- [x] I have disclosed use of any AI generated code in my commit messages.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

The server address field hands its contents to the mounter unchanged, so a leading space turns the URI into a relative path and the mount fails with g-io-error-quark code 15 — a message about volume capabilities that mentions neither the whitespace nor the address. The location bar already trims (`tab.rs`); this does the same for the dialog.

Measured on 1.7.0 (de73942), typing ` smb://server/share` into "Enter server address", same machine and server for both runs:

```
before
    INFO  network drive  smb://server/share: result Err(... code: 15 ...)
    WARN  failed to connect to " smb://server/share"

after
    INFO  network drive smb://server/share: result Ok(())
    INFO  connected to "smb://server/share"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
